### PR TITLE
Refactor error handling in getErrorCall and SimulationResults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rpact
 Title: Confirmatory Adaptive Clinical Trial Design and Analysis
-Version: 4.5.0.9311
-Date: 2026-07-15
+Version: 4.5.0.9312
+Date: 2026-07-20
 Authors@R: c(
 	person(
 		given = "Gernot",

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -856,4 +856,3 @@ getCipheredValue <- function(x) {
 .tcrossprodCpp <- function(x) {
     .Call(`_rpact_tcrossprod`, x)
 }
-

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -856,3 +856,4 @@ getCipheredValue <- function(x) {
 .tcrossprodCpp <- function(x) {
     .Call(`_rpact_tcrossprod`, x)
 }
+

--- a/R/class_analysis_dataset.R
+++ b/R/class_analysis_dataset.R
@@ -172,8 +172,8 @@ readDataset <- function(
         fileEncoding = "UTF-8") {
     if (!file.exists(file)) {
         stopIllegalArgument("the file ", .vQuote(file), " does not exist",
-            functionName = "readDataset", 
-		parameter ="file",
+            functionName = "readDataset",
+            parameter = "file",
             value = file
         )
     }
@@ -325,8 +325,8 @@ readDatasets <- function(
         fileEncoding = "UTF-8") {
     if (!file.exists(file)) {
         stopIllegalArgument("the file ", .vQuote(file), " does not exist",
-            functionName = "readDatasets", 
-		parameter ="file",
+            functionName = "readDatasets",
+            parameter = "file",
             value = file
         )
     }
@@ -337,9 +337,10 @@ readDatasets <- function(
     )
 
     if (is.null(data[["datasetId"]])) {
-        stopIllegalArgument("data file must contain the column 'datasetId'", 
-		functionName = "readDatasets", 
-		parameter ="datasetId")
+        stopIllegalArgument("data file must contain the column 'datasetId'",
+            functionName = "readDatasets",
+            parameter = "datasetId"
+        )
     }
 
     datasets <- list()
@@ -485,8 +486,9 @@ writeDatasets <- function(
     }
 
     if (is.null(dataFrames)) {
-        stopRuntimeIssue("failed to bind datasets", 
-		functionName = "writeDatasets")
+        stopRuntimeIssue("failed to bind datasets",
+            functionName = "writeDatasets"
+        )
     }
 
     utils::write.table(
@@ -500,8 +502,9 @@ writeDatasets <- function(
 .getDataset <- function(..., floatingPointNumbersEnabled = FALSE) {
     args <- list(...)
     if (length(args) == 0) {
-        stopMissingArgument("data.frame, data vectors, or datasets expected", 
-		functionName = ".getDataset")
+        stopMissingArgument("data.frame, data vectors, or datasets expected",
+            functionName = ".getDataset"
+        )
     }
 
     if (.optionalArgsContainsDatasets(...)) {
@@ -554,13 +557,15 @@ writeDatasets <- function(
         }
 
         if (length(paramNames) != numberOfParameters) {
-            stopIllegalArgument("all parameters must be named", 
-		functionName = ".getDataset")
+            stopIllegalArgument("all parameters must be named",
+                functionName = ".getDataset"
+            )
         }
 
         if (length(paramNames) != length(unique(paramNames))) {
-            stopIllegalArgument("the parameter names must be unique", 
-		functionName = ".getDataset")
+            stopIllegalArgument("the parameter names must be unique",
+                functionName = ".getDataset"
+            )
         }
 
         dataFrame <- .createDataFrame(...)
@@ -604,8 +609,9 @@ writeDatasets <- function(
         ))
     }
 
-    stopIllegalArgument("failed to identify dataset type", 
-		functionName = ".getDataset")
+    stopIllegalArgument("failed to identify dataset type",
+        functionName = ".getDataset"
+    )
 }
 
 #' @title
@@ -1040,8 +1046,9 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
     for (i in seq_len(length(subsetNames))) {
         subsetName <- subsetNames[i]
         if (subsetName == "" && !inherits(args[[i]], "TrialDesign")) {
-            stopIllegalArgument("all subsets must be named", 
-		functionName = ".getSubsetsFromArgs")
+            stopIllegalArgument("all subsets must be named",
+                functionName = ".getSubsetsFromArgs"
+            )
         }
 
         if (subsetName != "" && !(subsetName %in% validSubsetNames)) {
@@ -1194,11 +1201,13 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
     for (i in 1:nrow(dataFrame)) {
         row <- dataFrame[i, paramNames]
         if (anyNA(row) && !all(is.na(row))) {
-            stopConflictingArguments(gettextf(
-                paste0("inconsistent deselection in group %s at stage %s (", "%s: all or none must be NA)"),
-                dataFrame$group[i], dataFrame$stage[i], .arrayToString(paramNames, maxCharacters = 40)
-            ), 
-		functionName = ".validateEnrichmentDataFrameDeselection")
+            stopConflictingArguments(
+                gettextf(
+                    paste0("inconsistent deselection in group %s at stage %s (", "%s: all or none must be NA)"),
+                    dataFrame$group[i], dataFrame$stage[i], .arrayToString(paramNames, maxCharacters = 40)
+                ),
+                functionName = ".validateEnrichmentDataFrameDeselection"
+            )
         }
     }
 
@@ -1209,11 +1218,13 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
             subData <- dataFrame[dataFrame$subset == s & dataFrame$stage == stage, paramNames]
 
             if (deselectedStage > 0 && !all(is.na(subData))) {
-                stopConflictingArguments(gettextf(paste0(
-                    "%s was deselected at stage %s ", "and therefore must be also deselected in the following stages, ",
-                    "but is no longer deselected in stage %s"
-                ), s, deselectedStage, stage), 
-		functionName = ".validateEnrichmentDataFrameDeselection")
+                stopConflictingArguments(
+                    gettextf(paste0(
+                        "%s was deselected at stage %s ", "and therefore must be also deselected in the following stages, ",
+                        "but is no longer deselected in stage %s"
+                    ), s, deselectedStage, stage),
+                    functionName = ".validateEnrichmentDataFrameDeselection"
+                )
             }
 
             if (anyNA(subData)) {
@@ -1225,12 +1236,14 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
 .validateEnrichmentDataFrameMeans <- function(dataFrame) {
     if (any(na.omit(dataFrame$stDev) <= 0) || any(na.omit(dataFrame$overallStDev) <= 0)) {
-        stopIllegalArgument("all standard deviations must be > 0", 
-		functionName = ".validateEnrichmentDataFrameMeans")
+        stopIllegalArgument("all standard deviations must be > 0",
+            functionName = ".validateEnrichmentDataFrameMeans"
+        )
     }
     if (any(na.omit(dataFrame$sampleSize) <= 0) || any(na.omit(dataFrame$overallSampleSize) <= 0)) {
-        stopIllegalArgument("all sample sizes must be > 0", 
-		functionName = ".validateEnrichmentDataFrameMeans")
+        stopIllegalArgument("all sample sizes must be > 0",
+            functionName = ".validateEnrichmentDataFrameMeans"
+        )
     }
 
     .validateEnrichmentDataFrameAtFirstStage(dataFrame,
@@ -1281,8 +1294,9 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
 .validateEnrichmentDataFrameSurvival <- function(dataFrame) {
     if (any(na.omit(dataFrame$event) < 0) || any(na.omit(dataFrame$overallEvent) < 0)) {
-        stopIllegalArgument("all events must be >= 0", 
-		functionName = ".validateEnrichmentDataFrameSurvival")
+        stopIllegalArgument("all events must be >= 0",
+            functionName = ".validateEnrichmentDataFrameSurvival"
+        )
     }
 
     .validateEnrichmentDataFrameAtFirstStage(dataFrame,
@@ -1861,9 +1875,9 @@ Dataset <- R6::R6Class("Dataset",
             for (s in subset) {
                 if (!(s %in% levels(self$.data$subset))) {
                     stopIllegalArgument("'subset' (", s, ") is not a defined value ",
-                "[", .arrayToString(levels(self$.data$subset)), "]",
-                        functionName = ".assertIsValidSubset", 
-                        parameter = "subset", 
+                        "[", .arrayToString(levels(self$.data$subset)), "]",
+                        functionName = ".assertIsValidSubset",
+                        parameter = "subset",
                         value = self$.data$subset
                     )
                 }
@@ -1871,9 +1885,10 @@ Dataset <- R6::R6Class("Dataset",
         },
         .getIndices = function(..., stage, group, subset = NA_character_) {
             if (is.null(self$.data)) {
-                stopRuntimeIssue("'.data' must be defined", 
-                    functionName = ".getIndices", 
-		parameter =".data")
+                stopRuntimeIssue("'.data' must be defined",
+                    functionName = ".getIndices",
+                    parameter = ".data"
+                )
             }
 
             if (!is.null(stage) && !anyNA(stage) && all(stage < 0)) {
@@ -1914,7 +1929,9 @@ Dataset <- R6::R6Class("Dataset",
             nToCheck <- stats::na.omit(x)
             if (any(nToCheck != as.integer(nToCheck))) {
                 warning(parameterName, " specified as floating-point ",
-                "numbers were truncated", call. = FALSE)
+                    "numbers were truncated",
+                    call. = FALSE
+                )
             }
 
             x[!is.na(x)] <- as.integer(x[!is.na(x)])
@@ -1964,8 +1981,9 @@ Dataset <- R6::R6Class("Dataset",
                 numberOfStages <- length(unique(as.character(subData$stage)))
                 if (numberOfStages == 0) {
                     print(self$.data[, validColNames])
-                    stopRuntimeIssue(".data seems to contain an invalid column", 
-                        functionName = "getNumberOfStages")
+                    stopRuntimeIssue(".data seems to contain an invalid column",
+                        functionName = "getNumberOfStages"
+                    )
                 }
                 return(numberOfStages)
             }
@@ -2125,9 +2143,9 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
                 ), parameterName = "Sample sizes")
                 self$.validateValues(self$sampleSizes, "n")
                 if (any(stats::na.omit(self$sampleSizes) <= 0)) {
-                    stopIllegalArgument("all sample sizes must be > 0, but 'n' = ", 
+                    stopIllegalArgument("all sample sizes must be > 0, but 'n' = ",
                         .arrayToString(self$sampleSizes, vectorLookAndFeelEnabled = TRUE),
-                        functionName = ".initByDataFrame", 
+                        functionName = ".initByDataFrame",
                         parameter = "n"
                     )
                 }
@@ -2238,8 +2256,9 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
                     self$groups <- c(self$groups, rep(as.integer(group), length(overallSampleSizesTemp)))
                 }
             } else {
-                stopMissingArgument("sample sizes are missing or not correctly specified", 
-                    functionName = ".initByDataFrame")
+                stopMissingArgument("sample sizes are missing or not correctly specified",
+                    functionName = ".initByDataFrame"
+                )
             }
 
             if (self$.inputType == "stagewise") {
@@ -2277,12 +2296,14 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
             }
 
             if (sum(stats::na.omit(self$sampleSizes) < 0) > 0) {
-                stopIllegalArgument("all sample sizes must be >= 0", 
-                    functionName = ".initByDataFrame")
+                stopIllegalArgument("all sample sizes must be >= 0",
+                    functionName = ".initByDataFrame"
+                )
             }
             if (sum(stats::na.omit(self$stDevs) < 0) > 0) {
-                stopIllegalArgument("all standard deviations must be >= 0", 
-		functionName = ".initByDataFrame")
+                stopIllegalArgument("all standard deviations must be >= 0",
+                    functionName = ".initByDataFrame"
+                )
             }
         },
         .recreateDataFrame = function() {
@@ -2508,8 +2529,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
     if (!is.null(fixedCovariates)) {
         if (!is.list(fixedCovariates)) {
             stopIllegalArgument(sQuote("fixedCovariates"), " must be a named list",
-                functionName = ".getRandomDataMeans", 
-		parameter ="fixedCovariates",
+                functionName = ".getRandomDataMeans",
+                parameter = "fixedCovariates",
                 value = fixedCovariates
             )
         }
@@ -2517,8 +2538,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
     if (!is.null(covariateEffects)) {
         if (!is.list(covariateEffects)) {
             stopIllegalArgument(sQuote("covariateEffects"), " must be a named list",
-                functionName = ".getRandomDataMeans", 
-		parameter ="covariateEffects",
+                functionName = ".getRandomDataMeans",
+                parameter = "covariateEffects",
                 value = covariateEffects
             )
         }
@@ -2652,8 +2673,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
         fixedCovariateNames <- names(fixedCovariates)
         if (is.null(fixedCovariateNames) || any(nchar(trimws(fixedCovariateNames)) == 0)) {
             stopIllegalArgument(sQuote("fixedCovariates"), " must be a named list",
-                functionName = ".getRandomDataMeans", 
-		parameter ="fixedCovariates",
+                functionName = ".getRandomDataMeans",
+                parameter = "fixedCovariates",
                 value = fixedCovariates
             )
         }
@@ -2674,12 +2695,13 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
                 if (length(unique(values)) < length(values)) {
                     stopIllegalArgument(sQuote(paste0("fixedCovariates$", fixedCovariateName)), " (", .arrayToString(values,
                         maxLength = 20
-                    ), ") must be a unique vector", 
-		functionName = ".getRandomDataMeans", 
-		parameter =paste0(
+                    ), ") must be a unique vector",
+                    functionName = ".getRandomDataMeans",
+                    parameter = paste0(
                         "fixedCovariates$",
                         fixedCovariateName
-                    ))
+                    )
+                    )
                 }
 
                 fixedCovariateSample <- sample(values, length(subjects), replace = TRUE)
@@ -2822,8 +2844,9 @@ plot.Dataset <- function(
         showSource = FALSE,
         plotSettings = NULL) {
     if (x$.enrichmentEnabled) {
-        stopRuntimeIssue("plot of enrichment data is not yet implemented", 
-		functionName = ".plot.Dataset")
+        stopRuntimeIssue("plot of enrichment data is not yet implemented",
+            functionName = ".plot.Dataset"
+        )
     }
 
     .assertGgplotIsInstalled()
@@ -2840,8 +2863,9 @@ plot.Dataset <- function(
         }
     } else if (x$isDatasetSurvival()) {
         # Open work: implement dataset plot of survival data
-        stopRuntimeIssue("plot of survival data is not yet implemented", 
-		functionName = ".plot.Dataset")
+        stopRuntimeIssue("plot of survival data is not yet implemented",
+            functionName = ".plot.Dataset"
+        )
     }
 
     if (!is.logical(showSource) || isTRUE(showSource)) {
@@ -3077,9 +3101,10 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 if (any(stats::na.omit(self$sampleSizes) <= 0)) {
                     stopIllegalArgument("all sample sizes must be > 0, but 'n' = ", self$.arrayToString(self$sampleSizes,
                         vectorLookAndFeelEnabled = TRUE
-                    ), 
-		functionName = ".initByDataFrame", 
-		parameter ="n")
+                    ),
+                    functionName = ".initByDataFrame",
+                    parameter = "n"
+                    )
                 }
 
                 self$events <- self$.getValidatedFloatingPointNumbers(
@@ -3089,8 +3114,8 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 self$.validateValues(self$events, "events")
                 if (any(stats::na.omit(self$events) < 0)) {
                     stopIllegalArgument("all events must be >= 0, but 'events' = ", self$.arrayToString(self$events, vectorLookAndFeelEnabled = TRUE),
-                        functionName = ".initByDataFrame", 
-		parameter ="events", value = self$events
+                        functionName = ".initByDataFrame",
+                        parameter = "events", value = self$events
                     )
                 }
 
@@ -3173,9 +3198,10 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     if (any(stats::na.omit(sampleSizesTemp) <= 0)) {
                         stopIllegalArgument("all sample sizes must be > 0, but 'n", group, "' = ", self$.arrayToString(sampleSizesTemp,
                             vectorLookAndFeelEnabled = TRUE
-                        ), 
-		functionName = ".initByDataFrame", 
-		parameter ="group", value = group)
+                        ),
+                        functionName = ".initByDataFrame",
+                        parameter = "group", value = group
+                        )
                     }
                     self$sampleSizes <- c(self$sampleSizes, sampleSizesTemp)
 
@@ -3187,9 +3213,10 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     if (any(stats::na.omit(eventsTemp) < 0)) {
                         stopIllegalArgument("all events must be >= 0, but 'events", group, "' = ", self$.arrayToString(eventsTemp,
                             vectorLookAndFeelEnabled = TRUE
-                        ), 
-		functionName = ".initByDataFrame", 
-		parameter ="group", value = group)
+                        ),
+                        functionName = ".initByDataFrame",
+                        parameter = "group", value = group
+                        )
                     }
                     self$events <- c(self$events, eventsTemp)
 
@@ -3206,8 +3233,9 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     self$overallEvents <- c(self$overallEvents, overallData$overallEvents)
                 }
                 if (sum(stats::na.omit(self$sampleSizes) < 0) > 0) {
-                    stopIllegalArgument("all sample sizes must be >= 0", 
-		functionName = ".initByDataFrame")
+                    stopIllegalArgument("all sample sizes must be >= 0",
+                        functionName = ".initByDataFrame"
+                    )
                 }
 
                 self$.setParameterType("sampleSizes", C_PARAM_USER_DEFINED)
@@ -3275,8 +3303,9 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     self$events <- c(self$events, stageWiseData$events)
 
                     if (sum(stats::na.omit(self$sampleSizes) < 0) > 0) {
-                        stopIllegalArgument("all sample sizes must be >= 0", 
-		functionName = ".initByDataFrame")
+                        stopIllegalArgument("all sample sizes must be >= 0",
+                            functionName = ".initByDataFrame"
+                        )
                     }
                 }
 
@@ -3286,13 +3315,15 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 self$.setParameterType("overallSampleSizes", C_PARAM_USER_DEFINED)
                 self$.setParameterType("overallEvents", C_PARAM_USER_DEFINED)
             } else {
-                stopMissingArgument("sample sizes are missing or not correctly specified", 
-		functionName = ".initByDataFrame")
+                stopMissingArgument("sample sizes are missing or not correctly specified",
+                    functionName = ".initByDataFrame"
+                )
             }
 
             if (sum(stats::na.omit(self$events) < 0) > 0) {
-                stopIllegalArgument("all events must be >= 0", 
-		functionName = ".initByDataFrame")
+                stopIllegalArgument("all events must be >= 0",
+                    functionName = ".initByDataFrame"
+                )
             }
 
             self$.recreateDataFrame()
@@ -3420,9 +3451,10 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 )
             }
             if (is.null(dataInput[["events"]])) {
-                stopMissingArgument("data input must contain variable 'events'", 
-		functionName = ".getOverallData", 
-		parameter ="events")
+                stopMissingArgument("data input must contain variable 'events'",
+                    functionName = ".getOverallData",
+                    parameter = "events"
+                )
             }
 
             dataInput$overallSampleSizes <- c(
@@ -3642,8 +3674,9 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                 ), parameterName = "Events")
                 self$.validateValues(self$events, "events")
                 if (any(stats::na.omit(self$events) < 0)) {
-                    stopIllegalArgument("all events must be >= 0", 
-		functionName = ".initByDataFrame")
+                    stopIllegalArgument("all events must be >= 0",
+                        functionName = ".initByDataFrame"
+                    )
                 }
 
                 self$logRanks <- self$.getValuesByParameterName(dataFrame, C_KEY_WORDS_LOG_RANKS)
@@ -3727,9 +3760,10 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                     if (any(stats::na.omit(eventsTemp) < 0)) {
                         stopIllegalArgument("all events must be >= 0, but 'events", group, "' = ", self$.arrayToString(eventsTemp,
                             vectorLookAndFeelEnabled = TRUE
-                        ), 
-		functionName = ".initByDataFrame", 
-		parameter ="group", value = group)
+                        ),
+                        functionName = ".initByDataFrame",
+                        parameter = "group", value = group
+                        )
                     }
                     self$events <- c(self$events, eventsTemp)
 
@@ -3755,8 +3789,8 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                 }
             } else {
                 stopRuntimeIssue("unable to identify case for ", .getClassName(self), " and columns ", self$.arrayToString(colnames(dataFrame)),
-                    functionName = ".initByDataFrame", 
-		parameter ="self", value = self
+                    functionName = ".initByDataFrame",
+                    parameter = "self", value = self
                 )
             }
 
@@ -4074,15 +4108,15 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_OVERALL_EXPECTED_EVENTS)) {
                     stopMissingArgument("'overallExpectedEvents' or 'cumExpectedEvents' is missing",
                         functionName = ".initByDataFrame",
-                        parameter = "overallExpectedEvents", 
-		relatedParameter ="cumExpectedEvents"
+                        parameter = "overallExpectedEvents",
+                        relatedParameter = "cumExpectedEvents"
                     )
                 }
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_OVERALL_VARIANCE_EVENTS)) {
                     stopMissingArgument("'overallVarianceEvents' or 'cumVarianceEvents' is missing",
                         functionName = ".initByDataFrame",
-                        parameter = "overallVarianceEvents", 
-		relatedParameter ="cumVarianceEvents"
+                        parameter = "overallVarianceEvents",
+                        relatedParameter = "cumVarianceEvents"
                     )
                 }
 
@@ -4109,14 +4143,16 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
             } else if (self$.paramExists(dataFrame, C_KEY_WORDS_EXPECTED_EVENTS) ||
                     self$.paramExists(dataFrame, C_KEY_WORDS_VARIANCE_EVENTS)) {
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_EXPECTED_EVENTS)) {
-                    stopMissingArgument("'expectedEvents' is missing", 
-		functionName = ".initByDataFrame", 
-		parameter ="expectedEvents")
+                    stopMissingArgument("'expectedEvents' is missing",
+                        functionName = ".initByDataFrame",
+                        parameter = "expectedEvents"
+                    )
                 }
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_VARIANCE_EVENTS)) {
-                    stopMissingArgument("'varianceEvents' is missing", 
-		functionName = ".initByDataFrame", 
-		parameter ="varianceEvents")
+                    stopMissingArgument("'varianceEvents' is missing",
+                        functionName = ".initByDataFrame",
+                        parameter = "varianceEvents"
+                    )
                 }
 
                 self$.inputType <- "stagewise"

--- a/R/class_analysis_dataset.R
+++ b/R/class_analysis_dataset.R
@@ -171,8 +171,9 @@ readDataset <- function(
         comment.char = "",
         fileEncoding = "UTF-8") {
     if (!file.exists(file)) {
-        stopIllegalArgument("the file '", file, "' does not exist",
-            functionName = "readDataset", parameter = "file",
+        stopIllegalArgument("the file ", .vQuote(file), " does not exist",
+            functionName = "readDataset", 
+		parameter ="file",
             value = file
         )
     }
@@ -323,8 +324,9 @@ readDatasets <- function(
         comment.char = "",
         fileEncoding = "UTF-8") {
     if (!file.exists(file)) {
-        stopIllegalArgument("the file '", file, "' does not exist",
-            functionName = "readDatasets", parameter = "file",
+        stopIllegalArgument("the file ", .vQuote(file), " does not exist",
+            functionName = "readDatasets", 
+		parameter ="file",
             value = file
         )
     }
@@ -335,7 +337,9 @@ readDatasets <- function(
     )
 
     if (is.null(data[["datasetId"]])) {
-        stopIllegalArgument("data file must contain the column 'datasetId'", functionName = "readDatasets", parameter = "datasetId")
+        stopIllegalArgument("data file must contain the column 'datasetId'", 
+		functionName = "readDatasets", 
+		parameter ="datasetId")
     }
 
     datasets <- list()
@@ -435,11 +439,19 @@ writeDatasets <- function(
         qmethod = "double",
         fileEncoding = "UTF-8") {
     if (!is.list(datasets)) {
-        stopIllegalArgument("'datasets' must be a list of datasets", functionName = "writeDatasets", parameter = "datasets", value = datasets)
+        stopIllegalArgument("'datasets' must be a list of datasets",
+            functionName = "writeDatasets",
+            parameter = "datasets",
+            value = datasets
+        )
     }
 
     if (length(datasets) == 0) {
-        stopIllegalArgument("'datasets' is empty", functionName = "writeDatasets", parameter = "datasets", value = datasets)
+        stopIllegalArgument("'datasets' is empty",
+            functionName = "writeDatasets",
+            parameter = "datasets",
+            value = datasets
+        )
     }
 
     datasetType <- NA_character_
@@ -450,7 +462,9 @@ writeDatasets <- function(
         if (is.na(datasetType)) {
             datasetType <- .getClassName(dataset)
         } else if (.getClassName(dataset) != datasetType) {
-            stopIllegalArgument("all datasets must have the same type", functionName = "writeDatasets")
+            stopIllegalArgument("all datasets must have the same type",
+                functionName = "writeDatasets"
+            )
         }
 
         data <- as.data.frame(dataset, niceColumnNamesEnabled = FALSE)
@@ -471,7 +485,8 @@ writeDatasets <- function(
     }
 
     if (is.null(dataFrames)) {
-        stopRuntimeIssue("failed to bind datasets", functionName = "writeDatasets")
+        stopRuntimeIssue("failed to bind datasets", 
+		functionName = "writeDatasets")
     }
 
     utils::write.table(
@@ -485,7 +500,8 @@ writeDatasets <- function(
 .getDataset <- function(..., floatingPointNumbersEnabled = FALSE) {
     args <- list(...)
     if (length(args) == 0) {
-        stopMissingArgument("data.frame, data vectors, or datasets expected", functionName = ".getDataset")
+        stopMissingArgument("data.frame, data vectors, or datasets expected", 
+		functionName = ".getDataset")
     }
 
     if (.optionalArgsContainsDatasets(...)) {
@@ -538,11 +554,13 @@ writeDatasets <- function(
         }
 
         if (length(paramNames) != numberOfParameters) {
-            stopIllegalArgument("all parameters must be named", functionName = ".getDataset")
+            stopIllegalArgument("all parameters must be named", 
+		functionName = ".getDataset")
         }
 
         if (length(paramNames) != length(unique(paramNames))) {
-            stopIllegalArgument("the parameter names must be unique", functionName = ".getDataset")
+            stopIllegalArgument("the parameter names must be unique", 
+		functionName = ".getDataset")
         }
 
         dataFrame <- .createDataFrame(...)
@@ -586,7 +604,8 @@ writeDatasets <- function(
         ))
     }
 
-    stopIllegalArgument("failed to identify dataset type", functionName = ".getDataset")
+    stopIllegalArgument("failed to identify dataset type", 
+		functionName = ".getDataset")
 }
 
 #' @title
@@ -724,7 +743,10 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
                 argInfo <- paste0(sQuote(argName), " ")
             }
             argInfo <- paste0(argInfo, "(", .arrayToString(arg), ")")
-            warning("Argument ", argInfo, " will be ignored because only 'emmGrid' objects will be respected")
+            warning(
+                "Argument ", argInfo, " will be ignored ",
+                "because only 'emmGrid' objects will be respected"
+            )
         }
     }
 
@@ -745,12 +767,14 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 #' @param dfValue Numeric. Degrees of freedom for the t-distribution. Default is \code{NA_real_}.
 #' @param alpha Numeric. Significance level for the t-distribution. Default is \code{0.05}.
 #' @param lmEnabled Logical. If \code{TRUE}, linear model-based calculations are enabled. Default is \code{TRUE}.
-#' @param stDevCalcMode Character. Specifies the calculation mode for standard deviation. Options are \code{"auto"} or \code{"t"}.
+#' @param stDevCalcMode Character. Specifies the calculation
+#'        mode for standard deviation. Options are \code{"auto"} or \code{"t"}.
 #'
 #' @details
 #' The function performs the following tasks:
 #' \itemize{
-#'   \item If \code{stDevCalcMode} is set to \code{"t"} and \code{dfValue} is valid, it uses the t-distribution to calculate the standard deviation.
+#'   \item If \code{stDevCalcMode} is set to \code{"t"} and \code{dfValue} is
+#'         valid, it uses the t-distribution to calculate the standard deviation.
 #'   \item Otherwise, it defaults to using the normal distribution for the calculation.
 #' }
 #'
@@ -818,7 +842,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
                         "%s must contain %s objects created by emmeans(x), ",
                         "where x is a linear model result (one object per stage; class is %s at stage %s)"
                     ),
-                    sQuote("emmeansResults"), sQuote("emmGrid"), .getClassName(emmeansResultPerStage), stage
+                    sQuote("emmeansResults"), sQuote("emmGrid"),
+                    .getClassName(emmeansResultPerStage), stage
                 ),
                 parameter = "emmeansResults",
                 value = emmeansResultPerStage,
@@ -865,14 +890,16 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
                 )
             } else {
                 warning("Using ", modelFunction, " emmeans result objects as ",
-                    "arguments of getDataset() is experminental in this rpact version and not fully validated",
+                    "arguments of getDataset() is experminental in this rpact ",
+                    "version and not fully validated",
                     call. = FALSE
                 )
             }
         },
         error = function(e) {
             warning("Using emmeans result objects as ",
-                "arguments of getDataset() is experminental in this rpact version and not fully validated",
+                "arguments of getDataset() is experminental in this rpact ",
+                "version and not fully validated",
                 call. = FALSE
             )
         }
@@ -890,15 +917,18 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
         emmeansResultsList <- as.list(emmeansResult)
 
         if (is.null(emmeansResultsSummary[["emmean"]])) {
-            stopRuntimeIssue("the objects in summary(emmeansResults) must contain the field 'emmean'",
+            stopRuntimeIssue("the objects in summary(emmeansResults) ",
+                "must contain the field 'emmean'",
                 functionName = ".getDatasetMeansFromModelsByStage",
                 parameter = "emmean"
             )
         }
         for (expectedField in c("sigma", "extras")) {
             if (is.null(emmeansResultsList[[expectedField]])) {
-                stopRuntimeIssue("the objects in as.list(emmeansResults) must contain the field ", sQuote(expectedField),
-                    functionName = ".getDatasetMeansFromModelsByStage", parameter = expectedField
+                stopRuntimeIssue("the objects in as.list(emmeansResults) ",
+                    "must contain the field ", sQuote(expectedField),
+                    functionName = ".getDatasetMeansFromModelsByStage",
+                    parameter = expectedField
                 )
             }
         }
@@ -944,7 +974,10 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
         sampleSizes = sampleSizes
     )
     data <- data[order(data$stages, data$groups), ]
-    dataWide <- stats::reshape(data = data, direction = "wide", idvar = "stages", timevar = "groups")
+    dataWide <- stats::reshape(
+        data = data, direction = "wide",
+        idvar = "stages", timevar = "groups"
+    )
     colnames(dataWide) <- gsub("\\.", "", colnames(dataWide))
     return(getDataset(dataWide))
 }
@@ -966,16 +999,21 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 .getSubsetsFromArgs <- function(...) {
     args <- list(...)
     if (length(args) == 0) {
-        stopMissingArgument("one or more subset datasets expected", functionName = ".getSubsetsFromArgs")
+        stopMissingArgument("one or more subset datasets expected",
+            functionName = ".getSubsetsFromArgs"
+        )
     }
 
     subsetNames <- names(args)
     if (is.null(subsetNames)) {
-        stopIllegalArgument("all subsets must be named", functionName = ".getSubsetsFromArgs")
+        stopIllegalArgument("all subsets must be named",
+            functionName = ".getSubsetsFromArgs"
+        )
     }
 
     if (!("R" %in% subsetNames) && !("F" %in% subsetNames)) {
-        stopMissingArgument("\"R\" (stratified analysis)\" or \"F\" (non-stratified analysis) must be defined as subset",
+        stopMissingArgument("\"R\" (stratified analysis)\" or \"F\" ",
+            "(non-stratified analysis) must be defined as subset",
             functionName = ".getSubsetsFromArgs"
         )
     }
@@ -983,10 +1021,12 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
     subsetNumbers <- gsub("\\D", "", subsetNames)
     subsetNumbers <- subsetNumbers[subsetNumbers != ""] #  & nchar(subsetNumbers) == 1
     if (length(subsetNumbers) == 0) {
-        stopIllegalArgument("all subset names (", .arrayToString(subsetNames), ") must be \"S[n]\", \"R\", or \"F\", ",
+        stopIllegalArgument("all subset names (", .arrayToString(subsetNames), ") ",
+            "must be \"S[n]\", \"R\", or \"F\", ",
             "where [n] is a number with increasing digits (starting with 1)",
             functionName = ".getSubsetsFromArgs",
-            parameter = "subsetNames", value = subsetNames
+            parameter = "subsetNames",
+            value = subsetNames
         )
     }
 
@@ -1000,13 +1040,15 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
     for (i in seq_len(length(subsetNames))) {
         subsetName <- subsetNames[i]
         if (subsetName == "" && !inherits(args[[i]], "TrialDesign")) {
-            stopIllegalArgument("all subsets must be named", functionName = ".getSubsetsFromArgs")
+            stopIllegalArgument("all subsets must be named", 
+		functionName = ".getSubsetsFromArgs")
         }
 
         if (subsetName != "" && !(subsetName %in% validSubsetNames)) {
             suffix <- ifelse(stratifiedInput, " (stratified analysis)", " (non-stratified analysis)")
             if (length(validSubsetNames) < 10) {
-                stopIllegalArgument("invalid subset name (", subsetName, "); ", "valid names are ", .arrayToString(validSubsetNames),
+                stopIllegalArgument("invalid subset name (", subsetName, "); ",
+                    "valid names are ", .arrayToString(validSubsetNames),
                     suffix,
                     functionName = ".getSubsetsFromArgs",
                     parameter = "subsetName",
@@ -1040,7 +1082,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
             emptySubsetNames <- c(emptySubsetNames, subsetName)
         } else {
             if (!.isDataset(subset)) {
-                stopIllegalArgument("subset ", subsetName, " is not a dataset (is ", .getClassName(subset), ")",
+                stopIllegalArgument("subset ", subsetName, " is not a dataset ",
+                    "(is ", .getClassName(subset), ")",
                     functionName = ".getSubsetsFromArgs",
                     parameter = "subsetName",
                     value = subsetName,
@@ -1110,9 +1153,14 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
     for (param in params) {
         paramValue <- dataFrameStage1[[param]]
         if (any(is.null(paramValue) || any(is.infinite(paramValue)))) {
-            stopIllegalArgument(gettextf("all %s values (%s) at first stage must be valid", sQuote(param), .arrayToString(paramValue,
-                maxLength = 10
-            )), functionName = ".validateEnrichmentDataFrameAtFirstStage", parameter = param)
+            stopIllegalArgument(
+                gettextf(
+                    "all %s values (%s) at first stage must be valid",
+                    sQuote(param), .arrayToString(paramValue, maxLength = 10)
+                ),
+                functionName = ".validateEnrichmentDataFrameAtFirstStage",
+                parameter = param
+            )
         }
         if (anyNA(paramValue)) {
             subsets <- unique(dataFrame$subset)
@@ -1122,7 +1170,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
                 if (!all(is.na(subsetParamValues)) && anyNA(subsetParamValues[subData$stage == 1])) {
                     stopIllegalArgument(
                         gettextf(
-                            "all %s values (%s) at first stage must be valid (NA is not allowed)", sQuote(param),
+                            "all %s values (%s) at first stage must be valid (NA is not allowed)",
+                            sQuote(param),
                             .arrayToString(paramValue, maxLength = 10)
                         ),
                         functionName = ".validateEnrichmentDataFrameAtFirstStage",
@@ -1148,7 +1197,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
             stopConflictingArguments(gettextf(
                 paste0("inconsistent deselection in group %s at stage %s (", "%s: all or none must be NA)"),
                 dataFrame$group[i], dataFrame$stage[i], .arrayToString(paramNames, maxCharacters = 40)
-            ), functionName = ".validateEnrichmentDataFrameDeselection")
+            ), 
+		functionName = ".validateEnrichmentDataFrameDeselection")
         }
     }
 
@@ -1162,7 +1212,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
                 stopConflictingArguments(gettextf(paste0(
                     "%s was deselected at stage %s ", "and therefore must be also deselected in the following stages, ",
                     "but is no longer deselected in stage %s"
-                ), s, deselectedStage, stage), functionName = ".validateEnrichmentDataFrameDeselection")
+                ), s, deselectedStage, stage), 
+		functionName = ".validateEnrichmentDataFrameDeselection")
             }
 
             if (anyNA(subData)) {
@@ -1174,10 +1225,12 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
 .validateEnrichmentDataFrameMeans <- function(dataFrame) {
     if (any(na.omit(dataFrame$stDev) <= 0) || any(na.omit(dataFrame$overallStDev) <= 0)) {
-        stopIllegalArgument("all standard deviations must be > 0", functionName = ".validateEnrichmentDataFrameMeans")
+        stopIllegalArgument("all standard deviations must be > 0", 
+		functionName = ".validateEnrichmentDataFrameMeans")
     }
     if (any(na.omit(dataFrame$sampleSize) <= 0) || any(na.omit(dataFrame$overallSampleSize) <= 0)) {
-        stopIllegalArgument("all sample sizes must be > 0", functionName = ".validateEnrichmentDataFrameMeans")
+        stopIllegalArgument("all sample sizes must be > 0", 
+		functionName = ".validateEnrichmentDataFrameMeans")
     }
 
     .validateEnrichmentDataFrameAtFirstStage(dataFrame,
@@ -1228,7 +1281,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
 .validateEnrichmentDataFrameSurvival <- function(dataFrame) {
     if (any(na.omit(dataFrame$event) < 0) || any(na.omit(dataFrame$overallEvent) < 0)) {
-        stopIllegalArgument("all events must be >= 0", functionName = ".validateEnrichmentDataFrameSurvival")
+        stopIllegalArgument("all events must be >= 0", 
+		functionName = ".validateEnrichmentDataFrameSurvival")
     }
 
     .validateEnrichmentDataFrameAtFirstStage(dataFrame,
@@ -1266,7 +1320,9 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
 .validateEnrichmentDataFrameRates <- function(dataFrame) {
     if (any(na.omit(dataFrame$sampleSize) <= 0) || any(na.omit(dataFrame$overallSampleSize) <= 0)) {
-        stopIllegalArgument("all sample sizes must be > 0", functionName = ".validateEnrichmentDataFrameRates")
+        stopIllegalArgument("all sample sizes must be > 0",
+            functionName = ".validateEnrichmentDataFrameRates"
+        )
     }
 
     .validateEnrichmentDataFrameAtFirstStage(dataFrame,
@@ -1282,11 +1338,13 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
         for (s in subsets) {
             for (stage in unique(dataFrame$stage)) {
                 for (group in unique(dataFrame$group)) {
-                    subData <- dataFrame[dataFrame$subset == s & dataFrame$stage == stage & dataFrame$group == group, ]
+                    subData <- dataFrame[dataFrame$subset == s &
+                        dataFrame$stage == stage & dataFrame$group == group, ]
 
                     sampleSizeFull <- na.omit(fullData$sampleSize[fullData$stage == stage & fullData$group == group])
                     sampleSizeSubset <- na.omit(subData$sampleSize)
-                    if (length(sampleSizeFull) > 0 && length(sampleSizeSubset) > 0 && any(sampleSizeFull < sampleSizeSubset)) {
+                    if (length(sampleSizeFull) > 0 && length(sampleSizeSubset) > 0 &&
+                            any(sampleSizeFull < sampleSizeSubset)) {
                         stopConflictingArguments(
                             gettextf(
                                 "'sampleSize' F (%s) must be >= 'sampleSize' %s (%s) in group %s at stage %s",
@@ -1311,7 +1369,11 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
         subsetStages <- as.integer(sort(unique(na.omit(as.character(dataFrame$stage[dataFrame$subset == s])))))
         kMax <- max(subsetStages)
         if (!isTRUE(all.equal(1:kMax, subsetStages))) {
-            stopIllegalArgument(gettextf("subset %s has incomplete stages (%s)", s, .arrayToString(subsetStages)),
+            stopIllegalArgument(
+                gettextf(
+                    "subset %s has incomplete stages (%s)",
+                    s, .arrayToString(subsetStages)
+                ),
                 functionName = ".validateEnrichmentDataFrameHasConsistentNumberOfStages"
             )
         }
@@ -1321,8 +1383,9 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
     kMax <- unique(unlist(kMaxList))
     if (length(kMax) > 1) {
-        stopConflictingArguments("all subsets must have the identical number of stages defined (kMax: ", .listToString(kMaxList),
-            ")",
+        stopConflictingArguments(
+            "all subsets must have the identical number of ",
+            "stages defined (kMax: ", .listToString(kMaxList), ")",
             functionName = ".validateEnrichmentDataFrameHasConsistentNumberOfStages"
         )
     }
@@ -1338,7 +1401,9 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
         .validateEnrichmentDataFrameSurvival(dataFrame)
     } else {
         print(paramNames)
-        stopRuntimeIssue("could not identify the endpoint of the specified dataset", functionName = ".validateEnrichmentDataFrame")
+        stopRuntimeIssue("could not identify the endpoint of the specified dataset",
+            functionName = ".validateEnrichmentDataFrame"
+        )
     }
 
     subsets <- unique(dataFrame$subset)
@@ -1361,13 +1426,18 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
                             paramValueSubset <- subData[[paramName]]
                             if (length(paramValueRest) > 0 && length(paramValueSubset) > 0 &&
                                     anyNA(paramValueSubset) && !all(is.na(paramValueRest))) {
-                                stopConflictingArguments(gettextf(
-                                    paste0(
-                                        "if %s is deselected (NA) then R also must be deselected (NA) but, e.g., ",
-                                        "%s R is %s in group %s at stage %s"
-                                    ), s, sQuote(paramName), .arrayToString(paramValueRest, vectorLookAndFeelEnabled = TRUE),
-                                    group, stage
-                                ), functionName = ".validateEnrichmentDataFrame", parameter = paramName)
+                                stopConflictingArguments(
+                                    gettextf(
+                                        paste0(
+                                            "if %s is deselected (NA) then R also must be deselected (NA) but, e.g., ",
+                                            "%s R is %s in group %s at stage %s"
+                                        ), s, sQuote(paramName),
+                                        .arrayToString(paramValueRest, vectorLookAndFeelEnabled = TRUE),
+                                        group, stage
+                                    ),
+                                    functionName = ".validateEnrichmentDataFrame",
+                                    parameter = paramName
+                                )
                             }
                         }
                     }
@@ -1442,7 +1512,8 @@ getDataSet <- function(..., floatingPointNumbersEnabled = FALSE) {
 
     stopIllegalArgument("'exampleType' (", exampleType, ") is not allowed",
         functionName = ".getDatasetExample",
-        parameter = "exampleType", value = exampleType
+        parameter = "exampleType",
+        value = exampleType
     )
 }
 
@@ -1494,7 +1565,12 @@ Dataset <- R6::R6Class("Dataset",
         stages = NULL,
         groups = NULL,
         subsets = NULL,
-        initialize = function(dataFrame, ..., floatingPointNumbersEnabled = FALSE, enrichmentEnabled = FALSE, .design = NULL) {
+        initialize = function(
+                dataFrame,
+                ...,
+                floatingPointNumbersEnabled = FALSE,
+                enrichmentEnabled = FALSE,
+                .design = NULL) {
             super$initialize(...)
 
             self$.floatingPointNumbersEnabled <- floatingPointNumbersEnabled
@@ -1555,8 +1631,8 @@ Dataset <- R6::R6Class("Dataset",
         },
         .initByDataFrame = function(dataFrame) {
             if (!is.data.frame(dataFrame)) {
-                stopIllegalArgument("'dataFrame' must be a data.frame (is an instance of class ",
-                    .getClassName(dataFrame), ")",
+                stopIllegalArgument("'dataFrame' must be a data.frame ",
+                    "(is an instance of class ", .getClassName(dataFrame), ")",
                     functionName = ".initByDataFrame",
                     parameter = "dataFrame",
                     value = dataFrame
@@ -1608,7 +1684,7 @@ Dataset <- R6::R6Class("Dataset",
             for (var in names(self)) {
                 values <- self[[var]]
                 if (any(is.nan(values)) || any(is.infinite(values))) {
-                    stopRuntimeIssue("'", var, "' (", .arrayToString(values), ") ",
+                    stopRuntimeIssue(.pQuote(var), " (", .arrayToString(values), ") ",
                         "contains illegal values, i.e., something went wrong",
                         functionName = ".validateDataset",
                         parameter = "var",
@@ -1630,7 +1706,7 @@ Dataset <- R6::R6Class("Dataset",
                 stopConflictingArguments("there ",
                     ifelse(l1 == 1, paste("is", l1, "stage"), paste("are", l1, "stages")),
                     " defined", " (", .arrayToString(unique(self$stages)), ") and ",
-                    "'", name, "' has length ", l2,
+                    .pQuote(name), " has length ", l2,
                     functionName = ".validateValues",
                     parameter = "name",
                     value = name,
@@ -1747,7 +1823,8 @@ Dataset <- R6::R6Class("Dataset",
                 return(defaultValues)
             }
 
-            stopMissingArgument("parameter '", paste0(parameterNameVariants[1], suffix), "' is missing or not correctly specified",
+            stopMissingArgument("parameter ", .pQuote(paste0(parameterNameVariants[1], suffix)), " ",
+                "is missing or not correctly specified",
                 functionName = ".getValuesByParameterName"
             )
         },
@@ -1762,9 +1839,11 @@ Dataset <- R6::R6Class("Dataset",
             values <- self$.data[[paramName]]
             valueLevels <- self$.getValueLevels(values)
             if (!all(paramValues %in% valueLevels)) {
-                stopIllegalArgument("'", paramName, "' (", .arrayToString(paramValues), ") out of range [", .arrayToString(valueLevels),
-                    "]",
-                    functionName = ".getValues", parameter = paramName, value = paramValues
+                stopIllegalArgument(.pQuote(paramName), " (", .arrayToString(paramValues), ") ",
+                    "out of range [", .arrayToString(valueLevels), "]",
+                    functionName = ".getValues",
+                    parameter = paramName,
+                    value = paramValues
                 )
             }
             return(values)
@@ -1781,16 +1860,20 @@ Dataset <- R6::R6Class("Dataset",
         .assertIsValidSubset = function(subset) {
             for (s in subset) {
                 if (!(s %in% levels(self$.data$subset))) {
-                    stopIllegalArgument("'subset' (", s, ") is not a defined value [", .arrayToString(levels(self$.data$subset)),
-                        "]",
-                        functionName = ".assertIsValidSubset", parameter = "subset", value = self$.data$subset
+                    stopIllegalArgument("'subset' (", s, ") is not a defined value ",
+                "[", .arrayToString(levels(self$.data$subset)), "]",
+                        functionName = ".assertIsValidSubset", 
+                        parameter = "subset", 
+                        value = self$.data$subset
                     )
                 }
             }
         },
         .getIndices = function(..., stage, group, subset = NA_character_) {
             if (is.null(self$.data)) {
-                stopRuntimeIssue("'.data' must be defined", functionName = ".getIndices", parameter = ".data")
+                stopRuntimeIssue("'.data' must be defined", 
+                    functionName = ".getIndices", 
+		parameter =".data")
             }
 
             if (!is.null(stage) && !anyNA(stage) && all(stage < 0)) {
@@ -1830,7 +1913,8 @@ Dataset <- R6::R6Class("Dataset",
 
             nToCheck <- stats::na.omit(x)
             if (any(nToCheck != as.integer(nToCheck))) {
-                warning(parameterName, " specified as floating-point numbers were truncated", call. = FALSE)
+                warning(parameterName, " specified as floating-point ",
+                "numbers were truncated", call. = FALSE)
             }
 
             x[!is.na(x)] <- as.integer(x[!is.na(x)])
@@ -1863,7 +1947,7 @@ Dataset <- R6::R6Class("Dataset",
             if (!survivalCorrectionEnabled) {
                 return(length(levels(data$group)))
             }
-            return(length(levels(data$group)) + ifelse(inherits(self, "DatasetSurvival") || 
+            return(length(levels(data$group)) + ifelse(inherits(self, "DatasetSurvival") ||
                 inherits(self, "DatasetSurvival"), 1, 0))
         },
         getNumberOfStages = function(naOmitEnabled = TRUE) {
@@ -1880,7 +1964,8 @@ Dataset <- R6::R6Class("Dataset",
                 numberOfStages <- length(unique(as.character(subData$stage)))
                 if (numberOfStages == 0) {
                     print(self$.data[, validColNames])
-                    stopRuntimeIssue(".data seems to contain an invalid column", functionName = "getNumberOfStages")
+                    stopRuntimeIssue(".data seems to contain an invalid column", 
+                        functionName = "getNumberOfStages")
                 }
                 return(numberOfStages)
             }
@@ -2040,8 +2125,10 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
                 ), parameterName = "Sample sizes")
                 self$.validateValues(self$sampleSizes, "n")
                 if (any(stats::na.omit(self$sampleSizes) <= 0)) {
-                    stopIllegalArgument("all sample sizes must be > 0, but 'n' = ", .arrayToString(self$sampleSizes, vectorLookAndFeelEnabled = TRUE),
-                        functionName = ".initByDataFrame", parameter = "n"
+                    stopIllegalArgument("all sample sizes must be > 0, but 'n' = ", 
+                        .arrayToString(self$sampleSizes, vectorLookAndFeelEnabled = TRUE),
+                        functionName = ".initByDataFrame", 
+                        parameter = "n"
                     )
                 }
 
@@ -2151,7 +2238,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
                     self$groups <- c(self$groups, rep(as.integer(group), length(overallSampleSizesTemp)))
                 }
             } else {
-                stopMissingArgument("sample sizes are missing or not correctly specified", functionName = ".initByDataFrame")
+                stopMissingArgument("sample sizes are missing or not correctly specified", 
+                    functionName = ".initByDataFrame")
             }
 
             if (self$.inputType == "stagewise") {
@@ -2189,10 +2277,12 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
             }
 
             if (sum(stats::na.omit(self$sampleSizes) < 0) > 0) {
-                stopIllegalArgument("all sample sizes must be >= 0", functionName = ".initByDataFrame")
+                stopIllegalArgument("all sample sizes must be >= 0", 
+                    functionName = ".initByDataFrame")
             }
             if (sum(stats::na.omit(self$stDevs) < 0) > 0) {
-                stopIllegalArgument("all standard deviations must be >= 0", functionName = ".initByDataFrame")
+                stopIllegalArgument("all standard deviations must be >= 0", 
+		functionName = ".initByDataFrame")
             }
         },
         .recreateDataFrame = function() {
@@ -2418,7 +2508,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
     if (!is.null(fixedCovariates)) {
         if (!is.list(fixedCovariates)) {
             stopIllegalArgument(sQuote("fixedCovariates"), " must be a named list",
-                functionName = ".getRandomDataMeans", parameter = "fixedCovariates",
+                functionName = ".getRandomDataMeans", 
+		parameter ="fixedCovariates",
                 value = fixedCovariates
             )
         }
@@ -2426,7 +2517,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
     if (!is.null(covariateEffects)) {
         if (!is.list(covariateEffects)) {
             stopIllegalArgument(sQuote("covariateEffects"), " must be a named list",
-                functionName = ".getRandomDataMeans", parameter = "covariateEffects",
+                functionName = ".getRandomDataMeans", 
+		parameter ="covariateEffects",
                 value = covariateEffects
             )
         }
@@ -2560,7 +2652,8 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
         fixedCovariateNames <- names(fixedCovariates)
         if (is.null(fixedCovariateNames) || any(nchar(trimws(fixedCovariateNames)) == 0)) {
             stopIllegalArgument(sQuote("fixedCovariates"), " must be a named list",
-                functionName = ".getRandomDataMeans", parameter = "fixedCovariates",
+                functionName = ".getRandomDataMeans", 
+		parameter ="fixedCovariates",
                 value = fixedCovariates
             )
         }
@@ -2581,7 +2674,9 @@ DatasetMeans <- R6::R6Class("DatasetMeans",
                 if (length(unique(values)) < length(values)) {
                     stopIllegalArgument(sQuote(paste0("fixedCovariates$", fixedCovariateName)), " (", .arrayToString(values,
                         maxLength = 20
-                    ), ") must be a unique vector", functionName = ".getRandomDataMeans", parameter = paste0(
+                    ), ") must be a unique vector", 
+		functionName = ".getRandomDataMeans", 
+		parameter =paste0(
                         "fixedCovariates$",
                         fixedCovariateName
                     ))
@@ -2727,7 +2822,8 @@ plot.Dataset <- function(
         showSource = FALSE,
         plotSettings = NULL) {
     if (x$.enrichmentEnabled) {
-        stopRuntimeIssue("plot of enrichment data is not yet implemented", functionName = ".plot.Dataset")
+        stopRuntimeIssue("plot of enrichment data is not yet implemented", 
+		functionName = ".plot.Dataset")
     }
 
     .assertGgplotIsInstalled()
@@ -2744,7 +2840,8 @@ plot.Dataset <- function(
         }
     } else if (x$isDatasetSurvival()) {
         # Open work: implement dataset plot of survival data
-        stopRuntimeIssue("plot of survival data is not yet implemented", functionName = ".plot.Dataset")
+        stopRuntimeIssue("plot of survival data is not yet implemented", 
+		functionName = ".plot.Dataset")
     }
 
     if (!is.logical(showSource) || isTRUE(showSource)) {
@@ -2980,7 +3077,9 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 if (any(stats::na.omit(self$sampleSizes) <= 0)) {
                     stopIllegalArgument("all sample sizes must be > 0, but 'n' = ", self$.arrayToString(self$sampleSizes,
                         vectorLookAndFeelEnabled = TRUE
-                    ), functionName = ".initByDataFrame", parameter = "n")
+                    ), 
+		functionName = ".initByDataFrame", 
+		parameter ="n")
                 }
 
                 self$events <- self$.getValidatedFloatingPointNumbers(
@@ -2990,7 +3089,8 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 self$.validateValues(self$events, "events")
                 if (any(stats::na.omit(self$events) < 0)) {
                     stopIllegalArgument("all events must be >= 0, but 'events' = ", self$.arrayToString(self$events, vectorLookAndFeelEnabled = TRUE),
-                        functionName = ".initByDataFrame", parameter = "events", value = self$events
+                        functionName = ".initByDataFrame", 
+		parameter ="events", value = self$events
                     )
                 }
 
@@ -3073,7 +3173,9 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     if (any(stats::na.omit(sampleSizesTemp) <= 0)) {
                         stopIllegalArgument("all sample sizes must be > 0, but 'n", group, "' = ", self$.arrayToString(sampleSizesTemp,
                             vectorLookAndFeelEnabled = TRUE
-                        ), functionName = ".initByDataFrame", parameter = "group", value = group)
+                        ), 
+		functionName = ".initByDataFrame", 
+		parameter ="group", value = group)
                     }
                     self$sampleSizes <- c(self$sampleSizes, sampleSizesTemp)
 
@@ -3085,7 +3187,9 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     if (any(stats::na.omit(eventsTemp) < 0)) {
                         stopIllegalArgument("all events must be >= 0, but 'events", group, "' = ", self$.arrayToString(eventsTemp,
                             vectorLookAndFeelEnabled = TRUE
-                        ), functionName = ".initByDataFrame", parameter = "group", value = group)
+                        ), 
+		functionName = ".initByDataFrame", 
+		parameter ="group", value = group)
                     }
                     self$events <- c(self$events, eventsTemp)
 
@@ -3102,7 +3206,8 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     self$overallEvents <- c(self$overallEvents, overallData$overallEvents)
                 }
                 if (sum(stats::na.omit(self$sampleSizes) < 0) > 0) {
-                    stopIllegalArgument("all sample sizes must be >= 0", functionName = ".initByDataFrame")
+                    stopIllegalArgument("all sample sizes must be >= 0", 
+		functionName = ".initByDataFrame")
                 }
 
                 self$.setParameterType("sampleSizes", C_PARAM_USER_DEFINED)
@@ -3170,7 +3275,8 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     self$events <- c(self$events, stageWiseData$events)
 
                     if (sum(stats::na.omit(self$sampleSizes) < 0) > 0) {
-                        stopIllegalArgument("all sample sizes must be >= 0", functionName = ".initByDataFrame")
+                        stopIllegalArgument("all sample sizes must be >= 0", 
+		functionName = ".initByDataFrame")
                     }
                 }
 
@@ -3180,11 +3286,13 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 self$.setParameterType("overallSampleSizes", C_PARAM_USER_DEFINED)
                 self$.setParameterType("overallEvents", C_PARAM_USER_DEFINED)
             } else {
-                stopMissingArgument("sample sizes are missing or not correctly specified", functionName = ".initByDataFrame")
+                stopMissingArgument("sample sizes are missing or not correctly specified", 
+		functionName = ".initByDataFrame")
             }
 
             if (sum(stats::na.omit(self$events) < 0) > 0) {
-                stopIllegalArgument("all events must be >= 0", functionName = ".initByDataFrame")
+                stopIllegalArgument("all events must be >= 0", 
+		functionName = ".initByDataFrame")
             }
 
             self$.recreateDataFrame()
@@ -3312,7 +3420,9 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 )
             }
             if (is.null(dataInput[["events"]])) {
-                stopMissingArgument("data input must contain variable 'events'", functionName = ".getOverallData", parameter = "events")
+                stopMissingArgument("data input must contain variable 'events'", 
+		functionName = ".getOverallData", 
+		parameter ="events")
             }
 
             dataInput$overallSampleSizes <- c(
@@ -3532,7 +3642,8 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                 ), parameterName = "Events")
                 self$.validateValues(self$events, "events")
                 if (any(stats::na.omit(self$events) < 0)) {
-                    stopIllegalArgument("all events must be >= 0", functionName = ".initByDataFrame")
+                    stopIllegalArgument("all events must be >= 0", 
+		functionName = ".initByDataFrame")
                 }
 
                 self$logRanks <- self$.getValuesByParameterName(dataFrame, C_KEY_WORDS_LOG_RANKS)
@@ -3616,7 +3727,9 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                     if (any(stats::na.omit(eventsTemp) < 0)) {
                         stopIllegalArgument("all events must be >= 0, but 'events", group, "' = ", self$.arrayToString(eventsTemp,
                             vectorLookAndFeelEnabled = TRUE
-                        ), functionName = ".initByDataFrame", parameter = "group", value = group)
+                        ), 
+		functionName = ".initByDataFrame", 
+		parameter ="group", value = group)
                     }
                     self$events <- c(self$events, eventsTemp)
 
@@ -3642,7 +3755,8 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                 }
             } else {
                 stopRuntimeIssue("unable to identify case for ", .getClassName(self), " and columns ", self$.arrayToString(colnames(dataFrame)),
-                    functionName = ".initByDataFrame", parameter = "self", value = self
+                    functionName = ".initByDataFrame", 
+		parameter ="self", value = self
                 )
             }
 
@@ -3960,13 +4074,15 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_OVERALL_EXPECTED_EVENTS)) {
                     stopMissingArgument("'overallExpectedEvents' or 'cumExpectedEvents' is missing",
                         functionName = ".initByDataFrame",
-                        parameter = "overallExpectedEvents", relatedParameter = "cumExpectedEvents"
+                        parameter = "overallExpectedEvents", 
+		relatedParameter ="cumExpectedEvents"
                     )
                 }
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_OVERALL_VARIANCE_EVENTS)) {
                     stopMissingArgument("'overallVarianceEvents' or 'cumVarianceEvents' is missing",
                         functionName = ".initByDataFrame",
-                        parameter = "overallVarianceEvents", relatedParameter = "cumVarianceEvents"
+                        parameter = "overallVarianceEvents", 
+		relatedParameter ="cumVarianceEvents"
                     )
                 }
 
@@ -3993,10 +4109,14 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
             } else if (self$.paramExists(dataFrame, C_KEY_WORDS_EXPECTED_EVENTS) ||
                     self$.paramExists(dataFrame, C_KEY_WORDS_VARIANCE_EVENTS)) {
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_EXPECTED_EVENTS)) {
-                    stopMissingArgument("'expectedEvents' is missing", functionName = ".initByDataFrame", parameter = "expectedEvents")
+                    stopMissingArgument("'expectedEvents' is missing", 
+		functionName = ".initByDataFrame", 
+		parameter ="expectedEvents")
                 }
                 if (!self$.paramExists(dataFrame, C_KEY_WORDS_VARIANCE_EVENTS)) {
-                    stopMissingArgument("'varianceEvents' is missing", functionName = ".initByDataFrame", parameter = "varianceEvents")
+                    stopMissingArgument("'varianceEvents' is missing", 
+		functionName = ".initByDataFrame", 
+		parameter ="varianceEvents")
                 }
 
                 self$.inputType <- "stagewise"

--- a/R/class_analysis_dataset.R
+++ b/R/class_analysis_dataset.R
@@ -3099,11 +3099,12 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 )
                 self$.validateValues(self$sampleSizes, "n")
                 if (any(stats::na.omit(self$sampleSizes) <= 0)) {
-                    stopIllegalArgument("all sample sizes must be > 0, but 'n' = ", self$.arrayToString(self$sampleSizes,
-                        vectorLookAndFeelEnabled = TRUE
-                    ),
-                    functionName = ".initByDataFrame",
-                    parameter = "n"
+                    stopIllegalArgument("all sample sizes must be > 0, but 'n' = ",
+                        self$.arrayToString(self$sampleSizes,
+                            vectorLookAndFeelEnabled = TRUE
+                        ),
+                        functionName = ".initByDataFrame",
+                        parameter = "n"
                     )
                 }
 
@@ -3113,7 +3114,8 @@ DatasetRates <- R6::R6Class("DatasetRates",
                 )
                 self$.validateValues(self$events, "events")
                 if (any(stats::na.omit(self$events) < 0)) {
-                    stopIllegalArgument("all events must be >= 0, but 'events' = ", self$.arrayToString(self$events, vectorLookAndFeelEnabled = TRUE),
+                    stopIllegalArgument("all events must be >= 0, but 'events' = ",
+                        self$.arrayToString(self$events, vectorLookAndFeelEnabled = TRUE),
                         functionName = ".initByDataFrame",
                         parameter = "events", value = self$events
                     )
@@ -3147,14 +3149,20 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     parameterName = "Cumulative sample sizes"
                 )
                 self$.validateValues(self$overallSampleSizes, "overallSampleSizes")
-                .assertValuesAreStrictlyIncreasing(self$overallSampleSizes, "overallSampleSizes", endingNasAllowed = TRUE)
+                .assertValuesAreStrictlyIncreasing(self$overallSampleSizes,
+                    "overallSampleSizes",
+                    endingNasAllowed = TRUE
+                )
 
                 self$overallEvents <- self$.getValidatedFloatingPointNumbers(
                     self$.getValuesByParameterName(dataFrame, C_KEY_WORDS_OVERALL_EVENTS),
                     parameterName = "Cumulative events"
                 )
                 self$.validateValues(self$overallEvents, "overallEvents")
-                .assertValuesAreMonotoneIncreasing(self$overallEvents, "overallEvents", endingNasAllowed = TRUE)
+                .assertValuesAreMonotoneIncreasing(self$overallEvents,
+                    "overallEvents",
+                    endingNasAllowed = TRUE
+                )
 
                 kMax <- length(self$overallSampleSizes)
                 stageNumber <- length(stats::na.omit(self$overallSampleSizes))
@@ -3196,11 +3204,12 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     )
                     self$.validateValues(sampleSizesTemp, paste0("n", group))
                     if (any(stats::na.omit(sampleSizesTemp) <= 0)) {
-                        stopIllegalArgument("all sample sizes must be > 0, but 'n", group, "' = ", self$.arrayToString(sampleSizesTemp,
-                            vectorLookAndFeelEnabled = TRUE
-                        ),
-                        functionName = ".initByDataFrame",
-                        parameter = "group", value = group
+                        stopIllegalArgument(
+                            "all sample sizes must be > 0, but ",
+                            .pQuote(paste0("n", group)), " = ",
+                            self$.arrayToString(sampleSizesTemp, vectorLookAndFeelEnabled = TRUE),
+                            functionName = ".initByDataFrame",
+                            parameter = "group", value = group
                         )
                     }
                     self$sampleSizes <- c(self$sampleSizes, sampleSizesTemp)
@@ -3211,11 +3220,12 @@ DatasetRates <- R6::R6Class("DatasetRates",
                     )
                     self$.validateValues(eventsTemp, paste0("events", group))
                     if (any(stats::na.omit(eventsTemp) < 0)) {
-                        stopIllegalArgument("all events must be >= 0, but 'events", group, "' = ", self$.arrayToString(eventsTemp,
-                            vectorLookAndFeelEnabled = TRUE
-                        ),
-                        functionName = ".initByDataFrame",
-                        parameter = "group", value = group
+                        stopIllegalArgument(
+                            "all events must be >= 0, but ",
+                            .pQuote(paste0("events", group)), " = ",
+                            self$.arrayToString(eventsTemp, vectorLookAndFeelEnabled = TRUE),
+                            functionName = ".initByDataFrame",
+                            parameter = "group", value = group
                         )
                     }
                     self$events <- c(self$events, eventsTemp)
@@ -3617,7 +3627,9 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
 
                     self$allocationRatios <- self$.getValuesByParameterName(
                         dataFrame, C_KEY_WORDS_ALLOCATION_RATIOS,
-                        defaultValues = self$.getAllocationRatioDefaultValues(self$stages, self$events, self$expectedEvents)
+                        defaultValues = self$.getAllocationRatioDefaultValues(
+                            self$stages, self$events, self$expectedEvents
+                        )
                     )
                     self$.validateValues(self$allocationRatios, "allocationRatios")
                 } else if (self$.paramExists(dataFrame, C_KEY_WORDS_OVERALL_EXPECTED_EVENTS) ||
@@ -3633,7 +3645,9 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                     self$overallAllocationRatios <- self$.getValuesByParameterName(
                         dataFrame,
                         parameterNameVariants = C_KEY_WORDS_OVERALL_ALLOCATION_RATIOS,
-                        defaultValues = self$.getAllocationRatioDefaultValues(self$stages, self$overallEvents, self$overallExpectedEvents)
+                        defaultValues = self$.getAllocationRatioDefaultValues(
+                            self$stages, self$overallEvents, self$overallExpectedEvents
+                        )
                     )
                     self$.validateValues(self$overallAllocationRatios, "overallAllocationRatios")
                 }
@@ -3758,11 +3772,11 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                         suffix = group
                     ), parameterName = "Events")
                     if (any(stats::na.omit(eventsTemp) < 0)) {
-                        stopIllegalArgument("all events must be >= 0, but 'events", group, "' = ", self$.arrayToString(eventsTemp,
-                            vectorLookAndFeelEnabled = TRUE
-                        ),
-                        functionName = ".initByDataFrame",
-                        parameter = "group", value = group
+                        stopIllegalArgument("all events must be >= 0, but ",
+                            .pQuote(paste0("events", group)), " = ",
+                            self$.arrayToString(eventsTemp, vectorLookAndFeelEnabled = TRUE),
+                            functionName = ".initByDataFrame",
+                            parameter = "group", value = group
                         )
                     }
                     self$events <- c(self$events, eventsTemp)
@@ -3788,7 +3802,8 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                     self$groups <- c(self$groups, rep(as.integer(group), length(eventsTemp)))
                 }
             } else {
-                stopRuntimeIssue("unable to identify case for ", .getClassName(self), " and columns ", self$.arrayToString(colnames(dataFrame)),
+                stopRuntimeIssue("unable to identify case for ", .getClassName(self),
+                    " and columns ", self$.arrayToString(colnames(dataFrame)),
                     functionName = ".initByDataFrame",
                     parameter = "self", value = self
                 )
@@ -4024,7 +4039,8 @@ DatasetSurvival <- R6::R6Class("DatasetSurvival",
                         overallEvents[1:(kMax - 1)] / overallEvents[2:kMax]
             ) / (events[2:kMax] / overallEvents[2:kMax])
             if (any(stats::na.omit(result) <= 0)) {
-                stopIllegalArgument("overall allocation ratios not correctly specified: ", "one or more calculated stage-wise allocation ratios <= 0",
+                stopIllegalArgument("overall allocation ratios not correctly specified: ",
+                    "one or more calculated stage-wise allocation ratios <= 0",
                     functionName = ".getStageWiseAllocationRatios"
                 )
             }
@@ -4128,16 +4144,22 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
                 )
                 self$.validateValues(self$overallEvents, "overallEvents")
 
-                self$overallExpectedEvents <- self$.getValuesByParameterName(dataFrame, C_KEY_WORDS_OVERALL_EXPECTED_EVENTS)
+                self$overallExpectedEvents <- self$.getValuesByParameterName(
+                    dataFrame, C_KEY_WORDS_OVERALL_EXPECTED_EVENTS
+                )
                 self$.validateValues(self$overallExpectedEvents, "overallExpectedEvents")
 
-                self$overallVarianceEvents <- self$.getValuesByParameterName(dataFrame, C_KEY_WORDS_OVERALL_VARIANCE_EVENTS)
+                self$overallVarianceEvents <- self$.getValuesByParameterName(
+                    dataFrame, C_KEY_WORDS_OVERALL_VARIANCE_EVENTS
+                )
                 self$.validateValues(self$overallVarianceEvents, "overallVarianceEvents")
 
                 self$overallAllocationRatios <- self$.getValuesByParameterName(
                     dataFrame,
                     parameterNameVariants = C_KEY_WORDS_OVERALL_ALLOCATION_RATIOS,
-                    defaultValues = self$.getAllocationRatioDefaultValues(self$stages, self$overallEvents, self$overallExpectedEvents)
+                    defaultValues = self$.getAllocationRatioDefaultValues(
+                        self$stages, self$overallEvents, self$overallExpectedEvents
+                    )
                 )
                 self$.validateValues(self$overallAllocationRatios, "overallAllocationRatios")
             } else if (self$.paramExists(dataFrame, C_KEY_WORDS_EXPECTED_EVENTS) ||
@@ -4172,7 +4194,9 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
                 self$allocationRatios <- self$.getValuesByParameterName(
                     dataFrame,
                     parameterNameVariants = C_KEY_WORDS_ALLOCATION_RATIOS,
-                    defaultValues = self$.getAllocationRatioDefaultValues(self$stages, self$events, self$expectedEvents)
+                    defaultValues = self$.getAllocationRatioDefaultValues(
+                        self$stages, self$events, self$expectedEvents
+                    )
                 )
                 self$.validateValues(self$allocationRatios, "allocationRatios")
             }
@@ -4226,23 +4250,53 @@ DatasetEnrichmentSurvival <- R6::R6Class("DatasetEnrichmentSurvival",
             self$overallVarianceEvents <- self$.data$overallVarianceEvent
             self$expectedEvents <- self$.data$expectedEvent
         },
-        getOverallExpectedEvent = function(stage, group = 1, subset = NA_character_) {
+        getOverallExpectedEvent = function(
+                stage,
+                group = 1,
+                subset = NA_character_) {
             return(self$.data$overallExpectedEvent[self$.getIndices(stage = stage, group = group, subset = subset)])
         },
-        getOverallExpectedEvents = function(..., stage = NA_integer_, group = NA_integer_, subset = NA_character_) {
-            return(self$.data$overallExpectedEvent[self$.getIndices(stage = self$.getValidatedStage(stage), group = group, subset = subset)])
+        getOverallExpectedEvents = function(
+                ...,
+                stage = NA_integer_,
+                group = NA_integer_,
+                subset = NA_character_) {
+            return(self$.data$overallExpectedEvent[self$.getIndices(
+                stage = self$.getValidatedStage(stage), group = group, subset = subset
+            )])
         },
-        getOverallExpectedEventsUpTo = function(to, group = 1, subset = NA_character_) {
-            return(self$.data$overallExpectedEvent[self$.getIndices(stage = c(1:to), group = group, subset = subset)])
+        getOverallExpectedEventsUpTo = function(
+                to,
+                group = 1,
+                subset = NA_character_) {
+            return(self$.data$overallExpectedEvent[self$.getIndices(
+                stage = c(1:to), group = group, subset = subset
+            )])
         },
-        getOverallVarianceEvent = function(stage, group = 1, subset = NA_character_) {
-            return(self$.data$overallVarianceEvent[self$.getIndices(stage = stage, group = group, subset = subset)])
+        getOverallVarianceEvent = function(
+                stage,
+                group = 1,
+                subset = NA_character_) {
+            return(self$.data$overallVarianceEvent[self$.getIndices(
+                stage = stage, group = group, subset = subset
+            )])
         },
-        getOverallVarianceEvents = function(..., stage = NA_integer_, group = NA_integer_, subset = NA_character_) {
-            return(self$.data$overallVarianceEvent[self$.getIndices(stage = self$.getValidatedStage(stage), group = group, subset = subset)])
+        getOverallVarianceEvents = function(
+                ...,
+                stage = NA_integer_,
+                group = NA_integer_,
+                subset = NA_character_) {
+            return(self$.data$overallVarianceEvent[self$.getIndices(
+                stage = self$.getValidatedStage(stage), group = group, subset = subset
+            )])
         },
-        getOverallVarianceEventsUpTo = function(to, group = 1, subset = NA_character_) {
-            return(self$.data$overallVarianceEvent[self$.getIndices(stage = c(1:to), group = group, subset = subset)])
+        getOverallVarianceEventsUpTo = function(
+                to,
+                group = 1,
+                subset = NA_character_) {
+            return(self$.data$overallVarianceEvent[self$.getIndices(
+                stage = c(1:to), group = group, subset = subset
+            )])
         }
     )
 )
@@ -4365,7 +4419,10 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         paste0(groups, collapse = ifelse(object$isDatasetSurvival(), " with ", " and "))
     )
     if (object$.enrichmentEnabled) {
-        header <- paste0(header, ". The data will be analyzed ", ifelse(object$isStratified(), "", "non-"), "stratified")
+        header <- paste0(
+            header, ". The data will be analyzed ",
+            ifelse(object$isStratified(), "", "non-"), "stratified"
+        )
     }
     if (kMax > 1) {
         header <- paste0(
@@ -4430,7 +4487,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         if (kMax > 1) {
             summaryFactory$addParameter(object,
                 parameterName = "overallSampleSizes",
-                parameterCaption = "Cumulative sample size", roundDigits = digitsSampleSize
+                parameterCaption = "Cumulative sample size",
+                roundDigits = digitsSampleSize
             )
         }
     }
@@ -4444,7 +4502,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         if (kMax > 1) {
             summaryFactory$addParameter(object,
                 parameterName = "overallMeans",
-                parameterCaption = "Cumulative mean", roundDigits = digitsGeneral
+                parameterCaption = "Cumulative mean",
+                roundDigits = digitsGeneral
             )
         }
         summaryFactory$addParameter(object,
@@ -4455,7 +4514,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         if (kMax > 1) {
             summaryFactory$addParameter(object,
                 parameterName = "overallStDevs",
-                parameterCaption = "Cumulative standard deviation", roundDigits = digitsGeneral
+                parameterCaption = "Cumulative standard deviation",
+                roundDigits = digitsGeneral
             )
         }
     } else if (object$isDatasetRates()) {
@@ -4467,7 +4527,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         if (kMax > 1) {
             summaryFactory$addParameter(object,
                 parameterName = "overallEvents",
-                parameterCaption = "Cumulative number of events", roundDigits = digitsSampleSize
+                parameterCaption = "Cumulative number of events",
+                roundDigits = digitsSampleSize
             )
         }
     } else if (object$isDatasetSurvival()) {
@@ -4479,7 +4540,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         if (kMax > 1) {
             summaryFactory$addParameter(object,
                 parameterName = "overallEvents",
-                parameterCaption = "Cumulative number of events", roundDigits = digitsSampleSize
+                parameterCaption = "Cumulative number of events",
+                roundDigits = digitsSampleSize
             )
         }
         summaryFactory$addParameter(object,
@@ -4490,7 +4552,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         if (kMax > 1) {
             summaryFactory$addParameter(object,
                 parameterName = "overallLogRanks",
-                parameterCaption = "Cumulative log rank statistic", roundDigits = digitsGeneral
+                parameterCaption = "Cumulative log rank statistic",
+                roundDigits = digitsGeneral
             )
         }
         if (!anyNA(object$allocationRatios) && any(object$allocationRatios != 1)) {
@@ -4502,7 +4565,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
             if (kMax > 1) {
                 summaryFactory$addParameter(object,
                     parameterName = "overallAllocationRatios",
-                    parameterCaption = "Cumulative allocation ratio", roundDigits = digitsGeneral
+                    parameterCaption = "Cumulative allocation ratio",
+                    roundDigits = digitsGeneral
                 )
             }
         }
@@ -4527,7 +4591,8 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
         encapsulate <- grepl("^subset", paramName)
         if (!encapsulate || isTRUE(x$.enrichmentEnabled)) {
             values <- m[[paramName]]
-            if (!encapsulate && is.numeric(values) && !is.null(digits) && length(digits) == 1 && !is.na(digits)) {
+            if (!encapsulate && is.numeric(values) &&
+                    !is.null(digits) && length(digits) == 1 && !is.na(digits)) {
                 values <- round(values, digits = digits)
             }
             lines <- c(lines, paste0(paramName, " = ", .arrayToString(values,
@@ -4583,7 +4648,11 @@ summary.Dataset <- function(object, ..., type = 1, digits = NA_integer_) {
 #'
 #' @keywords internal
 #'
-print.Dataset <- function(x, ..., markdown = NA, output = c("list", "long", "wide", "r", "rComplete")) {
+print.Dataset <- function(
+        x,
+        ...,
+        markdown = NA,
+        output = c("list", "long", "wide", "r", "rComplete")) {
     fCall <- match.call(expand.dots = FALSE)
     sysCalls <- sys.calls()
 

--- a/R/class_analysis_results.R
+++ b/R/class_analysis_results.R
@@ -52,7 +52,16 @@ ConditionalPowerResults <- R6::R6Class("ConditionalPowerResults",
         iterations = NULL,
         seed = NULL,
         simulated = NULL,
-        initialize = function(..., .design = NULL, .stageResults = NULL, .plotData = NULL, nPlanned = NULL, allocationRatioPlanned = NULL, iterations = NULL, seed = NULL, simulated = NULL) {
+        initialize = function(
+                ...,
+                .design = NULL,
+                .stageResults = NULL,
+                .plotData = NULL,
+                nPlanned = NULL,
+                allocationRatioPlanned = NULL,
+                iterations = NULL,
+                seed = NULL,
+                simulated = NULL) {
             self$.design <- .design
             self$.stageResults <- .stageResults
             self$.plotData <- .plotData
@@ -155,7 +164,11 @@ ConditionalPowerResultsMeans <- R6::R6Class("ConditionalPowerResultsMeans",
         conditionalPower = NULL,
         thetaH1 = NULL,
         assumedStDev = NULL,
-        initialize = function(..., conditionalPower = NULL, thetaH1 = NULL, assumedStDev = NULL) {
+        initialize = function(
+                ...,
+                conditionalPower = NULL,
+                thetaH1 = NULL,
+                assumedStDev = NULL) {
             self$conditionalPower <- conditionalPower
             self$thetaH1 <- thetaH1
             self$assumedStDev <- assumedStDev
@@ -191,14 +204,17 @@ ConditionalPowerResultsMultiHypotheses <- R6::R6Class("ConditionalPowerResultsMu
             if (self$.readyForInitialization()) {
                 gMax <- self$getGMax()
                 kMax <- self$.design$kMax
-                if (is.null(self$conditionalPower) || (nrow(self$conditionalPower) == 0 && ncol(self$conditionalPower) == 0)) {
+                if (is.null(self$conditionalPower) ||
+                        (nrow(self$conditionalPower) == 0 && ncol(self$conditionalPower) == 0)) {
                     self$conditionalPower <- matrix(rep(NA_real_, gMax * kMax), nrow = gMax, ncol = kMax)
                 }
             }
         },
         .toString = function(startWithUpperCase = FALSE) {
             s <- "Conditional power results"
-            s <- paste0(s, " ", ifelse(grepl("Enrichment", .getClassName(self$.stageResults)), "enrichment", "multi-arm"))
+            s <- paste0(s, " ", ifelse(grepl("Enrichment", .getClassName(self$.stageResults)),
+                "enrichment", "multi-arm"
+            ))
             if (grepl("Means", .getClassName(self))) {
                 s <- paste0(s, " means")
             } else if (grepl("Rates", .getClassName(self))) {
@@ -1265,7 +1281,8 @@ as.data.frame.AnalysisResults <- function(
 #' @description
 #' Function to get the names of an \code{\link{AnalysisResults}} object.
 #'
-#' @param x An \code{\link{AnalysisResults}} object created by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' @param x An \code{\link{AnalysisResults}} object created
+#'        by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @details
 #' Returns the names of an analysis results that can be accessed by the user.
@@ -1337,7 +1354,12 @@ AnalysisResultsGroupSequential <- R6::R6Class("AnalysisResultsGroupSequential",
     public = list(
         maxInformation = NULL,
         informationEpsilon = NULL,
-        initialize = function(design, dataInput, ..., maxInformation = NULL, informationEpsilon = NULL) {
+        initialize = function(
+                design,
+                dataInput,
+                ...,
+                maxInformation = NULL,
+                informationEpsilon = NULL) {
             self$maxInformation <- maxInformation
             self$informationEpsilon <- informationEpsilon
 
@@ -1721,7 +1743,9 @@ AnalysisResultsConditionalDunnett <- R6::R6Class("AnalysisResultsConditionalDunn
         allocationRatioPlanned <- NA_real_
     }
 
-    if ((.isConditionalPowerEnabled(x$nPlanned) || .isConditionalPowerEnabled(nPlanned)) && is.na(allocationRatioPlanned)) {
+    if ((.isConditionalPowerEnabled(x$nPlanned) ||
+            .isConditionalPowerEnabled(nPlanned)) &&
+            is.na(allocationRatioPlanned)) {
         allocationRatioPlanned <- 1
     }
 
@@ -1752,9 +1776,14 @@ AnalysisResultsConditionalDunnett <- R6::R6Class("AnalysisResultsConditionalDunn
     return(data)
 }
 
-.getConfidenceIntervalDataPerBound <- function(x, ciName = c("lower", "upper"), treatmentArmsToShow = NULL) {
+.getConfidenceIntervalDataPerBound <- function(
+        x,
+        ciName = c("lower", "upper"),
+        treatmentArmsToShow = NULL) {
     ciName <- match.arg(ciName)
-    paramName <- ifelse(ciName == "lower", "repeatedConfidenceIntervalLowerBounds", "repeatedConfidenceIntervalUpperBounds")
+    paramName <- ifelse(ciName == "lower",
+        "repeatedConfidenceIntervalLowerBounds", "repeatedConfidenceIntervalUpperBounds"
+    )
     data <- x[[paramName]]
 
     if (is.matrix(data) && !is.null(treatmentArmsToShow) &&
@@ -2065,7 +2094,12 @@ plot.AnalysisResults <- function(
     return(eval.parent(functionCall[[paramName]]))
 }
 
-.addAnalysisPlotArgumentsToFunctionCall <- function(x, functionCall, ..., result = NULL, args = list()) {
+.addAnalysisPlotArgumentsToFunctionCall <- function(
+        x,
+        functionCall,
+        ...,
+        result = NULL,
+        args = list()) {
     if (is.null(result)) {
         result <- functionCall
     }
@@ -2204,7 +2238,10 @@ plot.AnalysisResults <- function(
 
     .warnInCaseOfUnknownArguments(
         functionName = "plot",
-        ignore = c("thetaRange", "assumedStDev", "assumedStDevs", "treatmentArms", "populations", "pi2", "piTreatmentRange"),
+        ignore = c(
+            "thetaRange", "assumedStDev", "assumedStDevs",
+            "treatmentArms", "populations", "pi2", "piTreatmentRange"
+        ),
         ...
     )
 

--- a/R/class_analysis_stage_results.R
+++ b/R/class_analysis_stage_results.R
@@ -1489,7 +1489,8 @@ as.data.frame.StageResults <- function(
     } else if (!all(populationsToShow %in% validComparisons)) {
         stopIllegalArgument("'populations' (", .arrayToString(populationsToShow), ") must be a vector ", "containing one or more values of ",
             .arrayToString(validComparisons),
-            functionName = ".getPopulationsToShow", parameter = "populations"
+            functionName = ".getPopulationsToShow", 
+		parameter ="populations"
         )
     }
     populationsToShow <- sort(unique(populationsToShow))
@@ -1633,7 +1634,8 @@ plot.StageResults <- function(
     .stopInCaseOfIllegalStageDefinition2(...)
 
     if (x$.design$kMax == 1) {
-        stopIllegalArgument("cannot plot stage results of a fixed design", functionName = ".plot.StageResults")
+        stopIllegalArgument("cannot plot stage results of a fixed design", 
+		functionName = ".plot.StageResults")
     }
 
     if (!is.logical(showSource) || isTRUE(showSource)) {

--- a/R/class_analysis_stage_results.R
+++ b/R/class_analysis_stage_results.R
@@ -1487,7 +1487,8 @@ as.data.frame.StageResults <- function(
             all(is.na(populationsToShow)) || !is.numeric(populationsToShow)) {
         populationsToShow <- validComparisons
     } else if (!all(populationsToShow %in% validComparisons)) {
-        stopIllegalArgument("'populations' (", .arrayToString(populationsToShow), ") must be a vector ", "containing one or more values of ",
+        stopIllegalArgument("'populations' (", .arrayToString(populationsToShow), ") must be a vector ", 
+            "containing one or more values of ",
             .arrayToString(validComparisons),
             functionName = ".getPopulationsToShow",
             parameter = "populations"

--- a/R/class_analysis_stage_results.R
+++ b/R/class_analysis_stage_results.R
@@ -1489,8 +1489,8 @@ as.data.frame.StageResults <- function(
     } else if (!all(populationsToShow %in% validComparisons)) {
         stopIllegalArgument("'populations' (", .arrayToString(populationsToShow), ") must be a vector ", "containing one or more values of ",
             .arrayToString(validComparisons),
-            functionName = ".getPopulationsToShow", 
-		parameter ="populations"
+            functionName = ".getPopulationsToShow",
+            parameter = "populations"
         )
     }
     populationsToShow <- sort(unique(populationsToShow))
@@ -1634,8 +1634,9 @@ plot.StageResults <- function(
     .stopInCaseOfIllegalStageDefinition2(...)
 
     if (x$.design$kMax == 1) {
-        stopIllegalArgument("cannot plot stage results of a fixed design", 
-		functionName = ".plot.StageResults")
+        stopIllegalArgument("cannot plot stage results of a fixed design",
+            functionName = ".plot.StageResults"
+        )
     }
 
     if (!is.logical(showSource) || isTRUE(showSource)) {

--- a/R/class_core_parameter_set.R
+++ b/R/class_core_parameter_set.R
@@ -268,7 +268,7 @@ ParameterSet <- R6::R6Class("ParameterSet",
                     C_PARAM_USER_DEFINED, C_PARAM_DEFAULT_VALUE,
                     C_PARAM_GENERATED, C_PARAM_DERIVED, C_PARAM_NOT_APPLICABLE
                 ))) {
-                stopIllegalArgument("'parameterType' ('", parameterType, "') is invalid",
+                stopIllegalArgument("'parameterType' (", .pQuote(parameterType), ") is invalid",
                     functionName = ".setParameterType",
                     parameter = "parameterType", value = parameterType
                 )
@@ -400,7 +400,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
                 self$.showAllParameters(consoleOutputEnabled = consoleOutputEnabled)
                 self$.showParameterTypeDescription(consoleOutputEnabled = consoleOutputEnabled)
             } else {
-                stopRuntimeIssue("method '.show()' is not implemented in class '", .getClassName(self), "'",
+                stopRuntimeIssue("method '.show()' is not implemented in class ", 
+                    .getClassName(self, quote = TRUE), 
                     functionName = ".show",
                     parameter = ".show()"
                 )
@@ -488,7 +489,7 @@ ParameterSet <- R6::R6Class("ParameterSet",
                 },
                 error = function(e) {
                     if (consoleOutputEnabled) {
-                        warning("Failed to show parameter '", parameterName, "': ", e$message)
+                        warning("Failed to show parameter ", .pQuote(parameterName), ": ", e$message)
                     }
                 }
             )
@@ -569,7 +570,7 @@ ParameterSet <- R6::R6Class("ParameterSet",
                 },
                 error = function(e) {
                     if (consoleOutputEnabled) {
-                        warning("Failed to show single parameter '", parameterName, "' (", param$type, "): ", e$message)
+                        warning("Failed to show single parameter ", .pQuote(parameterName), " (", param$type, "): ", e$message)
                     }
                 }
             )
@@ -688,7 +689,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
                         } else {
                             stopRuntimeIssue("only ClosedCombinationTestResults ", "supports function .getHypothesisPopulationVariants() (object is ",
                                 .getClassName(self), ")",
-                                functionName = ".showParameterFormatted", parameter = "self", value = self
+                                functionName = ".showParameterFormatted", 
+		parameter ="self", value = self
                             )
                         }
                         paramCaption <- paste0(paramCaption, " ", populations)
@@ -928,7 +930,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
 
             if (!is.character(listEntryNames)) {
                 stopRuntimeIssue("'listEntryNames' must be a character vector",
-                    functionName = ".getSubListByNames", parameter = "listEntryNames",
+                    functionName = ".getSubListByNames", 
+		parameter ="listEntryNames",
                     value = listEntryNames
                 )
             }
@@ -1081,9 +1084,10 @@ ParameterSet <- R6::R6Class("ParameterSet",
             return(paste(parameterValues, collapse = ", "))
         }
 
-        stopRuntimeIssue("parameter '", parameterName, "' has an invalid ", "dimension (length is ", length(parameterValues),
+        stopRuntimeIssue("parameter ", .pQuote(parameterName), " has an invalid ", "dimension (length is ", length(parameterValues),
             ")",
-            functionName = ".getDataFrameColumnValues", parameter = parameterName, value = length(parameterValues)
+            functionName = ".getDataFrameColumnValues", 
+		parameter =parameterName, value = length(parameterValues)
         )
     } else if (parameterName == "effectMatrix") {
         # return effect matrix row if 'effectMatrix' is user defined
@@ -1149,7 +1153,7 @@ ParameterSet <- R6::R6Class("ParameterSet",
         return(rep(parameterValues[, 1], numberOfVariants))
     }
 
-    stopRuntimeIssue("parameter '", parameterName, "' has an invalid ",
+    stopRuntimeIssue("parameter ", .pQuote(parameterName), " has an invalid ",
         "dimension (", nrow(parameterValues),
         " x ", ncol(parameterValues), "); ",
         "expected was (", numberOfStages, " x ", numberOfVariants, ")",
@@ -2043,7 +2047,8 @@ fetch.ParameterSet <- function(x, ..., output = c("named", "labeled", "value", "
     .assertIsInClosedInterval(var, "var", lower = -length(varNames), upper = length(varNames))
     if (var == 0) {
         stopIllegalArgument("'var' (", var, ") must != 0",
-            functionName = ".getParameterSetValue", parameter = "var",
+            functionName = ".getParameterSetValue", 
+		parameter ="var",
             value = var
         )
     }
@@ -2113,8 +2118,10 @@ plot.ParameterSet <- function(
         plotSettings = NULL) {
     .assertGgplotIsInstalled()
 
-    stopRuntimeIssue("sorry, function 'plot' is not yet implemented for class '", .getClassName(x), "'",
-        functionName = "plot.ParameterSet", parameter = "plot"
+    stopRuntimeIssue("sorry, function 'plot' is not yet implemented for class ", 
+        .getClassName(x, quote = TRUE), 
+        functionName = "plot.ParameterSet", 
+		parameter ="plot"
     )
 }
 

--- a/R/class_core_parameter_set.R
+++ b/R/class_core_parameter_set.R
@@ -400,8 +400,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
                 self$.showAllParameters(consoleOutputEnabled = consoleOutputEnabled)
                 self$.showParameterTypeDescription(consoleOutputEnabled = consoleOutputEnabled)
             } else {
-                stopRuntimeIssue("method '.show()' is not implemented in class ", 
-                    .getClassName(self, quote = TRUE), 
+                stopRuntimeIssue("method '.show()' is not implemented in class ",
+                    .getClassName(self, quote = TRUE),
                     functionName = ".show",
                     parameter = ".show()"
                 )
@@ -639,12 +639,12 @@ ParameterSet <- R6::R6Class("ParameterSet",
             if (is.null(paramCaption)) {
                 paramCaption <- paste0("%", paramName, "%")
             }
-            
+
             if (!is.null(category) && !is.na(category)) {
-                if (.isMultiArmSimulationResults(self) && 
+                if (.isMultiArmSimulationResults(self) &&
                         paramName %in% c("singleEventsPerArmAndStage", "selectedArms")) {
                     if (!inherits(self, "SimulationResultsEnrichmentSurvival") &&
-                            !is.na(numberOfCategories) && numberOfCategories == category && 
+                            !is.na(numberOfCategories) && numberOfCategories == category &&
                             paramName == "singleEventsPerArmAndStage") {
                         category <- "control"
                     }
@@ -689,8 +689,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
                         } else {
                             stopRuntimeIssue("only ClosedCombinationTestResults ", "supports function .getHypothesisPopulationVariants() (object is ",
                                 .getClassName(self), ")",
-                                functionName = ".showParameterFormatted", 
-		parameter ="self", value = self
+                                functionName = ".showParameterFormatted",
+                                parameter = "self", value = self
                             )
                         }
                         paramCaption <- paste0(paramCaption, " ", populations)
@@ -930,8 +930,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
 
             if (!is.character(listEntryNames)) {
                 stopRuntimeIssue("'listEntryNames' must be a character vector",
-                    functionName = ".getSubListByNames", 
-		parameter ="listEntryNames",
+                    functionName = ".getSubListByNames",
+                    parameter = "listEntryNames",
                     value = listEntryNames
                 )
             }
@@ -1086,8 +1086,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
 
         stopRuntimeIssue("parameter ", .pQuote(parameterName), " has an invalid ", "dimension (length is ", length(parameterValues),
             ")",
-            functionName = ".getDataFrameColumnValues", 
-		parameter =parameterName, value = length(parameterValues)
+            functionName = ".getDataFrameColumnValues",
+            parameter = parameterName, value = length(parameterValues)
         )
     } else if (parameterName == "effectMatrix") {
         # return effect matrix row if 'effectMatrix' is user defined
@@ -2047,8 +2047,8 @@ fetch.ParameterSet <- function(x, ..., output = c("named", "labeled", "value", "
     .assertIsInClosedInterval(var, "var", lower = -length(varNames), upper = length(varNames))
     if (var == 0) {
         stopIllegalArgument("'var' (", var, ") must != 0",
-            functionName = ".getParameterSetValue", 
-		parameter ="var",
+            functionName = ".getParameterSetValue",
+            parameter = "var",
             value = var
         )
     }
@@ -2118,10 +2118,10 @@ plot.ParameterSet <- function(
         plotSettings = NULL) {
     .assertGgplotIsInstalled()
 
-    stopRuntimeIssue("sorry, function 'plot' is not yet implemented for class ", 
-        .getClassName(x, quote = TRUE), 
-        functionName = "plot.ParameterSet", 
-		parameter ="plot"
+    stopRuntimeIssue("sorry, function 'plot' is not yet implemented for class ",
+        .getClassName(x, quote = TRUE),
+        functionName = "plot.ParameterSet",
+        parameter = "plot"
     )
 }
 
@@ -2231,9 +2231,9 @@ kable.ParameterSet <- function(x, ...) {
             }
             if (grepl("^ *print\\(", objName)) {
                 stopIllegalArgument(
-                    "kable(", objName, ") ", "does not work correctly. ", 
-                    "Use ", sub("print", "kable", objName), 
-                    " without 'print' instead or ", 
+                    "kable(", objName, ") ", "does not work correctly. ",
+                    "Use ", sub("print", "kable", objName),
+                    " without 'print' instead or ",
                     sub("\\)", ", markdown = TRUE, call. = FALSE)", objName),
                     functionName = "kable.ParameterSet",
                     parameter = "print"

--- a/R/class_core_parameter_set.R
+++ b/R/class_core_parameter_set.R
@@ -604,7 +604,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
                 },
                 error = function(e) {
                     if (consoleOutputEnabled) {
-                        warning("Failed to extract parameter name and value from ", sQuote(parameterName), ": ", e$message)
+                        warning("Failed to extract parameter name and value from ", 
+                            sQuote(parameterName), ": ", e$message)
                     }
                     return(list(parameterName = parameterName, paramValue = ""))
                 }
@@ -687,7 +688,8 @@ ParameterSet <- R6::R6Class("ParameterSet",
                         } else if (inherits(self, "ClosedCombinationTestResults")) {
                             populations <- self$.getHypothesisPopulationVariants()[matrixRow]
                         } else {
-                            stopRuntimeIssue("only ClosedCombinationTestResults ", "supports function .getHypothesisPopulationVariants() (object is ",
+                            stopRuntimeIssue("only ClosedCombinationTestResults ", 
+                                "supports function .getHypothesisPopulationVariants() (object is ",
                                 .getClassName(self), ")",
                                 functionName = ".showParameterFormatted",
                                 parameter = "self", value = self
@@ -1084,10 +1086,11 @@ ParameterSet <- R6::R6Class("ParameterSet",
             return(paste(parameterValues, collapse = ", "))
         }
 
-        stopRuntimeIssue("parameter ", .pQuote(parameterName), " has an invalid ", "dimension (length is ", length(parameterValues),
-            ")",
+        stopRuntimeIssue("parameter ", .pQuote(parameterName), " has an invalid ", 
+            "dimension (length is ", length(parameterValues), ")",
             functionName = ".getDataFrameColumnValues",
-            parameter = parameterName, value = length(parameterValues)
+            parameter = parameterName, 
+            value = length(parameterValues)
         )
     } else if (parameterName == "effectMatrix") {
         # return effect matrix row if 'effectMatrix' is user defined
@@ -1599,8 +1602,10 @@ as.matrix.FieldSet <- function(x, ..., enforceRowNames = TRUE, niceColumnNamesEn
     }
 
     if (inherits(x, "AnalysisResults")) {
-        dfDesign <- as.data.frame(x$.design, niceColumnNamesEnabled = niceColumnNamesEnabled)
-        dfStageResults <- as.data.frame(x$.stageResults, niceColumnNamesEnabled = niceColumnNamesEnabled)
+        dfDesign <- as.data.frame(x$.design, 
+            niceColumnNamesEnabled = niceColumnNamesEnabled)
+        dfStageResults <- as.data.frame(x$.stageResults, 
+            niceColumnNamesEnabled = niceColumnNamesEnabled)
         dfStageResults <- dfStageResults[!is.na(dfStageResults[
             ,
             grep("(test statistic)|(testStatistics)", colnames(dfStageResults))
@@ -1655,7 +1660,8 @@ as.matrix.FieldSet <- function(x, ..., enforceRowNames = TRUE, niceColumnNamesEn
 #' @inheritParams param_digits
 #' @param output The output parts, default is \code{"all"}.
 #' @param printObject Show also the print output after the summary, default is \code{FALSE}.
-#' @param sep The separator line between the summary and the optional print output, default is \code{"\n\n-----\n\n"}.
+#' @param sep The separator line between the summary and the 
+#'        optional print output, default is \code{"\n\n-----\n\n"}.
 #' @inheritParams param_three_dots
 #'
 #' @details
@@ -1845,9 +1851,11 @@ fetch <- function(x, ..., output) UseMethod("fetch")
 #'  - a positive integer, giving the position counting from the left
 #'  - a negative integer, giving the position counting from the right.
 #' The default returns the last parameter.
-#' This argument is taken by expression and supports quasi-quotation (you can unquote column names and column locations).
+#' This argument is taken by expression and supports quasi-quotation 
+#' (you can unquote column names and column locations).
 #' @param output A character defining the output type as follows:
-#'  - "named" (default) returns the named value if the value is a single value, the value inside a named list otherwise
+#'  - "named" (default) returns the named value if the value is 
+#'    a single value, the value inside a named list otherwise
 #'  - "value" returns only the value itself
 #'  - "list" returns the value inside a named list
 #'

--- a/R/class_core_plot_settings.R
+++ b/R/class_core_plot_settings.R
@@ -701,8 +701,8 @@ PlotSettings <- R6::R6Class("PlotSettings",
             }
             if (!(length(margin) %in% c(1, 4))) {
                 stopRuntimeIssue("'margin' (", .arrayToString(margin), ") must be a numeric vector with length 1 or 4",
-                    functionName = "setMarginAroundPlot", 
-		parameter ="margin", value = margin
+                    functionName = "setMarginAroundPlot",
+                    parameter = "margin", value = margin
                 )
             }
             p <- p + ggplot2::theme(plot.margin = ggplot2::unit(margin, "cm"))

--- a/R/class_core_plot_settings.R
+++ b/R/class_core_plot_settings.R
@@ -700,9 +700,11 @@ PlotSettings <- R6::R6Class("PlotSettings",
                 margin <- base::rep(margin, 4)
             }
             if (!(length(margin) %in% c(1, 4))) {
-                stopRuntimeIssue("'margin' (", .arrayToString(margin), ") must be a numeric vector with length 1 or 4",
+                stopRuntimeIssue("'margin' (", .arrayToString(margin), ") ",
+                    "must be a numeric vector with length 1 or 4",
                     functionName = "setMarginAroundPlot",
-                    parameter = "margin", value = margin
+                    parameter = "margin", 
+                    value = margin
                 )
             }
             p <- p + ggplot2::theme(plot.margin = ggplot2::unit(margin, "cm"))

--- a/R/class_core_plot_settings.R
+++ b/R/class_core_plot_settings.R
@@ -701,7 +701,8 @@ PlotSettings <- R6::R6Class("PlotSettings",
             }
             if (!(length(margin) %in% c(1, 4))) {
                 stopRuntimeIssue("'margin' (", .arrayToString(margin), ") must be a numeric vector with length 1 or 4",
-                    functionName = "setMarginAroundPlot", parameter = "margin", value = margin
+                    functionName = "setMarginAroundPlot", 
+		parameter ="margin", value = margin
                 )
             }
             p <- p + ggplot2::theme(plot.margin = ggplot2::unit(margin, "cm"))

--- a/R/class_design.R
+++ b/R/class_design.R
@@ -1297,7 +1297,8 @@ plot.TrialDesign <- function(
 
     availablePlotTypes <- getAvailablePlotTypes(x, output = "numeric", numberInCaptionEnabled = FALSE)
     if (length(availablePlotTypes) == 0) {
-        stopIllegalArgument("no plot type available for the specified design", functionName = "plot.TrialDesign")
+        stopIllegalArgument("no plot type available for the specified design", 
+		functionName = "plot.TrialDesign")
     }
     if (is.na(type)) {
         type <- availablePlotTypes[1]
@@ -1484,7 +1485,8 @@ plot.TrialDesignCharacteristics <- function(x, y, ..., type = 1L, grid = 1) {
                 variedParameters <- "typeOfDesign"
             } else {
                 stopMissingArgument("'variedParameters' needs to be specified, ", "e.g., variedParameters = \"typeOfDesign\"",
-                    functionName = ".plotTrialDesign", parameter = "variedParameters"
+                    functionName = ".plotTrialDesign", 
+		parameter ="variedParameters"
                 )
             }
         }

--- a/R/class_design.R
+++ b/R/class_design.R
@@ -1305,10 +1305,13 @@ plot.TrialDesign <- function(
         type <- availablePlotTypes[1]
     }
     if (!(type %in% availablePlotTypes)) {
-        stopIllegalArgument("'type' (", type, ") is not available; 'type' can ", ifelse(length(availablePlotTypes) ==
-            1, "only ", ""), "be ", .arrayToString(availablePlotTypes, mode = "or"),
-        functionName = "plot.TrialDesign",
-        parameter = "type", value = type
+        stopIllegalArgument(
+            "'type' (", type, ") is not available; 'type' can ",
+            ifelse(length(availablePlotTypes) == 1, "only ", ""), "be ",
+            .arrayToString(availablePlotTypes, mode = "or"),
+            functionName = "plot.TrialDesign",
+            parameter = "type",
+            value = type
         )
     }
 
@@ -1461,9 +1464,11 @@ plot.TrialDesignCharacteristics <- function(x, y, ..., type = 1L, grid = 1) {
 
     .assertIsSingleInteger(type, "type", naAllowed = FALSE, validateType = FALSE)
     if (any(.isTrialDesignFisher(x)) && !(type %in% c(1, 3, 4))) {
-        stopIllegalArgument("'type' (", type, ") is not allowed for Fisher designs; must be 1, 3 or 4",
+        stopIllegalArgument(
+            "'type' (", type, ") is not allowed for Fisher designs; must be 1, 3 or 4",
             functionName = ".plotTrialDesign",
-            parameter = "type", value = type
+            parameter = "type",
+            value = type
         )
     }
 
@@ -1485,7 +1490,9 @@ plot.TrialDesignCharacteristics <- function(x, y, ..., type = 1L, grid = 1) {
                     x$typeOfDesign != y$typeOfDesign) {
                 variedParameters <- "typeOfDesign"
             } else {
-                stopMissingArgument("'variedParameters' needs to be specified, ", "e.g., variedParameters = \"typeOfDesign\"",
+                stopMissingArgument(
+                    "'variedParameters' needs to be specified, ",
+                    "e.g., variedParameters = \"typeOfDesign\"",
                     functionName = ".plotTrialDesign",
                     parameter = "variedParameters"
                 )

--- a/R/class_design.R
+++ b/R/class_design.R
@@ -1297,8 +1297,9 @@ plot.TrialDesign <- function(
 
     availablePlotTypes <- getAvailablePlotTypes(x, output = "numeric", numberInCaptionEnabled = FALSE)
     if (length(availablePlotTypes) == 0) {
-        stopIllegalArgument("no plot type available for the specified design", 
-		functionName = "plot.TrialDesign")
+        stopIllegalArgument("no plot type available for the specified design",
+            functionName = "plot.TrialDesign"
+        )
     }
     if (is.na(type)) {
         type <- availablePlotTypes[1]
@@ -1485,8 +1486,8 @@ plot.TrialDesignCharacteristics <- function(x, y, ..., type = 1L, grid = 1) {
                 variedParameters <- "typeOfDesign"
             } else {
                 stopMissingArgument("'variedParameters' needs to be specified, ", "e.g., variedParameters = \"typeOfDesign\"",
-                    functionName = ".plotTrialDesign", 
-		parameter ="variedParameters"
+                    functionName = ".plotTrialDesign",
+                    parameter = "variedParameters"
                 )
             }
         }

--- a/R/class_design_plan.R
+++ b/R/class_design_plan.R
@@ -958,7 +958,7 @@ TrialDesignPlanSurvival <- R6::R6Class("TrialDesignPlanSurvival",
                 dropoutRate2 = self$dropoutRate2,
                 dropoutTime = self$dropoutTime
             )
-            
+
             if (self$.design$sided == 1 && self$isUserDefinedParameter("directionUpper")) {
                 directionUpperTemp <- self$directionUpper
                 if (length(directionUpperTemp) == 1) {

--- a/R/class_design_plan.R
+++ b/R/class_design_plan.R
@@ -269,7 +269,7 @@ TrialDesignPlan <- R6::R6Class("TrialDesignPlan",
             } else if (.isTrialDesignPlanSurvival(self)) {
                 result <- "survival data"
             } else {
-                result <- paste0("unknown data class '", .getClassName(self), "'")
+                result <- paste0("unknown data class ", .getClassName(self, quote = TRUE))
             }
             return(ifelse(startWithUpperCase, .firstCharacterToUpperCase(result), result))
         }

--- a/R/class_design_plan.R
+++ b/R/class_design_plan.R
@@ -538,7 +538,8 @@ TrialDesignPlanMeans <- R6::R6Class("TrialDesignPlanMeans",
 #' @template field_futilityBoundsPValueScale
 #'
 #' @details
-#' This object cannot be created directly; use \code{\link[=getSampleSizeRates]{getSampleSizeRates()}}
+#' This object cannot be created directly; 
+#' use \code{\link[=getSampleSizeRates]{getSampleSizeRates()}}
 #' with suitable arguments to create a design plan for a dataset of rates.
 #'
 #' @include class_core_parameter_set.R
@@ -736,7 +737,8 @@ TrialDesignPlanRates <- R6::R6Class("TrialDesignPlanRates",
 #' @template field_futilityBoundsPValueScale
 #'
 #' @details
-#' This object cannot be created directly; use \code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}}
+#' This object cannot be created directly; 
+#' use \code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}}
 #' with suitable arguments to create a design plan for a dataset of survival data.
 #'
 #' @include class_core_parameter_set.R

--- a/R/class_design_set.R
+++ b/R/class_design_set.R
@@ -120,8 +120,9 @@ summary.TrialDesignSet <- function(object, ..., type = 1, digits = NA_integer_) 
 
     .assertIsTrialDesignSet(object)
     if (object$isEmpty()) {
-        stopIllegalArgument("cannot create summary because the design set is empty", 
-		functionName = "summary.TrialDesignSet")
+        stopIllegalArgument("cannot create summary because the design set is empty",
+            functionName = "summary.TrialDesignSet"
+        )
     }
 
     markdown <- .getOptionalArgument("markdown", ..., optionalArgumentDefaultValue = NA)
@@ -302,8 +303,9 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
         },
         getDesignMaster = function() {
             if (length(self$designs) == 0) {
-                stopRuntimeIssue("no design master defined", 
-		functionName = "getDesignMaster")
+                stopRuntimeIssue("no design master defined",
+                    functionName = "getDesignMaster"
+                )
             }
 
             return(self$designs[[1]])
@@ -311,16 +313,16 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
         .validateDesignsArgument = function(designsToAdd, args) {
             if (!is.list(designsToAdd)) {
                 stopIllegalArgument("'designsToAdd' must be a list",
-                    functionName = ".validateDesignsArgument", 
-		parameter ="designsToAdd",
+                    functionName = ".validateDesignsArgument",
+                    parameter = "designsToAdd",
                     value = designsToAdd
                 )
             }
 
             if (length(designsToAdd) == 0) {
                 stopIllegalArgument("'designsToAdd' must be not empty",
-                    functionName = ".validateDesignsArgument", 
-		parameter ="designsToAdd",
+                    functionName = ".validateDesignsArgument",
+                    parameter = "designsToAdd",
                     value = designsToAdd
                 )
             }
@@ -365,8 +367,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
         addVariedParameters = function(varPar) {
             if (is.null(varPar) || !is.character(varPar)) {
                 stopIllegalArgument("'varPar' must be a valid character vector",
-                    functionName = "addVariedParameters", 
-		parameter ="varPar",
+                    functionName = "addVariedParameters",
+                    parameter = "varPar",
                     value = varPar
                 )
             }
@@ -385,8 +387,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             optionalArgumentsDefined <- (length(args) > 0)
             if (is.null(design) && !optionalArgumentsDefined) {
                 stopIllegalArgument("please specify a 'design' to add and/or a design parameter, ", "e.g., deltaWT = c(0.1, 0.3, 0.4)",
-                    functionName = ".validateOptionalArguments", 
-		parameter ="design"
+                    functionName = ".validateOptionalArguments",
+                    parameter = "design"
                 )
             }
 
@@ -484,8 +486,9 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             for (design in self$designs) {
                 if (sided != design$sided) {
                     stopConflictingArguments("designs have different directions of alternative (design master is ", ifelse(sided ==
-                        1, "one", "two"), " sided)", 
-		functionName = "assertHaveEqualSidedValues")
+                        1, "one", "two"), " sided)",
+                    functionName = "assertHaveEqualSidedValues"
+                    )
                 }
             }
         },
@@ -504,8 +507,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
 
             if (length(argumentNames) > 2) {
                 stopIllegalArgument("too many arguments (", .arrayToString(argumentNames, encapsulate = TRUE), "): up to 2 design parameters are allowed",
-                    functionName = ".createDesignVariants", 
-		parameter ="argumentNames", value = argumentNames
+                    functionName = ".createDesignVariants",
+                    parameter = "argumentNames", value = argumentNames
                 )
             }
 
@@ -839,8 +842,9 @@ as.data.frame.TrialDesignSet <- function(
         ...) {
     .assertIsTrialDesignSet(x)
     if (x$isEmpty()) {
-        stopIllegalArgument("cannot create data.frame because the design set is empty", 
-		functionName = "as.data.frame.TrialDesignSet")
+        stopIllegalArgument("cannot create data.frame because the design set is empty",
+            functionName = "as.data.frame.TrialDesignSet"
+        )
     }
 
     fCall <- match.call(expand.dots = FALSE)
@@ -858,7 +862,7 @@ as.data.frame.TrialDesignSet <- function(
     for (design in x$designs) {
         if (fisherDesignEnabled != .isTrialDesignFisher(design)) {
             stopConflictingArguments("all trial designs must be from the same type ",
-                "(", .getClassName(x$designs[[1]], quote = TRUE), " != ", 
+                "(", .getClassName(x$designs[[1]], quote = TRUE), " != ",
                 .getClassName(design, quote = TRUE), ")",
                 functionName = "as.data.frame.TrialDesignSet",
                 parameter = "design",
@@ -1011,8 +1015,9 @@ plot.TrialDesignSet <- function(
 
     availablePlotTypes <- getAvailablePlotTypes(x, output = "numeric", numberInCaptionEnabled = FALSE)
     if (length(availablePlotTypes) == 0) {
-        stopIllegalArgument("no plot type available for the specified design", 
-		functionName = "plot.TrialDesignSet")
+        stopIllegalArgument("no plot type available for the specified design",
+            functionName = "plot.TrialDesignSet"
+        )
     }
     if (is.na(type)) {
         type <- availablePlotTypes[1]
@@ -1178,8 +1183,9 @@ plot.TrialDesignSet <- function(
             }
         }
     } else if (type == 2) {
-        stopIllegalArgument("designs with undefined endpoint do not support plot type 2", 
-		functionName = ".plotTrialDesignSet")
+        stopIllegalArgument("designs with undefined endpoint do not support plot type 2",
+            functionName = ".plotTrialDesignSet"
+        )
     } else if (type == 3) {
         main <- .getMainTitle(main, title = "Stage Levels", nMax = nMax)
         xParameterName <- "informationRates"

--- a/R/class_design_set.R
+++ b/R/class_design_set.R
@@ -386,7 +386,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             design <- .getOptionalArgument(optionalArgumentName = "design", ...)
             optionalArgumentsDefined <- (length(args) > 0)
             if (is.null(design) && !optionalArgumentsDefined) {
-                stopIllegalArgument("please specify a 'design' to add and/or a design parameter, ", "e.g., deltaWT = c(0.1, 0.3, 0.4)",
+                stopIllegalArgument("please specify a 'design' to add and/or a design parameter, ",
+                    "e.g., deltaWT = c(0.1, 0.3, 0.4)",
                     functionName = ".validateOptionalArguments",
                     parameter = "design"
                 )
@@ -399,7 +400,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             }
 
             if (is.null(design) && optionalArgumentsDefined && length(self$designs) == 0) {
-                stopIncompleteArguments("at least one design (master) must be defined in this ", "design set to respect any design parameters",
+                stopIncompleteArguments("at least one design (master) must be defined in this ",
+                    "design set to respect any design parameters",
                     functionName = ".validateOptionalArguments"
                 )
             }
@@ -485,9 +487,10 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             sided <- self$getDesignMaster()$sided
             for (design in self$designs) {
                 if (sided != design$sided) {
-                    stopConflictingArguments("designs have different directions of alternative (design master is ", ifelse(sided ==
-                        1, "one", "two"), " sided)",
-                    functionName = "assertHaveEqualSidedValues"
+                    stopConflictingArguments(
+                        "designs have different directions of alternative (design master is ",
+                        ifelse(sided == 1, "one", "two"), " sided)",
+                        functionName = "assertHaveEqualSidedValues"
                     )
                 }
             }
@@ -506,9 +509,12 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             }
 
             if (length(argumentNames) > 2) {
-                stopIllegalArgument("too many arguments (", .arrayToString(argumentNames, encapsulate = TRUE), "): up to 2 design parameters are allowed",
+                stopIllegalArgument("too many arguments (",
+                    .arrayToString(argumentNames, encapsulate = TRUE), "): ",
+                    "up to 2 design parameters are allowed",
                     functionName = ".createDesignVariants",
-                    parameter = "argumentNames", value = argumentNames
+                    parameter = "argumentNames",
+                    value = argumentNames
                 )
             }
 
@@ -1023,10 +1029,12 @@ plot.TrialDesignSet <- function(
         type <- availablePlotTypes[1]
     }
     if (!(type %in% availablePlotTypes)) {
-        stopIllegalArgument("'type' (", type, ") is not available; 'type' can ", ifelse(length(availablePlotTypes) ==
-            1, "only ", ""), "be ", .arrayToString(availablePlotTypes, mode = "or"),
-        functionName = "plot.TrialDesignSet",
-        parameter = "type", value = type
+        stopIllegalArgument(
+            "'type' (", type, ") is not available; 'type' can ",
+            ifelse(length(availablePlotTypes) == 1, "only ", ""), "be ",
+            .arrayToString(availablePlotTypes, mode = "or"),
+            functionName = "plot.TrialDesignSet",
+            parameter = "type", value = type
         )
     }
 
@@ -1173,8 +1181,10 @@ plot.TrialDesignSet <- function(
         main <- .getMainTitle(main, title = "Boundaries", nMax = nMax)
         xParameterName <- "informationRates"
         yParameterNames <- "criticalValues"
-        if (designMaster$sided == 1 || (designMaster$kMax > 1 && .isTrialDesignInverseNormalOrGroupSequential(designMaster) &&
-                (identical(designMaster$typeOfDesign, C_TYPE_OF_DESIGN_PT) || grepl("^bs", designMaster$typeBetaSpending)))) {
+        if (designMaster$sided == 1 || (designMaster$kMax > 1 &&
+                .isTrialDesignInverseNormalOrGroupSequential(designMaster) &&
+                (identical(designMaster$typeOfDesign, C_TYPE_OF_DESIGN_PT) ||
+                    grepl("^bs", designMaster$typeBetaSpending)))) {
             if (.isTrialDesignWithValidFutilityBounds(designMaster)) {
                 yParameterNames <- c("futilityBounds", yParameterNames)
             }
@@ -1274,7 +1284,8 @@ plot.TrialDesignSet <- function(
 }
 
 .addDecisionCriticalValuesToPlot <- function(p, designMaster, type, nMax = NA_integer_) {
-    if (type != 1 || .isTrialDesignFixed(designMaster) || !.isTrialDesignInverseNormalOrGroupSequential(designMaster)) {
+    if (type != 1 || .isTrialDesignFixed(designMaster) ||
+            !.isTrialDesignInverseNormalOrGroupSequential(designMaster)) {
         return(p)
     }
 
@@ -1291,7 +1302,9 @@ plot.TrialDesignSet <- function(
         data$delayedInformationRates <- data$delayedInformationRates * nMax
         tryCatch(
             {
-                data$delayedInformationRates <- as.numeric(.formatSampleSizes(data$delayedInformationRates))
+                data$delayedInformationRates <- as.numeric(
+                    .formatSampleSizes(data$delayedInformationRates)
+                )
             },
             error = function(e) {
                 warning("Failed to format delayed information rates on x-axis: ", e$message)
@@ -1331,6 +1344,8 @@ plot.TrialDesignSet <- function(
         )
     }
 
-    try(suppressWarnings(suppressMessages(p <- p + ggplot2::scale_color_manual(values = c("#4daf4a", "#377eb8", "#e41a1c")))))
+    try(suppressWarnings(suppressMessages(p <- p + ggplot2::scale_color_manual(
+        values = c("#4daf4a", "#377eb8", "#e41a1c")
+    ))))
     return(p)
 }

--- a/R/class_design_set.R
+++ b/R/class_design_set.R
@@ -120,7 +120,8 @@ summary.TrialDesignSet <- function(object, ..., type = 1, digits = NA_integer_) 
 
     .assertIsTrialDesignSet(object)
     if (object$isEmpty()) {
-        stopIllegalArgument("cannot create summary because the design set is empty", functionName = "summary.TrialDesignSet")
+        stopIllegalArgument("cannot create summary because the design set is empty", 
+		functionName = "summary.TrialDesignSet")
     }
 
     markdown <- .getOptionalArgument("markdown", ..., optionalArgumentDefaultValue = NA)
@@ -301,7 +302,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
         },
         getDesignMaster = function() {
             if (length(self$designs) == 0) {
-                stopRuntimeIssue("no design master defined", functionName = "getDesignMaster")
+                stopRuntimeIssue("no design master defined", 
+		functionName = "getDesignMaster")
             }
 
             return(self$designs[[1]])
@@ -309,14 +311,16 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
         .validateDesignsArgument = function(designsToAdd, args) {
             if (!is.list(designsToAdd)) {
                 stopIllegalArgument("'designsToAdd' must be a list",
-                    functionName = ".validateDesignsArgument", parameter = "designsToAdd",
+                    functionName = ".validateDesignsArgument", 
+		parameter ="designsToAdd",
                     value = designsToAdd
                 )
             }
 
             if (length(designsToAdd) == 0) {
                 stopIllegalArgument("'designsToAdd' must be not empty",
-                    functionName = ".validateDesignsArgument", parameter = "designsToAdd",
+                    functionName = ".validateDesignsArgument", 
+		parameter ="designsToAdd",
                     value = designsToAdd
                 )
             }
@@ -328,7 +332,7 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
                 } else {
                     parentDesign <- d[[".design"]]
                     if (is.null(parentDesign)) {
-                        stopIllegalArgument("'designsToAdd' must be a list of trial designs (found '", .getClassName(d), "')",
+                        stopIllegalArgument("'designsToAdd' must be a list of trial designs (found ", .getClassName(d, quote = TRUE), ")",
                             functionName = ".validateDesignsArgument",
                             parameter = "designsToAdd", value = designsToAdd
                         )
@@ -361,7 +365,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
         addVariedParameters = function(varPar) {
             if (is.null(varPar) || !is.character(varPar)) {
                 stopIllegalArgument("'varPar' must be a valid character vector",
-                    functionName = "addVariedParameters", parameter = "varPar",
+                    functionName = "addVariedParameters", 
+		parameter ="varPar",
                     value = varPar
                 )
             }
@@ -380,7 +385,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             optionalArgumentsDefined <- (length(args) > 0)
             if (is.null(design) && !optionalArgumentsDefined) {
                 stopIllegalArgument("please specify a 'design' to add and/or a design parameter, ", "e.g., deltaWT = c(0.1, 0.3, 0.4)",
-                    functionName = ".validateOptionalArguments", parameter = "design"
+                    functionName = ".validateOptionalArguments", 
+		parameter ="design"
                 )
             }
 
@@ -478,7 +484,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
             for (design in self$designs) {
                 if (sided != design$sided) {
                     stopConflictingArguments("designs have different directions of alternative (design master is ", ifelse(sided ==
-                        1, "one", "two"), " sided)", functionName = "assertHaveEqualSidedValues")
+                        1, "one", "two"), " sided)", 
+		functionName = "assertHaveEqualSidedValues")
                 }
             }
         },
@@ -497,7 +504,8 @@ TrialDesignSet <- R6::R6Class("TrialDesignSet",
 
             if (length(argumentNames) > 2) {
                 stopIllegalArgument("too many arguments (", .arrayToString(argumentNames, encapsulate = TRUE), "): up to 2 design parameters are allowed",
-                    functionName = ".createDesignVariants", parameter = "argumentNames", value = argumentNames
+                    functionName = ".createDesignVariants", 
+		parameter ="argumentNames", value = argumentNames
                 )
             }
 
@@ -831,7 +839,8 @@ as.data.frame.TrialDesignSet <- function(
         ...) {
     .assertIsTrialDesignSet(x)
     if (x$isEmpty()) {
-        stopIllegalArgument("cannot create data.frame because the design set is empty", functionName = "as.data.frame.TrialDesignSet")
+        stopIllegalArgument("cannot create data.frame because the design set is empty", 
+		functionName = "as.data.frame.TrialDesignSet")
     }
 
     fCall <- match.call(expand.dots = FALSE)
@@ -849,8 +858,8 @@ as.data.frame.TrialDesignSet <- function(
     for (design in x$designs) {
         if (fisherDesignEnabled != .isTrialDesignFisher(design)) {
             stopConflictingArguments("all trial designs must be from the same type ",
-                "('", .getClassName(x$designs[[1]]),
-                "' != '", .getClassName(design), ")'",
+                "(", .getClassName(x$designs[[1]], quote = TRUE), " != ", 
+                .getClassName(design, quote = TRUE), ")",
                 functionName = "as.data.frame.TrialDesignSet",
                 parameter = "design",
                 value = design,
@@ -1002,7 +1011,8 @@ plot.TrialDesignSet <- function(
 
     availablePlotTypes <- getAvailablePlotTypes(x, output = "numeric", numberInCaptionEnabled = FALSE)
     if (length(availablePlotTypes) == 0) {
-        stopIllegalArgument("no plot type available for the specified design", functionName = "plot.TrialDesignSet")
+        stopIllegalArgument("no plot type available for the specified design", 
+		functionName = "plot.TrialDesignSet")
     }
     if (is.na(type)) {
         type <- availablePlotTypes[1]
@@ -1168,7 +1178,8 @@ plot.TrialDesignSet <- function(
             }
         }
     } else if (type == 2) {
-        stopIllegalArgument("designs with undefined endpoint do not support plot type 2", functionName = ".plotTrialDesignSet")
+        stopIllegalArgument("designs with undefined endpoint do not support plot type 2", 
+		functionName = ".plotTrialDesignSet")
     } else if (type == 3) {
         main <- .getMainTitle(main, title = "Stage Levels", nMax = nMax)
         xParameterName <- "informationRates"

--- a/R/class_dictionary.R
+++ b/R/class_dictionary.R
@@ -130,14 +130,16 @@ initDictionary <- function(x, keyValuePairList) {
     .assertIsDictionary(x)
     if (is.null(keyValuePairList) || length(keyValuePairList) == 0 || !is.list(keyValuePairList)) {
         stopIllegalArgument("'keyValuePairList' must be a valid list",
-            functionName = "initDictionary", parameter = "keyValuePairList",
+            functionName = "initDictionary", 
+		parameter ="keyValuePairList",
             value = keyValuePairList
         )
     }
 
     if (any(names(keyValuePairList) == "")) {
         stopIllegalArgument("'keyValuePairList' must be a named list",
-            functionName = "initDictionary", parameter = "keyValuePairList",
+            functionName = "initDictionary", 
+		parameter ="keyValuePairList",
             value = keyValuePairList
         )
     }

--- a/R/class_dictionary.R
+++ b/R/class_dictionary.R
@@ -153,7 +153,8 @@ initDictionary <- function(x, keyValuePairList) {
 addValueToDictionary <- function(x, key, value) {
     .assertIsDictionary(x)
     if (base::exists(key, envir = x)) {
-        stopIllegalArgument("dictionary ", base::sQuote(base::attr(x, "name")), " already contains key ", base::sQuote(key),
+        stopIllegalArgument("dictionary ", base::sQuote(base::attr(x, "name")), 
+            " already contains key ", base::sQuote(key),
             functionName = "addValueToDictionary"
         )
     }
@@ -168,7 +169,8 @@ setValueToDictionary <- function(x, key, value) {
 getValueFromDictionary <- function(x, key) {
     .assertIsDictionary(x)
     if (!base::exists(key, envir = x)) {
-        stopIllegalArgument("dictionary ", base::sQuote(base::attr(x, "name")), " does not contain key ", base::sQuote(key),
+        stopIllegalArgument("dictionary ", base::sQuote(base::attr(x, "name")), 
+            " does not contain key ", base::sQuote(key),
             functionName = "getValueFromDictionary"
         )
     }

--- a/R/class_dictionary.R
+++ b/R/class_dictionary.R
@@ -130,16 +130,16 @@ initDictionary <- function(x, keyValuePairList) {
     .assertIsDictionary(x)
     if (is.null(keyValuePairList) || length(keyValuePairList) == 0 || !is.list(keyValuePairList)) {
         stopIllegalArgument("'keyValuePairList' must be a valid list",
-            functionName = "initDictionary", 
-		parameter ="keyValuePairList",
+            functionName = "initDictionary",
+            parameter = "keyValuePairList",
             value = keyValuePairList
         )
     }
 
     if (any(names(keyValuePairList) == "")) {
         stopIllegalArgument("'keyValuePairList' must be a named list",
-            functionName = "initDictionary", 
-		parameter ="keyValuePairList",
+            functionName = "initDictionary",
+            parameter = "keyValuePairList",
             value = keyValuePairList
         )
     }

--- a/R/class_simulation_results.R
+++ b/R/class_simulation_results.R
@@ -143,8 +143,8 @@ SimulationResults <- R6::R6Class(
             } else {
                 if (is.null(showStatistics) || length(showStatistics) != 1) {
                     stopIllegalArgument("'showStatistics' (", .arrayToString(showStatistics), ") must be a single logical or character",
-                        functionName = ".show", 
-		parameter ="showStatistics", value = showStatistics
+                        functionName = ".show",
+                        parameter = "showStatistics", value = showStatistics
                     )
                 }
 

--- a/R/class_simulation_results.R
+++ b/R/class_simulation_results.R
@@ -142,7 +142,8 @@ SimulationResults <- R6::R6Class(
                 super$.show(showType = showType, digits = digits, consoleOutputEnabled = consoleOutputEnabled)
             } else {
                 if (is.null(showStatistics) || length(showStatistics) != 1) {
-                    stopIllegalArgument("'showStatistics' (", .arrayToString(showStatistics), ") must be a single logical or character",
+                    stopIllegalArgument(
+                        "'showStatistics' (", .arrayToString(showStatistics), ") must be a single logical or character",
                         functionName = ".show",
                         parameter = "showStatistics", value = showStatistics
                     )

--- a/R/class_simulation_results.R
+++ b/R/class_simulation_results.R
@@ -143,7 +143,8 @@ SimulationResults <- R6::R6Class(
             } else {
                 if (is.null(showStatistics) || length(showStatistics) != 1) {
                     stopIllegalArgument("'showStatistics' (", .arrayToString(showStatistics), ") must be a single logical or character",
-                        functionName = ".show", parameter = "showStatistics", value = showStatistics
+                        functionName = ".show", 
+		parameter ="showStatistics", value = showStatistics
                     )
                 }
 

--- a/R/class_summary.R
+++ b/R/class_summary.R
@@ -31,16 +31,16 @@ SummaryItem <- R6::R6Class("SummaryItem",
             if (!is.null(self$legendEntry) && length(self$legendEntry) > 0) {
                 if (is.null(names(self$legendEntry))) {
                     stopIllegalArgument(sQuote("legendEntry"), " must be a named list",
-                        functionName = "initialize", 
-		parameter ="legendEntry",
+                        functionName = "initialize",
+                        parameter = "legendEntry",
                         value = legendEntry
                     )
                 }
                 for (l in self$legendEntry) {
                     if (length(l) == 0) {
                         stopIllegalArgument(sQuote("legendEntry"), " must be not empty",
-                            functionName = "initialize", 
-		parameter ="legendEntry",
+                            functionName = "initialize",
+                            parameter = "legendEntry",
                             value = legendEntry
                         )
                     }
@@ -578,9 +578,10 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
             if (is.list(parameterSet) && is.matrix(values)) {
                 parameterSet <- parameterSet[["parameterSet"]]
                 if (is.null(parameterSet)) {
-                    stopRuntimeIssue("'parameterSet' must be added to list", 
-		functionName = "addParameter", 
-		parameter ="parameterSet", value = parameterSet)
+                    stopRuntimeIssue("'parameterSet' must be added to list",
+                        functionName = "addParameter",
+                        parameter = "parameterSet", value = parameterSet
+                    )
                 }
             }
 
@@ -756,8 +757,8 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
                             numberOfVariants <- length(variedParameterValues)
                         } else {
                             stopRuntimeIssue("varied parameter identification ", "is not implemented for ", .getClassName(parameterSet),
-                                functionName = "addParameter", 
-		parameter ="parameterSet", value = parameterSet
+                                functionName = "addParameter",
+                                parameter = "parameterSet", value = parameterSet
                             )
                         }
                         variedParameterCaption <- tolower(variedParameterCaption)
@@ -2865,8 +2866,8 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
     if (!inherits(object, "AnalysisResults")) {
         stopIllegalArgument("'object' must be a valid analysis result object (is class ", .getClassName(object),
             ")",
-            functionName = ".createSummaryAnalysisResults", 
-		parameter ="object", value = object
+            functionName = ".createSummaryAnalysisResults",
+            parameter = "object", value = object
         )
     }
 
@@ -3459,8 +3460,8 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
     } else {
         stopIllegalArgument("'object' must be a valid design, design plan, ", "or simulation result object (is class ",
             .getClassName(object), ")",
-            functionName = ".createSummaryDesignPlan", 
-		parameter ="object", value = object
+            functionName = ".createSummaryDesignPlan",
+            parameter = "object", value = object
         )
     }
 

--- a/R/class_summary.R
+++ b/R/class_summary.R
@@ -31,14 +31,16 @@ SummaryItem <- R6::R6Class("SummaryItem",
             if (!is.null(self$legendEntry) && length(self$legendEntry) > 0) {
                 if (is.null(names(self$legendEntry))) {
                     stopIllegalArgument(sQuote("legendEntry"), " must be a named list",
-                        functionName = "initialize", parameter = "legendEntry",
+                        functionName = "initialize", 
+		parameter ="legendEntry",
                         value = legendEntry
                     )
                 }
                 for (l in self$legendEntry) {
                     if (length(l) == 0) {
                         stopIllegalArgument(sQuote("legendEntry"), " must be not empty",
-                            functionName = "initialize", parameter = "legendEntry",
+                            functionName = "initialize", 
+		parameter ="legendEntry",
                             value = legendEntry
                         )
                     }
@@ -419,7 +421,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
                     self$addSummaryItem(SummaryItem$new(title = title, values = values, legendEntry = legendEntry))
                 },
                 error = function(e) {
-                    stopRuntimeIssue("failed to add summary item '", title, "' = ", .arrayToString(values),
+                    stopRuntimeIssue("failed to add summary item ", .pQuote(title), " = ", .arrayToString(values),
                         " (class: ", .getClassName(values), "): ", e$message,
                         functionName = "addItem",
                         parameter = "title",
@@ -433,7 +435,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
         addSummaryItem = function(summaryItem) {
             if (!inherits(summaryItem, "SummaryItem")) {
                 stopIllegalArgument("'summaryItem' must be an instance of class ",
-                    "'SummaryItem' (was '", .getClassName(summaryItem), "')",
+                    "'SummaryItem' (was ", .getClassName(summaryItem, quote = TRUE), ")",
                     functionName = "addSummaryItem",
                     parameter = "summaryItem",
                     value = summaryItem,
@@ -507,7 +509,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
                 values <- parameterSet[[parameterName1]]
                 if (is.null(values)) {
                     stopRuntimeIssue(.getClassName(parameterSet), " does not ",
-                        "contain a field '", parameterName1, "'",
+                        "contain a field ", .pQuote(parameterName1), "",
                         functionName = "addParameter",
                         parameter = "parameterSet",
                         value = parameterSet,
@@ -525,7 +527,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
                 parameterName <- parameterName[1]
                 if (is.null(values2)) {
                     stopRuntimeIssue(.getClassName(parameterSet), " does not ",
-                        "contain a field '", parameterName2, "'",
+                        "contain a field ", .pQuote(parameterName2), "",
                         functionName = "addParameter",
                         parameter = "parameterSet",
                         value = parameterSet,
@@ -576,7 +578,9 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
             if (is.list(parameterSet) && is.matrix(values)) {
                 parameterSet <- parameterSet[["parameterSet"]]
                 if (is.null(parameterSet)) {
-                    stopRuntimeIssue("'parameterSet' must be added to list", functionName = "addParameter", parameter = "parameterSet", value = parameterSet)
+                    stopRuntimeIssue("'parameterSet' must be added to list", 
+		functionName = "addParameter", 
+		parameter ="parameterSet", value = parameterSet)
                 }
             }
 
@@ -685,8 +689,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
             } else {
                 if (!inherits(parameterSet, "ParameterSet")) {
                     stopIllegalArgument("for varied values 'parameterSet' must be an instance of ",
-                        "class 'ParameterSet' (was '",
-                        .getClassName(parameterSet), "')",
+                        "class 'ParameterSet' (was ", .getClassName(parameterSet, quote = TRUE), ")",
                         functionName = "addParameter",
                         parameter = "parameterSet",
                         value = parameterSet
@@ -753,7 +756,8 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
                             numberOfVariants <- length(variedParameterValues)
                         } else {
                             stopRuntimeIssue("varied parameter identification ", "is not implemented for ", .getClassName(parameterSet),
-                                functionName = "addParameter", parameter = "parameterSet", value = parameterSet
+                                functionName = "addParameter", 
+		parameter ="parameterSet", value = parameterSet
                             )
                         }
                         variedParameterCaption <- tolower(variedParameterCaption)
@@ -1170,7 +1174,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
                 }
             },
             error = function(e) {
-                stopRuntimeIssue("failed to show parameter '", parameterName, "': ", e$message,
+                stopRuntimeIssue("failed to show parameter ", .pQuote(parameterName), ": ", e$message,
                     functionName = ".getSummaryValuesFormatted",
                     parameter = parameterName
                 )
@@ -1356,8 +1360,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
             !inherits(object, "SimulationResults")) {
         stopIllegalArgument("'object' must be an instance of class ",
             "'AnalysisResults', 'TrialDesignPlan' ",
-            "or 'SimulationResults' (is '",
-            .getClassName(object), "')",
+            "or 'SimulationResults' (is ", .getClassName(object, quote = TRUE), ")",
             functionName = ".createSummaryHypothesisText",
             parameter = "object",
             value = .getClassName(object)
@@ -2608,7 +2611,7 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
         if (userDefinedFunction) {
             header <- .concatenateSummaryText(
                 header,
-                paste0("sample size reassessment: user defined '", functionName, "'")
+                paste0("sample size reassessment: user defined ", .pQuote(functionName))
             )
             if ((!is.null(designPlan[["conditionalPower"]]) && !is.na(designPlan$conditionalPower))) {
                 header <- .concatenateSummaryText(
@@ -2862,7 +2865,8 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
     if (!inherits(object, "AnalysisResults")) {
         stopIllegalArgument("'object' must be a valid analysis result object (is class ", .getClassName(object),
             ")",
-            functionName = ".createSummaryAnalysisResults", parameter = "object", value = object
+            functionName = ".createSummaryAnalysisResults", 
+		parameter ="object", value = object
         )
     }
 
@@ -3455,7 +3459,8 @@ SummaryFactory <- R6::R6Class("SummaryFactory",
     } else {
         stopIllegalArgument("'object' must be a valid design, design plan, ", "or simulation result object (is class ",
             .getClassName(object), ")",
-            functionName = ".createSummaryDesignPlan", parameter = "object", value = object
+            functionName = ".createSummaryDesignPlan", 
+		parameter ="object", value = object
         )
     }
 

--- a/R/class_time.R
+++ b/R/class_time.R
@@ -593,13 +593,14 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                         self$median1,
                         kappa = self$kappa
                     ), self$lambda1, tolerance = 1e-05))) {
-                    stopRuntimeIssue("'lambda1' must be ", round(
-                        getLambdaByMedian(self$median1, kappa = self$kappa), 5
-                    ),
-                    ", ", "but is ", round(self$lambda1, 5),
-                    functionName = ".validateCalculatedArguments",
-                    parameter = "lambda1",
-                    value = self$lambda1
+                    stopRuntimeIssue(
+                        "'lambda1' must be ", round(
+                            getLambdaByMedian(self$median1, kappa = self$kappa), 5
+                        ),
+                        ", ", "but is ", round(self$lambda1, 5),
+                        functionName = ".validateCalculatedArguments",
+                        parameter = "lambda1",
+                        value = self$lambda1
                     )
                 }
                 if (!anyNA(self$pi1) &&
@@ -610,13 +611,14 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                             self$pi1,
                             tolerance = 1e-05
                         ))) {
-                    stopRuntimeIssue("'pi1' must be ", round(
-                        getPiByMedian(self$median1, eventTime = self$eventTime, kappa = self$kappa),
-                        5
-                    ), ", but is ", round(self$pi1, 5),
-                    functionName = ".validateCalculatedArguments",
-                    parameter = "pi1",
-                    value = self$pi1
+                    stopRuntimeIssue(
+                        "'pi1' must be ", round(
+                            getPiByMedian(self$median1, eventTime = self$eventTime, kappa = self$kappa),
+                            5
+                        ), ", but is ", round(self$pi1, 5),
+                        functionName = ".validateCalculatedArguments",
+                        parameter = "pi1",
+                        value = self$pi1
                     )
                 }
             }
@@ -625,7 +627,9 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                 if (!isTRUE(all.equal(getLambdaByMedian(self$median2,
                         kappa = self$kappa
                     ), self$lambda2, tolerance = 1e-05))) {
-                    stopRuntimeIssue("'lambda2' must be ", round(getLambdaByMedian(self$median2, kappa = self$kappa), 5),
+                    stopRuntimeIssue(
+                        "'lambda2' must be ",
+                        round(getLambdaByMedian(self$median2, kappa = self$kappa), 5),
                         ", ", "but is ", round(self$lambda2, 5),
                         functionName = ".validateCalculatedArguments",
                         parameter = "lambda2",
@@ -637,13 +641,14 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                             self$pi2,
                             tolerance = 1e-05
                         ))) {
-                    stopRuntimeIssue("'pi2' must be ", round(
-                        getPiByMedian(self$median2, eventTime = self$eventTime, kappa = self$kappa),
-                        5
-                    ), ", but is ", round(self$pi2, 5),
-                    functionName = ".validateCalculatedArguments",
-                    parameter = "pi2",
-                    value = self$pi2
+                    stopRuntimeIssue(
+                        "'pi2' must be ", round(
+                            getPiByMedian(self$median2, eventTime = self$eventTime, kappa = self$kappa),
+                            5
+                        ), ", but is ", round(self$pi2, 5),
+                        functionName = ".validateCalculatedArguments",
+                        parameter = "pi2",
+                        value = self$pi2
                     )
                 }
             }
@@ -653,41 +658,47 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                     self$isUserDefinedParameter("lambda2") ||
                     self$isUserDefinedParameter("median2")) {
                 if (!anyNA(self$pi1)) {
-                    stopRuntimeIssue("'pi1' (", self$pi1, ") must be NA_real_",
+                    stopRuntimeIssue(
+                        "'pi1' (", self$pi1, ") must be NA_real_",
                         functionName = ".validateCalculatedArguments",
                         parameter = "pi1", value = self$pi1
                     )
                 }
                 if (self$.getParameterType("pi1") != C_PARAM_NOT_APPLICABLE) {
-                    stopRuntimeIssue("parameter type of 'pi1' (", self$.getParameterType("pi1"),
+                    stopRuntimeIssue(
+                        "parameter type of 'pi1' (", self$.getParameterType("pi1"),
                         ") must be C_PARAM_NOT_APPLICABLE",
                         functionName = ".validateCalculatedArguments",
                         parameter = "pi1"
                     )
                 }
                 if (!anyNA(self$pi1)) {
-                    stopRuntimeIssue("'pi2' (", self$pi2, ") must be NA_real_",
+                    stopRuntimeIssue(
+                        "'pi2' (", self$pi2, ") must be NA_real_",
                         functionName = ".validateCalculatedArguments",
                         parameter = "pi2",
                         value = self$pi2
                     )
                 }
                 if (self$.getParameterType("pi2") != C_PARAM_NOT_APPLICABLE) {
-                    stopRuntimeIssue("parameter type of 'pi2' (", self$.getParameterType("pi2"),
+                    stopRuntimeIssue(
+                        "parameter type of 'pi2' (", self$.getParameterType("pi2"),
                         ") must be C_PARAM_NOT_APPLICABLE",
                         functionName = ".validateCalculatedArguments",
                         parameter = "pi2"
                     )
                 }
                 if (!anyNA(self$eventTime)) {
-                    stopRuntimeIssue("'eventTime' (", self$eventTime, ") must be NA_real_",
+                    stopRuntimeIssue(
+                        "'eventTime' (", self$eventTime, ") must be NA_real_",
                         functionName = ".validateCalculatedArguments",
                         parameter = "eventTime",
                         value = self$eventTime
                     )
                 }
                 if (self$.getParameterType("eventTime") != C_PARAM_NOT_APPLICABLE) {
-                    stopRuntimeIssue("parameter type of 'eventTime' (",
+                    stopRuntimeIssue(
+                        "parameter type of 'eventTime' (",
                         self$.getParameterType("eventTime"),
                         ") must be C_PARAM_NOT_APPLICABLE",
                         functionName = ".validateCalculatedArguments",
@@ -697,7 +708,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
             }
 
             if (self$isUndefinedParameter("hazardRatio")) {
-                stopRuntimeIssue("parameter type of 'hazardRatio' (",
+                stopRuntimeIssue(
+                    "parameter type of 'hazardRatio' (",
                     self$hazardRatio, ") must be != C_PARAM_TYPE_UNKNOWN",
                     functionName = ".validateCalculatedArguments",
                     parameter = "hazardRatio",
@@ -707,7 +719,9 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
         },
         .stopInCaseOfConflictingArguments = function(arg1, argName1, arg2, argName2) {
             if (length(arg1) > 0 && !all(is.na(arg1)) && length(arg2) > 0 && !all(is.na(arg2))) {
-                stopConflictingArguments("it is not allowed to specify ", .pQuote(argName1), " (", .arrayToString(arg1), ")",
+                stopConflictingArguments(
+                    "it is not allowed to specify ", .pQuote(argName1),
+                    " (", .arrayToString(arg1), ")",
                     " and ", .pQuote(argName2), " (", .arrayToString(arg2), ") concurrently",
                     functionName = ".stopInCaseOfConflictingArguments",
                     parameter = "argName1",
@@ -883,8 +897,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                 if (i < length(pwSurvTimeNames)) {
                     parts <- strsplit(timePeriod, "- *(< *)?", perl = TRUE)[[1]]
                     if (length(parts) != 2) {
-                        stopIllegalArgument("all regions (", timePeriod,
-                            ") must have the format ", "\"time_1 - <time_2\", e.g., \"3 - <6\"",
+                        stopIllegalArgument("all regions (", timePeriod, ") must have the format ",
+                            "\"time_1 - <time_2\", e.g., \"3 - <6\"",
                             functionName = ".initFromList",
                             parameter = "timePeriod",
                             value = timePeriod
@@ -1025,7 +1039,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
 
                         if (is.na(self$median2)) {
                             if (anyNA(self$hazardRatio)) {
-                                stopMissingArgument("'hazardRatio', 'lambda2', or 'median2' must be specified",
+                                stopMissingArgument(
+                                    "'hazardRatio', 'lambda2', or 'median2' must be specified",
                                     functionName = ".init",
                                     parameter = "hazardRatio",
                                     relatedParameter = "lambda2"
@@ -1033,7 +1048,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                             }
 
                             if (length(self$hazardRatio) != length(self$median1)) {
-                                stopConflictingArguments("length of 'hazardRatio' (", .arrayToString(self$hazardRatio), ") must be ",
+                                stopConflictingArguments(
+                                    "length of 'hazardRatio' (", .arrayToString(self$hazardRatio), ") must be ",
                                     "equal to length of 'median1' (", .arrayToString(self$median1), ")",
                                     functionName = ".init",
                                     parameter = "hazardRatio",
@@ -1048,7 +1064,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                             self$lambda2 <- getLambda2ByLambda1AndHazardRatio(getLambdaByMedian(self$median1, self$kappa), self$hazardRatio)
 
                             if (!self$delayedResponseAllowed && length(unique(round(self$lambda2, 8))) > 1) {
-                                stopIllegalArgument("'lambda2' can only be calculated if ",
+                                stopIllegalArgument(
+                                    "'lambda2' can only be calculated if ",
                                     "'unique(lambda1 / hazardRatio)' ",
                                     "result in a single value; current result = ",
                                     .arrayToString(round(self$lambda2, 4), vectorLookAndFeelEnabled = TRUE),
@@ -1230,7 +1247,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                     )
                     if (all(is.na(self$piecewiseSurvivalTime))) {
                         if (self$isUserDefinedParameter("median1")) {
-                            stopConflictingArguments("'median1' (", .arrayToString(self$median1), ") with length > 1 can only ",
+                            stopConflictingArguments(
+                                "'median1' (", .arrayToString(self$median1), ") with length > 1 can only ",
                                 "defined together with a single 'median2', 'lambda2' or 'pi2'",
                                 functionName = ".init",
                                 parameter = "median1",
@@ -1242,7 +1260,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                                 !all(is.na(self$lambda1)) &&
                                 length(self$lambda1) != length(self$lambda2) &&
                                 self$delayedResponseAllowed) {
-                            stopIllegalArgument("length of 'lambda1' (", length(self$lambda1), "), ",
+                            stopIllegalArgument(
+                                "length of 'lambda1' (", length(self$lambda1), "), ",
                                 "'lambda2' (", length(self$lambda2),
                                 "), and ", "'piecewiseSurvivalTime' (", length(self$piecewiseSurvivalTime),
                                 ") must be equal",
@@ -1459,7 +1478,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                 return(invisible())
             }
 
-            stopIllegalArgument("'hazardRatio' can only be calculated if 'unique(lambda1 / lambda2)' ",
+            stopIllegalArgument(
+                "'hazardRatio' can only be calculated if 'unique(lambda1 / lambda2)' ",
                 "result in a single value; current result = ",
                 .arrayToString(round(hr, 4), vectorLookAndFeelEnabled = TRUE),
                 " (e.g., delayed response is not allowed)",
@@ -1472,28 +1492,32 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
         },
         .validateInitialization = function() {
             if (length(self$piecewiseSurvivalTime) == 0) {
-                stopIllegalArgument("'piecewiseSurvivalTime' must contain at least one survival start time",
+                stopIllegalArgument(
+                    "'piecewiseSurvivalTime' must contain at least one survival start time",
                     functionName = ".validateInitialization",
                     parameter = "piecewiseSurvivalTime"
                 )
             }
 
             if (anyNA(self$piecewiseSurvivalTime)) {
-                stopIllegalArgument("'piecewiseSurvivalTime' must contain valid survival start times",
+                stopIllegalArgument(
+                    "'piecewiseSurvivalTime' must contain valid survival start times",
                     functionName = ".validateInitialization",
                     parameter = "piecewiseSurvivalTime"
                 )
             }
 
             if (self$piecewiseSurvivalTime[1] != 0) {
-                stopIllegalArgument("the first value of 'piecewiseSurvivalTime' must be 0",
+                stopIllegalArgument(
+                    "the first value of 'piecewiseSurvivalTime' must be 0",
                     functionName = ".validateInitialization",
                     parameter = "piecewiseSurvivalTime"
                 )
             }
 
             if (length(self$piecewiseSurvivalTime) != length(self$lambda2)) {
-                stopIllegalArgument("length of 'piecewiseSurvivalTime' (",
+                stopIllegalArgument(
+                    "length of 'piecewiseSurvivalTime' (",
                     length(self$piecewiseSurvivalTime), ") and length of 'lambda2' (",
                     length(self$lambda2), ") must be equal",
                     functionName = ".validateInitialization",
@@ -1516,7 +1540,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                     if (!self$delayedResponseEnabled && self$.isLambdaBased()) {
                         if (self$delayedResponseAllowed) {
                             if (length(self$hazardRatio) != length(self$lambda2)) {
-                                stopIllegalArgument("length of 'hazardRatio' (",
+                                stopIllegalArgument(
+                                    "length of 'hazardRatio' (",
                                     length(self$hazardRatio), ") and length of 'lambda2' (",
                                     length(self$lambda2), ") must be equal",
                                     functionName = ".validateInitialization",
@@ -1553,9 +1578,10 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                 target <- getLambda1ByLambda2AndHazardRatio(self$lambda2, self$hazardRatio)
                 if (length(self$lambda1) > 0 && !all(is.na(self$lambda1)) &&
                         !isTRUE(all.equal(target, self$lambda1))) {
-                    stopIllegalArgument("'lambda1' (", .arrayToString(self$lambda1),
-                        ") ", "is not as expected (", .arrayToString(target),
-                        ") ", "for given hazard ratio ", self$hazardRatio,
+                    stopIllegalArgument(
+                        "'lambda1' (", .arrayToString(self$lambda1), ") ",
+                        "is not as expected (", .arrayToString(target), ") ",
+                        "for given hazard ratio ", self$hazardRatio,
                         functionName = ".validateInitialization",
                         parameter = "lambda1",
                         value = self$lambda1
@@ -2073,7 +2099,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
             # Case 6
             if (!self$endOfAccrualIsUserDefined && self$maxNumberOfSubjectsIsUserDefined &&
                     !self$absoluteAccrualIntensityEnabled) {
-                stopIllegalArgument("the calculation of 'followUpTime' for given 'maxNumberOfSubjects' ",
+                stopIllegalArgument(
+                    "the calculation of 'followUpTime' for given 'maxNumberOfSubjects' ",
                     "and relative accrual intensities (< 1) ",
                     "can only be done if end of accrual is defined",
                     functionName = ".validate",
@@ -2086,7 +2113,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
             # Case 8
             else if (!self$endOfAccrualIsUserDefined && !self$maxNumberOfSubjectsIsUserDefined &&
                     self$followUpTimeMustBeUserDefined && !self$absoluteAccrualIntensityEnabled) {
-                stopIllegalArgument("the calculation of 'maxNumberOfSubjects' for given 'followUpTime' ",
+                stopIllegalArgument(
+                    "the calculation of 'maxNumberOfSubjects' for given 'followUpTime' ",
                     "and relative accrual intensities (< 1) ",
                     "can only be done if end of accrual is defined",
                     functionName = ".validate",
@@ -2343,7 +2371,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                 }
 
                 if (self$accrualTime[1] != 0) {
-                    stopIllegalArgument("the first value of 'accrualTime' (", .arrayToString(self$accrualTime), ") must be 0",
+                    stopIllegalArgument(
+                        "the first value of 'accrualTime' (", .arrayToString(self$accrualTime), ") must be 0",
                         functionName = ".init",
                         parameter = "accrualTime", value = self$accrualTime
                     )
@@ -2377,7 +2406,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                         length(self$accrualIntensity),
                         length(self$accrualIntensity) + 1
                     ))) {
-                    stopIllegalArgument("length of 'accrualTime' (", length(self$accrualTime),
+                    stopIllegalArgument(
+                        "length of 'accrualTime' (", length(self$accrualTime),
                         ") must be equal to length of 'accrualIntensity' if the last 'accrualTime' ",
                         "shall be calculated ",
                         "based on 'maxNumberOfSubjects' or length of 'accrualIntensity' (", length(self$accrualIntensity),
@@ -2404,7 +2434,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                 if (length(self$accrualTime) == 1) {
                     if (length(self$maxNumberOfSubjects) > 0 && !is.na(self$maxNumberOfSubjects) &&
                             self$maxNumberOfSubjects > 0 && self$maxNumberOfSubjects < self$accrualIntensity[1]) {
-                        stopIllegalArgument("'maxNumberOfSubjects' (", self$maxNumberOfSubjects, ") ",
+                        stopIllegalArgument(
+                            "'maxNumberOfSubjects' (", self$maxNumberOfSubjects, ") ",
                             "must be >= ", self$accrualIntensity[1],
                             " ('accrualIntensity')",
                             functionName = ".init",
@@ -2428,7 +2459,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                             } else {
                                 if (length(self$accrualTime) == length(self$accrualIntensity) + 1 &&
                                         self$absoluteAccrualIntensityEnabled) {
-                                    stopConflictingArguments("'maxNumberOfSubjects' (", self$maxNumberOfSubjects,
+                                    stopConflictingArguments(
+                                        "'maxNumberOfSubjects' (", self$maxNumberOfSubjects,
                                         ") disagrees with ", "the defined accrual time and intensity: ",
                                         self$.getFormula(), " = ", sampleSize,
                                         functionName = ".init",
@@ -2436,7 +2468,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                                         value = self$maxNumberOfSubjects
                                     )
                                 } else {
-                                    stopIllegalArgument("'maxNumberOfSubjects' (", self$maxNumberOfSubjects,
+                                    stopIllegalArgument(
+                                        "'maxNumberOfSubjects' (", self$maxNumberOfSubjects,
                                         ") ", "must be >= ", sampleSize,
                                         functionName = ".init",
                                         parameter = "maxNumberOfSubjects",
@@ -2573,7 +2606,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                 if (!stopInCaseOfError) {
                     return(invisible())
                 }
-                stopIllegalArgument("'maxNumberOfSubjects' (", self$maxNumberOfSubjects, ") ",
+                stopIllegalArgument(
+                    "'maxNumberOfSubjects' (", self$maxNumberOfSubjects, ") ",
                     "is too small for the defined accrual time (minimum = ",
                     sampleSize, ")",
                     functionName = ".calculateRemainingTime",
@@ -2606,7 +2640,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                 if (!stopInCaseOfError) {
                     return(invisible())
                 }
-                stopIllegalArgument("'maxNumberOfSubjects' (", self$maxNumberOfSubjects, ") ",
+                stopIllegalArgument(
+                    "'maxNumberOfSubjects' (", self$maxNumberOfSubjects, ") ",
                     "is too small for the defined accrual time",
                     functionName = ".calculateRemainingTime",
                     parameter = "maxNumberOfSubjects",
@@ -2616,7 +2651,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
         },
         .validateAccrualTimeAndIntensity = function() {
             if ((length(self$accrualTime) >= 2 && any(self$accrualTime[2:length(self$accrualTime)] < 0))) {
-                stopIllegalArgument("'accrualTime' (", .arrayToString(self$accrualTime), ") must be > 0",
+                stopIllegalArgument(
+                    "'accrualTime' (", .arrayToString(self$accrualTime), ") must be > 0",
                     functionName = ".validateAccrualTimeAndIntensity",
                     parameter = "accrualTime",
                     value = self$accrualTime
@@ -2626,7 +2662,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
             .assertValuesAreStrictlyIncreasing(self$accrualTime, "accrualTime")
 
             if ((length(self$accrualTime) > 1) && any(self$accrualIntensity < 0)) {
-                stopIllegalArgument("'accrualIntensity' (", .arrayToString(self$accrualIntensity), ") must be >= 0",
+                stopIllegalArgument(
+                    "'accrualIntensity' (", .arrayToString(self$accrualIntensity), ") must be >= 0",
                     functionName = ".validateAccrualTimeAndIntensity",
                     parameter = "accrualIntensity",
                     value = self$accrualIntensity
@@ -2635,7 +2672,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
 
             if (length(self$accrualIntensity) == 1 && !is.na(self$accrualIntensity) &&
                     self$accrualIntensity == 0) {
-                stopIllegalArgument("at least one 'accrualIntensity' value must be > 0",
+                stopIllegalArgument(
+                    "at least one 'accrualIntensity' value must be > 0",
                     functionName = ".validateAccrualTimeAndIntensity",
                     parameter = "accrualIntensity"
                 )

--- a/R/class_time.R
+++ b/R/class_time.R
@@ -536,7 +536,7 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
             } else {
                 self$.silent <- FALSE
             }
-            
+
             self$piecewiseSurvivalEnabled <- FALSE
             self$delayedResponseEnabled <- FALSE
 
@@ -614,8 +614,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                         getPiByMedian(self$median1, eventTime = self$eventTime, kappa = self$kappa),
                         5
                     ), ", but is ", round(self$pi1, 5),
-                    functionName = ".validateCalculatedArguments", 
-		parameter ="pi1",
+                    functionName = ".validateCalculatedArguments",
+                    parameter = "pi1",
                     value = self$pi1
                     )
                 }
@@ -627,8 +627,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                     ), self$lambda2, tolerance = 1e-05))) {
                     stopRuntimeIssue("'lambda2' must be ", round(getLambdaByMedian(self$median2, kappa = self$kappa), 5),
                         ", ", "but is ", round(self$lambda2, 5),
-                        functionName = ".validateCalculatedArguments", 
-		parameter ="lambda2",
+                        functionName = ".validateCalculatedArguments",
+                        parameter = "lambda2",
                         value = self$lambda2
                     )
                 }
@@ -641,8 +641,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                         getPiByMedian(self$median2, eventTime = self$eventTime, kappa = self$kappa),
                         5
                     ), ", but is ", round(self$pi2, 5),
-                    functionName = ".validateCalculatedArguments", 
-		parameter ="pi2",
+                    functionName = ".validateCalculatedArguments",
+                    parameter = "pi2",
                     value = self$pi2
                     )
                 }
@@ -661,8 +661,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                 if (self$.getParameterType("pi1") != C_PARAM_NOT_APPLICABLE) {
                     stopRuntimeIssue("parameter type of 'pi1' (", self$.getParameterType("pi1"),
                         ") must be C_PARAM_NOT_APPLICABLE",
-                        functionName = ".validateCalculatedArguments", 
-		parameter ="pi1"
+                        functionName = ".validateCalculatedArguments",
+                        parameter = "pi1"
                     )
                 }
                 if (!anyNA(self$pi1)) {
@@ -2119,9 +2119,10 @@ AccrualTime <- R6::R6Class("AccrualTime",
         },
         .initFromList = function(accrualTimeList) {
             if (!is.list(accrualTimeList)) {
-                stopIllegalArgument("'accrualTime' must be a list", 
-		functionName = ".initFromList", 
-		parameter ="accrualTime")
+                stopIllegalArgument("'accrualTime' must be a list",
+                    functionName = ".initFromList",
+                    parameter = "accrualTime"
+                )
             }
 
             if (length(accrualTimeList) == 0) {
@@ -2257,8 +2258,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
             if (length(accrualTimeArg) == 0 || anyNA(accrualTimeArg) ||
                     !all(is.numeric(accrualTimeArg))) {
                 stopRuntimeIssue("'accrualTimeArg' must a be valid numeric vector",
-                    functionName = ".isNoPiecewiseAccrualTime", 
-		parameter ="accrualTimeArg",
+                    functionName = ".isNoPiecewiseAccrualTime",
+                    parameter = "accrualTimeArg",
                     value = accrualTimeArg
                 )
             }
@@ -2343,8 +2344,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
 
                 if (self$accrualTime[1] != 0) {
                     stopIllegalArgument("the first value of 'accrualTime' (", .arrayToString(self$accrualTime), ") must be 0",
-                        functionName = ".init", 
-		parameter ="accrualTime", value = self$accrualTime
+                        functionName = ".init",
+                        parameter = "accrualTime", value = self$accrualTime
                     )
                 }
 
@@ -2430,8 +2431,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                                     stopConflictingArguments("'maxNumberOfSubjects' (", self$maxNumberOfSubjects,
                                         ") disagrees with ", "the defined accrual time and intensity: ",
                                         self$.getFormula(), " = ", sampleSize,
-                                        functionName = ".init", 
-		parameter ="maxNumberOfSubjects",
+                                        functionName = ".init",
+                                        parameter = "maxNumberOfSubjects",
                                         value = self$maxNumberOfSubjects
                                     )
                                 } else {

--- a/R/class_time.R
+++ b/R/class_time.R
@@ -614,7 +614,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                         getPiByMedian(self$median1, eventTime = self$eventTime, kappa = self$kappa),
                         5
                     ), ", but is ", round(self$pi1, 5),
-                    functionName = ".validateCalculatedArguments", parameter = "pi1",
+                    functionName = ".validateCalculatedArguments", 
+		parameter ="pi1",
                     value = self$pi1
                     )
                 }
@@ -626,7 +627,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                     ), self$lambda2, tolerance = 1e-05))) {
                     stopRuntimeIssue("'lambda2' must be ", round(getLambdaByMedian(self$median2, kappa = self$kappa), 5),
                         ", ", "but is ", round(self$lambda2, 5),
-                        functionName = ".validateCalculatedArguments", parameter = "lambda2",
+                        functionName = ".validateCalculatedArguments", 
+		parameter ="lambda2",
                         value = self$lambda2
                     )
                 }
@@ -639,7 +641,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                         getPiByMedian(self$median2, eventTime = self$eventTime, kappa = self$kappa),
                         5
                     ), ", but is ", round(self$pi2, 5),
-                    functionName = ".validateCalculatedArguments", parameter = "pi2",
+                    functionName = ".validateCalculatedArguments", 
+		parameter ="pi2",
                     value = self$pi2
                     )
                 }
@@ -658,7 +661,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                 if (self$.getParameterType("pi1") != C_PARAM_NOT_APPLICABLE) {
                     stopRuntimeIssue("parameter type of 'pi1' (", self$.getParameterType("pi1"),
                         ") must be C_PARAM_NOT_APPLICABLE",
-                        functionName = ".validateCalculatedArguments", parameter = "pi1"
+                        functionName = ".validateCalculatedArguments", 
+		parameter ="pi1"
                     )
                 }
                 if (!anyNA(self$pi1)) {
@@ -703,8 +707,8 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
         },
         .stopInCaseOfConflictingArguments = function(arg1, argName1, arg2, argName2) {
             if (length(arg1) > 0 && !all(is.na(arg1)) && length(arg2) > 0 && !all(is.na(arg2))) {
-                stopConflictingArguments("it is not allowed to specify '", argName1, "' (", .arrayToString(arg1), ")",
-                    " and '", argName2, "' (", .arrayToString(arg2), ") concurrently",
+                stopConflictingArguments("it is not allowed to specify ", .pQuote(argName1), " (", .arrayToString(arg1), ")",
+                    " and ", .pQuote(argName2), " (", .arrayToString(arg2), ") concurrently",
                     functionName = ".stopInCaseOfConflictingArguments",
                     parameter = "argName1",
                     value = argName1,
@@ -1268,7 +1272,7 @@ PiecewiseSurvivalTime <- R6::R6Class("PiecewiseSurvivalTime",
                         paramName <- paste0(param, group)
                         if (self$isUserDefinedParameter(paramName)) {
                             warning(
-                                "'", paramName, "' (", .arrayToString(self[[paramName]]), ") ",
+                                .pQuote(paramName), " (", .arrayToString(self[[paramName]]), ") ",
                                 "was converted to 'lambda", group, "' ",
                                 "and is not available in output because piecewise ",
                                 "exponential survival time is enabled"
@@ -2115,7 +2119,9 @@ AccrualTime <- R6::R6Class("AccrualTime",
         },
         .initFromList = function(accrualTimeList) {
             if (!is.list(accrualTimeList)) {
-                stopIllegalArgument("'accrualTime' must be a list", functionName = ".initFromList", parameter = "accrualTime")
+                stopIllegalArgument("'accrualTime' must be a list", 
+		functionName = ".initFromList", 
+		parameter ="accrualTime")
             }
 
             if (length(accrualTimeList) == 0) {
@@ -2251,7 +2257,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
             if (length(accrualTimeArg) == 0 || anyNA(accrualTimeArg) ||
                     !all(is.numeric(accrualTimeArg))) {
                 stopRuntimeIssue("'accrualTimeArg' must a be valid numeric vector",
-                    functionName = ".isNoPiecewiseAccrualTime", parameter = "accrualTimeArg",
+                    functionName = ".isNoPiecewiseAccrualTime", 
+		parameter ="accrualTimeArg",
                     value = accrualTimeArg
                 )
             }
@@ -2336,7 +2343,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
 
                 if (self$accrualTime[1] != 0) {
                     stopIllegalArgument("the first value of 'accrualTime' (", .arrayToString(self$accrualTime), ") must be 0",
-                        functionName = ".init", parameter = "accrualTime", value = self$accrualTime
+                        functionName = ".init", 
+		parameter ="accrualTime", value = self$accrualTime
                     )
                 }
 
@@ -2422,7 +2430,8 @@ AccrualTime <- R6::R6Class("AccrualTime",
                                     stopConflictingArguments("'maxNumberOfSubjects' (", self$maxNumberOfSubjects,
                                         ") disagrees with ", "the defined accrual time and intensity: ",
                                         self$.getFormula(), " = ", sampleSize,
-                                        functionName = ".init", parameter = "maxNumberOfSubjects",
+                                        functionName = ".init", 
+		parameter ="maxNumberOfSubjects",
                                         value = self$maxNumberOfSubjects
                                     )
                                 } else {

--- a/R/data.R
+++ b/R/data.R
@@ -18,7 +18,8 @@
 #' One-Arm Dataset of Means
 #'
 #' A dataset containing the sample sizes, means, and standard deviations of one group.
-#' Use \code{getDataset(dataMeans)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataMeans)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -29,7 +30,8 @@
 #' One-Arm Dataset of Rates
 #'
 #' A dataset containing the sample sizes and events of one group.
-#' Use \code{getDataset(dataRates)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataRates)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -40,7 +42,8 @@
 #' One-Arm Dataset of Survival Data
 #'
 #' A dataset containing the log-rank statistics, events, and allocation ratios of one group.
-#' Use \code{getDataset(dataSurvival)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataSurvival)} to create a dataset object that can b
+#' e processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -53,7 +56,8 @@
 #' Multi-Arm Dataset of Means
 #'
 #' A dataset containing the sample sizes, means, and standard deviations of four groups.
-#' Use \code{getDataset(dataMultiArmMeans)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataMultiArmMeans)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -64,7 +68,8 @@
 #' Multi-Arm Dataset of Rates
 #'
 #' A dataset containing the sample sizes and events of three groups.
-#' Use \code{getDataset(dataMultiArmRates)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataMultiArmRates)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -75,7 +80,8 @@
 #' Multi-Arm Dataset of Survival Data
 #'
 #' A dataset containing the log-rank statistics, events, and allocation ratios of three groups.
-#' Use \code{getDataset(dataMultiArmSurvival)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataMultiArmSurvival)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -88,7 +94,8 @@
 #' Enrichment Dataset of Means
 #'
 #' A dataset containing the sample sizes, means, and standard deviations of two groups.
-#' Use \code{getDataset(dataEnrichmentMeans)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataEnrichmentMeans)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -99,7 +106,8 @@
 #' Enrichment Dataset of Rates
 #'
 #' A dataset containing the sample sizes and events of two groups.
-#' Use \code{getDataset(dataEnrichmentRates)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataEnrichmentRates)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -110,7 +118,8 @@
 #' Enrichment Dataset of Survival Data
 #'
 #' A dataset containing the log-rank statistics, events, and allocation ratios of two groups.
-#' Use \code{getDataset(dataEnrichmentSurvival)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataEnrichmentSurvival)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -123,7 +132,8 @@
 #' Stratified Enrichment Dataset of Means
 #'
 #' A dataset containing the sample sizes, means, and standard deviations of two groups.
-#' Use \code{getDataset(dataEnrichmentMeansStratified)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataEnrichmentMeansStratified)} to create a dataset object that can 
+#' be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -134,7 +144,8 @@
 #' Stratified Enrichment Dataset of Rates
 #'
 #' A dataset containing the sample sizes and events of two groups.
-#' Use \code{getDataset(dataEnrichmentRatesStratified)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataEnrichmentRatesStratified)} to create a dataset object that 
+#' can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'
@@ -145,7 +156,8 @@
 #' Stratified Enrichment Dataset of Survival Data
 #'
 #' A dataset containing the log-rank statistics, events, and allocation ratios of two groups.
-#' Use \code{getDataset(dataEnrichmentSurvivalStratified)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+#' Use \code{getDataset(dataEnrichmentSurvivalStratified)} to create a dataset object that 
+#' can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 #'
 #' @format A \code{\link[base]{data.frame}} object.
 #'

--- a/R/f_analysis_base.R
+++ b/R/f_analysis_base.R
@@ -499,7 +499,8 @@ getStageResults <- function(
 getTestActions <- function(stageResults, ...) {
     .warnInCaseOfUnknownArguments(functionName = "getTestActions", ...)
 
-    stageResults <- .getStageResultsObject(stageResults, functionName = "getTestActions", ...)
+    stageResults <- .getStageResultsObject(stageResults, 
+		functionName = "getTestActions", ...)
     .assertIsStageResultsNonMultiHypotheses(stageResults)
     design <- stageResults$.design
     criticalValues <- .getCriticalValues(design)
@@ -863,7 +864,8 @@ getConditionalPower <- function(
         ...,
         nPlanned,
         allocationRatioPlanned = 1) {
-    stageResults <- .getStageResultsObject(stageResults = stageResults, functionName = "getConditionalPower", ...)
+    stageResults <- .getStageResultsObject(stageResults = stageResults, 
+		functionName = "getConditionalPower", ...)
     .assertIsValidAllocationRatioPlanned(allocationRatioPlanned, stageResults$.dataInput$getNumberOfGroups())
 
     conditionalPower <- NULL
@@ -1040,7 +1042,8 @@ getConditionalPower <- function(
 getRepeatedPValues <- function(stageResults, ..., tolerance = 1e-06) {
     .assertIsValidTolerance(tolerance)
     .assertIsValidTolerance(tolerance)
-    stageResults <- .getStageResultsObject(stageResults, functionName = "getRepeatedPValues", ...)
+    stageResults <- .getStageResultsObject(stageResults, 
+		functionName = "getRepeatedPValues", ...)
 
     if (.isEnrichmentStageResults(stageResults)) {
         return(.getRepeatedPValuesEnrichment(stageResults = stageResults, tolerance = tolerance, ...))
@@ -1090,8 +1093,8 @@ getRepeatedPValues <- function(stageResults, ..., tolerance = 1e-06) {
 
     if (.isTrialDesignFisher(design)) {
         if (design$method == C_FISHER_METHOD_USER_DEFINED_ALPHA) {
-            warning("Repeated p-values not available for 'method' = '",
-                C_FISHER_METHOD_USER_DEFINED_ALPHA, "'",
+            warning("Repeated p-values not available for 'method' = ", 
+                .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA),
                 call. = FALSE
             )
             return(rep(NA_real_, design$kMax))
@@ -1476,7 +1479,8 @@ getRepeatedPValues <- function(stageResults, ..., tolerance = 1e-06) {
 #' @export
 #'
 getFinalPValue <- function(stageResults, ...) {
-    stageResults <- .getStageResultsObject(stageResults, functionName = "getFinalPValue", ...)
+    stageResults <- .getStageResultsObject(stageResults, 
+		functionName = "getFinalPValue", ...)
 
     .assertIsStageResultsNonMultiHypotheses(stageResults)
 
@@ -2425,7 +2429,7 @@ getConditionalRejectionProbabilities <- function(stageResults, ...) {
             } else if (case == "medianUnbiasedGeneral") {
                 return(sum(probs[3, ] - probs[2, ]) - 0.50)
             } else {
-                stopRuntimeIssue("'case' = '", case, "' is not implemented",
+                stopRuntimeIssue("'case' = ", .vQuote(case), " is not implemented",
                     functionName = ".getDecisionMatrixRoot",
                     parameter = "case", value = case
                 )

--- a/R/f_analysis_base.R
+++ b/R/f_analysis_base.R
@@ -499,8 +499,9 @@ getStageResults <- function(
 getTestActions <- function(stageResults, ...) {
     .warnInCaseOfUnknownArguments(functionName = "getTestActions", ...)
 
-    stageResults <- .getStageResultsObject(stageResults, 
-		functionName = "getTestActions", ...)
+    stageResults <- .getStageResultsObject(stageResults,
+        functionName = "getTestActions", ...
+    )
     .assertIsStageResultsNonMultiHypotheses(stageResults)
     design <- stageResults$.design
     criticalValues <- .getCriticalValues(design)
@@ -864,8 +865,10 @@ getConditionalPower <- function(
         ...,
         nPlanned,
         allocationRatioPlanned = 1) {
-    stageResults <- .getStageResultsObject(stageResults = stageResults, 
-		functionName = "getConditionalPower", ...)
+    stageResults <- .getStageResultsObject(
+        stageResults = stageResults,
+        functionName = "getConditionalPower", ...
+    )
     .assertIsValidAllocationRatioPlanned(allocationRatioPlanned, stageResults$.dataInput$getNumberOfGroups())
 
     conditionalPower <- NULL
@@ -1042,8 +1045,9 @@ getConditionalPower <- function(
 getRepeatedPValues <- function(stageResults, ..., tolerance = 1e-06) {
     .assertIsValidTolerance(tolerance)
     .assertIsValidTolerance(tolerance)
-    stageResults <- .getStageResultsObject(stageResults, 
-		functionName = "getRepeatedPValues", ...)
+    stageResults <- .getStageResultsObject(stageResults,
+        functionName = "getRepeatedPValues", ...
+    )
 
     if (.isEnrichmentStageResults(stageResults)) {
         return(.getRepeatedPValuesEnrichment(stageResults = stageResults, tolerance = tolerance, ...))
@@ -1093,7 +1097,7 @@ getRepeatedPValues <- function(stageResults, ..., tolerance = 1e-06) {
 
     if (.isTrialDesignFisher(design)) {
         if (design$method == C_FISHER_METHOD_USER_DEFINED_ALPHA) {
-            warning("Repeated p-values not available for 'method' = ", 
+            warning("Repeated p-values not available for 'method' = ",
                 .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA),
                 call. = FALSE
             )
@@ -1479,8 +1483,9 @@ getRepeatedPValues <- function(stageResults, ..., tolerance = 1e-06) {
 #' @export
 #'
 getFinalPValue <- function(stageResults, ...) {
-    stageResults <- .getStageResultsObject(stageResults, 
-		functionName = "getFinalPValue", ...)
+    stageResults <- .getStageResultsObject(stageResults,
+        functionName = "getFinalPValue", ...
+    )
 
     .assertIsStageResultsNonMultiHypotheses(stageResults)
 

--- a/R/f_analysis_base_means.R
+++ b/R/f_analysis_base_means.R
@@ -812,11 +812,13 @@ NULL
 
         maxSearchIterations <- maxSearchIterations - 1
         if (maxSearchIterations < 0) {
-            stopRuntimeIssue(sprintf(
-                paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
-                stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
-            ), 
-		functionName = ".getUpperLowerThetaMeans")
+            stopRuntimeIssue(
+                sprintf(
+                    paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
+                    stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
+                ),
+                functionName = ".getUpperLowerThetaMeans"
+            )
         }
     }
 

--- a/R/f_analysis_base_means.R
+++ b/R/f_analysis_base_means.R
@@ -814,7 +814,8 @@ NULL
         if (maxSearchIterations < 0) {
             stopRuntimeIssue(
                 sprintf(
-                    paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
+                    paste0("failed to find theta (k = %s, firstValue = %s, ", 
+                        "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
                     stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
                 ),
                 functionName = ".getUpperLowerThetaMeans"
@@ -1808,7 +1809,8 @@ NULL
                 )
             }
 
-            firstParameterName <- ifelse(.isTrialDesignGroupSequential(design), "overallPValues", "combInverseNormal")
+            firstParameterName <- ifelse(.isTrialDesignGroupSequential(design), 
+                "overallPValues", "combInverseNormal")
 
             finalConfidenceIntervalGeneral[1] <- .getDecisionMatrixRoot(
                 design = design,

--- a/R/f_analysis_base_means.R
+++ b/R/f_analysis_base_means.R
@@ -815,7 +815,8 @@ NULL
             stopRuntimeIssue(sprintf(
                 paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
                 stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
-            ), functionName = ".getUpperLowerThetaMeans")
+            ), 
+		functionName = ".getUpperLowerThetaMeans")
         }
     }
 

--- a/R/f_analysis_base_rates.R
+++ b/R/f_analysis_base_rates.R
@@ -478,7 +478,9 @@ NULL
 
     if (dataInput$getNumberOfGroups() == 1) {
         if (is.na(thetaH0)) {
-            stopMissingArgument("'thetaH0' must be defined", functionName = ".getStageResultsRates", parameter = "thetaH0", value = thetaH0)
+            stopMissingArgument("'thetaH0' must be defined", 
+		functionName = ".getStageResultsRates", 
+		parameter ="thetaH0", value = thetaH0)
         }
 
         if (normalApproximation) {
@@ -586,7 +588,8 @@ NULL
                 )
             } else {
                 if (thetaH0 != 0) {
-                    stopConflictingArguments("thetaH0 must be equal 0 for performing Fisher's exact test", functionName = ".getStageResultsRates")
+                    stopConflictingArguments("thetaH0 must be equal 0 for performing Fisher's exact test", 
+		functionName = ".getStageResultsRates")
                 }
 
                 overallPValues[k] <- stats::phyper(

--- a/R/f_analysis_base_rates.R
+++ b/R/f_analysis_base_rates.R
@@ -478,9 +478,10 @@ NULL
 
     if (dataInput$getNumberOfGroups() == 1) {
         if (is.na(thetaH0)) {
-            stopMissingArgument("'thetaH0' must be defined", 
-		functionName = ".getStageResultsRates", 
-		parameter ="thetaH0", value = thetaH0)
+            stopMissingArgument("'thetaH0' must be defined",
+                functionName = ".getStageResultsRates",
+                parameter = "thetaH0", value = thetaH0
+            )
         }
 
         if (normalApproximation) {
@@ -588,8 +589,9 @@ NULL
                 )
             } else {
                 if (thetaH0 != 0) {
-                    stopConflictingArguments("thetaH0 must be equal 0 for performing Fisher's exact test", 
-		functionName = ".getStageResultsRates")
+                    stopConflictingArguments("thetaH0 must be equal 0 for performing Fisher's exact test",
+                        functionName = ".getStageResultsRates"
+                    )
                 }
 
                 overallPValues[k] <- stats::phyper(

--- a/R/f_analysis_base_survival.R
+++ b/R/f_analysis_base_survival.R
@@ -568,11 +568,13 @@ NULL
 
         maxSearchIterations <- maxSearchIterations - 1
         if (maxSearchIterations < 0) {
-            stopRuntimeIssue(sprintf(
-                paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
-                stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
-            ), 
-		functionName = ".getUpperLowerThetaSurvival")
+            stopRuntimeIssue(
+                sprintf(
+                    paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
+                    stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
+                ),
+                functionName = ".getUpperLowerThetaSurvival"
+            )
         }
     }
 

--- a/R/f_analysis_base_survival.R
+++ b/R/f_analysis_base_survival.R
@@ -571,7 +571,8 @@ NULL
             stopRuntimeIssue(sprintf(
                 paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
                 stage, stageResults[[firstParameterName]][stage], secondValue, firstValue, theta
-            ), functionName = ".getUpperLowerThetaSurvival")
+            ), 
+		functionName = ".getUpperLowerThetaSurvival")
         }
     }
 

--- a/R/f_analysis_boundary_recalculation.R
+++ b/R/f_analysis_boundary_recalculation.R
@@ -369,7 +369,8 @@ getObservedInformationRates <- function(
 
     stageFromData <- dataInput$getNumberOfStages()
     if (stageFromData == 1) {
-        stopIllegalArgument("recalculation of the information rates not possible at stage 1", functionName = ".getDesignWithRecalculatedBoundaries")
+        stopIllegalArgument("recalculation of the information rates not possible at stage 1", 
+		functionName = ".getDesignWithRecalculatedBoundaries")
     }
 
     if (!(getLogLevel() %in% c(C_LOG_LEVEL_DISABLED, C_LOG_LEVEL_PROGRESS))) {

--- a/R/f_analysis_boundary_recalculation.R
+++ b/R/f_analysis_boundary_recalculation.R
@@ -369,8 +369,9 @@ getObservedInformationRates <- function(
 
     stageFromData <- dataInput$getNumberOfStages()
     if (stageFromData == 1) {
-        stopIllegalArgument("recalculation of the information rates not possible at stage 1", 
-		functionName = ".getDesignWithRecalculatedBoundaries")
+        stopIllegalArgument("recalculation of the information rates not possible at stage 1",
+            functionName = ".getDesignWithRecalculatedBoundaries"
+        )
     }
 
     if (!(getLogLevel() %in% c(C_LOG_LEVEL_DISABLED, C_LOG_LEVEL_PROGRESS))) {

--- a/R/f_analysis_boundary_recalculation.R
+++ b/R/f_analysis_boundary_recalculation.R
@@ -332,7 +332,8 @@ getObservedInformationRates <- function(
     }
 
     if (design$typeOfDesign == "asUser") {
-        stopIllegalArgument("recalculation of the information rates not possible ", "for user-defined alpha spending designs",
+        stopIllegalArgument("recalculation of the information rates not possible ", 
+            "for user-defined alpha spending designs",
             functionName = ".getDesignWithRecalculatedBoundaries"
         )
     }

--- a/R/f_analysis_enrichment.R
+++ b/R/f_analysis_enrichment.R
@@ -266,8 +266,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalRejectionProbabilitiesEnrichment", 
-		parameter ="design"
+        functionName = ".getConditionalRejectionProbabilitiesEnrichment",
+        parameter = "design"
     )
 }
 

--- a/R/f_analysis_enrichment.R
+++ b/R/f_analysis_enrichment.R
@@ -266,7 +266,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalRejectionProbabilitiesEnrichment", parameter = "design"
+        functionName = ".getConditionalRejectionProbabilitiesEnrichment", 
+		parameter ="design"
     )
 }
 

--- a/R/f_analysis_enrichment_means.R
+++ b/R/f_analysis_enrichment_means.R
@@ -225,26 +225,30 @@ NULL
 
     if ((gMax > 2) && intersectionTest == "SpiessensDebois") {
         stopIllegalArgument("gMax (", gMax, ") > 2: Spiessens & Debois intersection test test can only be used for one subset",
-            functionName = ".getStageResultsMeansEnrichment", parameter = "gMax", value = gMax
+            functionName = ".getStageResultsMeansEnrichment", 
+		parameter ="gMax", value = gMax
         )
     }
     if (varianceOption == "pooledFromFull") {
         if (gMax > 2) {
             stopIllegalArgument("gMax (", gMax, ") > 2: varianceOption 'pooledFromFull' can only be used for one subset",
-                functionName = ".getStageResultsMeansEnrichment", parameter = "pooledFromFull"
+                functionName = ".getStageResultsMeansEnrichment", 
+		parameter ="pooledFromFull"
             )
         }
     }
 
     if (intersectionTest == "SpiessensDebois" && varianceOption != "pooledFromFull" && !normalApproximation) {
         stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", "residual (stratified) variance from full population,\n\t\t\t select 'varianceOption' = \"pooledFromFull\"",
-            parameter = "varianceOption", value = varianceOption, constraint = "pooledFromFull", functionName = ".getStageResultsMeansEnrichment"
+            parameter = "varianceOption", value = varianceOption, constraint = "pooledFromFull", 
+		functionName = ".getStageResultsMeansEnrichment"
         )
     }
 
     if (intersectionTest == "SpiessensDebois" && !stratifiedAnalysis && !normalApproximation) {
         stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", "residual (stratified) variance from full population,\n\t\t\tselect 'stratifiedAnalysis' = TRUE",
-            parameter = "stratifiedAnalysis", value = stratifiedAnalysis, constraint = TRUE, functionName = ".getStageResultsMeansEnrichment"
+            parameter = "stratifiedAnalysis", value = stratifiedAnalysis, constraint = TRUE, 
+		functionName = ".getStageResultsMeansEnrichment"
         )
     }
 
@@ -786,7 +790,8 @@ NULL
             stopRuntimeIssue(sprintf(
                 paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
                 stage, stageResults[[firstParameterName]][population, stage], secondValue, firstValue, theta
-            ), functionName = ".getUpperLowerThetaMeansEnrichment")
+            ), 
+		functionName = ".getUpperLowerThetaMeansEnrichment")
         }
     }
 
@@ -1162,8 +1167,11 @@ NULL
                 paste0("length of 'thetaH1' (%s) ", "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(thetaH1), gMax
             ),
-            functionName = ".getConditionalPowerMeansEnrichment", parameter = "thetaH1",
-            value = thetaH1, relatedParameter = "gMax", relatedValue = gMax
+            functionName = ".getConditionalPowerMeansEnrichment", 
+		parameter ="thetaH1",
+            value = thetaH1, 
+		relatedParameter ="gMax", 
+		relatedValue = gMax
         )
     }
 
@@ -1182,7 +1190,8 @@ NULL
     if (length(thetaH1) > 1) {
         if (any(is.na(thetaH1[!is.na(stageResults$testStatistics[, stage])]))) {
             stopIllegalArgument("any of 'thetaH1' not correctly specified",
-                functionName = ".getConditionalPowerMeansEnrichment", parameter = "thetaH1",
+                functionName = ".getConditionalPowerMeansEnrichment", 
+		parameter ="thetaH1",
                 value = thetaH1
             )
         }
@@ -1208,7 +1217,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalPowerMeansEnrichment", parameter = "design"
+        functionName = ".getConditionalPowerMeansEnrichment", 
+		parameter ="design"
     )
 }
 

--- a/R/f_analysis_enrichment_means.R
+++ b/R/f_analysis_enrichment_means.R
@@ -225,30 +225,30 @@ NULL
 
     if ((gMax > 2) && intersectionTest == "SpiessensDebois") {
         stopIllegalArgument("gMax (", gMax, ") > 2: Spiessens & Debois intersection test test can only be used for one subset",
-            functionName = ".getStageResultsMeansEnrichment", 
-		parameter ="gMax", value = gMax
+            functionName = ".getStageResultsMeansEnrichment",
+            parameter = "gMax", value = gMax
         )
     }
     if (varianceOption == "pooledFromFull") {
         if (gMax > 2) {
             stopIllegalArgument("gMax (", gMax, ") > 2: varianceOption 'pooledFromFull' can only be used for one subset",
-                functionName = ".getStageResultsMeansEnrichment", 
-		parameter ="pooledFromFull"
+                functionName = ".getStageResultsMeansEnrichment",
+                parameter = "pooledFromFull"
             )
         }
     }
 
     if (intersectionTest == "SpiessensDebois" && varianceOption != "pooledFromFull" && !normalApproximation) {
         stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", "residual (stratified) variance from full population,\n\t\t\t select 'varianceOption' = \"pooledFromFull\"",
-            parameter = "varianceOption", value = varianceOption, constraint = "pooledFromFull", 
-		functionName = ".getStageResultsMeansEnrichment"
+            parameter = "varianceOption", value = varianceOption, constraint = "pooledFromFull",
+            functionName = ".getStageResultsMeansEnrichment"
         )
     }
 
     if (intersectionTest == "SpiessensDebois" && !stratifiedAnalysis && !normalApproximation) {
         stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", "residual (stratified) variance from full population,\n\t\t\tselect 'stratifiedAnalysis' = TRUE",
-            parameter = "stratifiedAnalysis", value = stratifiedAnalysis, constraint = TRUE, 
-		functionName = ".getStageResultsMeansEnrichment"
+            parameter = "stratifiedAnalysis", value = stratifiedAnalysis, constraint = TRUE,
+            functionName = ".getStageResultsMeansEnrichment"
         )
     }
 
@@ -787,11 +787,13 @@ NULL
         firstValue <- stageResults[[firstParameterName]][population, stage]
         maxSearchIterations <- maxSearchIterations - 1
         if (maxSearchIterations < 0) {
-            stopRuntimeIssue(sprintf(
-                paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
-                stage, stageResults[[firstParameterName]][population, stage], secondValue, firstValue, theta
-            ), 
-		functionName = ".getUpperLowerThetaMeansEnrichment")
+            stopRuntimeIssue(
+                sprintf(
+                    paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
+                    stage, stageResults[[firstParameterName]][population, stage], secondValue, firstValue, theta
+                ),
+                functionName = ".getUpperLowerThetaMeansEnrichment"
+            )
         }
     }
 
@@ -1167,11 +1169,11 @@ NULL
                 paste0("length of 'thetaH1' (%s) ", "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(thetaH1), gMax
             ),
-            functionName = ".getConditionalPowerMeansEnrichment", 
-		parameter ="thetaH1",
-            value = thetaH1, 
-		relatedParameter ="gMax", 
-		relatedValue = gMax
+            functionName = ".getConditionalPowerMeansEnrichment",
+            parameter = "thetaH1",
+            value = thetaH1,
+            relatedParameter = "gMax",
+            relatedValue = gMax
         )
     }
 
@@ -1190,8 +1192,8 @@ NULL
     if (length(thetaH1) > 1) {
         if (any(is.na(thetaH1[!is.na(stageResults$testStatistics[, stage])]))) {
             stopIllegalArgument("any of 'thetaH1' not correctly specified",
-                functionName = ".getConditionalPowerMeansEnrichment", 
-		parameter ="thetaH1",
+                functionName = ".getConditionalPowerMeansEnrichment",
+                parameter = "thetaH1",
                 value = thetaH1
             )
         }
@@ -1217,8 +1219,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalPowerMeansEnrichment", 
-		parameter ="design"
+        functionName = ".getConditionalPowerMeansEnrichment",
+        parameter = "design"
     )
 }
 

--- a/R/f_analysis_enrichment_means.R
+++ b/R/f_analysis_enrichment_means.R
@@ -239,14 +239,16 @@ NULL
     }
 
     if (intersectionTest == "SpiessensDebois" && varianceOption != "pooledFromFull" && !normalApproximation) {
-        stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", "residual (stratified) variance from full population,\n\t\t\t select 'varianceOption' = \"pooledFromFull\"",
+        stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", 
+            "residual (stratified) variance from full population,\n\t\t\t select 'varianceOption' = \"pooledFromFull\"",
             parameter = "varianceOption", value = varianceOption, constraint = "pooledFromFull",
             functionName = ".getStageResultsMeansEnrichment"
         )
     }
 
     if (intersectionTest == "SpiessensDebois" && !stratifiedAnalysis && !normalApproximation) {
-        stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", "residual (stratified) variance from full population,\n\t\t\tselect 'stratifiedAnalysis' = TRUE",
+        stopIllegalArgument("Spiessens & Depois t test can only be performed with pooled ", 
+            "residual (stratified) variance from full population,\n\t\t\tselect 'stratifiedAnalysis' = TRUE",
             parameter = "stratifiedAnalysis", value = stratifiedAnalysis, constraint = TRUE,
             functionName = ".getStageResultsMeansEnrichment"
         )
@@ -789,7 +791,8 @@ NULL
         if (maxSearchIterations < 0) {
             stopRuntimeIssue(
                 sprintf(
-                    paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
+                    paste0("failed to find theta (k = %s, firstValue = %s, ", 
+                        "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
                     stage, stageResults[[firstParameterName]][population, stage], secondValue, firstValue, theta
                 ),
                 functionName = ".getUpperLowerThetaMeansEnrichment"
@@ -1020,7 +1023,8 @@ NULL
     .warnInCaseOfUnknownArguments(
         functionName =
             ".getRepeatedConfidenceIntervalsMeansEnrichmentInverseNormal",
-        ignore = c(.getDesignArgumentsToIgnoreAtUnknownArgumentCheck(design, powerCalculationEnabled = TRUE), "stage"), ...
+        ignore = c(.getDesignArgumentsToIgnoreAtUnknownArgumentCheck(
+            design, powerCalculationEnabled = TRUE), "stage"), ...
     )
 
     return(.getRepeatedConfidenceIntervalsMeansEnrichmentAll(

--- a/R/f_analysis_enrichment_rates.R
+++ b/R/f_analysis_enrichment_rates.R
@@ -219,7 +219,8 @@ NULL
     }
 
     if (intersectionTest == "SpiessensDebois" && !normalApproximation) {
-        stopIllegalArgument("Spiessens & Debois test cannot be used with Fisher's ", "exact test (normalApproximation = FALSE)",
+        stopIllegalArgument("Spiessens & Debois test cannot be used with Fisher's ",
+            "exact test (normalApproximation = FALSE)",
             functionName = ".getStageResultsRatesEnrichment"
         )
     }
@@ -1022,7 +1023,10 @@ NULL
     if ((length(piTreatments) != 1) && (length(piTreatments) != gMax)) {
         stopIllegalArgument(
             sprintf(
-                paste0("length of 'piTreatments' (%s) ", "must be equal to 'gMax' (%s) or 1"),
+                paste0(
+                    "length of 'piTreatments' (%s) ",
+                    "must be equal to 'gMax' (%s) or 1"
+                ),
                 .arrayToString(piTreatments), gMax
             ),
             functionName = ".getConditionalPowerRatesEnrichment",
@@ -1036,7 +1040,10 @@ NULL
     if ((length(piControls) != 1) && (length(piControls) != gMax)) {
         stopIllegalArgument(
             sprintf(
-                paste0("length of 'piControls' (%s) ", "must be equal to 'gMax' (%s) or 1"),
+                paste0(
+                    "length of 'piControls' (%s) ",
+                    "must be equal to 'gMax' (%s) or 1"
+                ),
                 .arrayToString(piControls), gMax
             ),
             functionName = ".getConditionalPowerRatesEnrichment",

--- a/R/f_analysis_enrichment_rates.R
+++ b/R/f_analysis_enrichment_rates.R
@@ -213,7 +213,8 @@ NULL
 
     if ((gMax > 2) && intersectionTest == "SpiessensDebois") {
         stopIllegalArgument("gMax (", gMax, ") > 2: Spiessens & Debois intersection test test can only be used for one subset",
-            functionName = ".getStageResultsRatesEnrichment", parameter = "gMax", value = gMax
+            functionName = ".getStageResultsRatesEnrichment", 
+		parameter ="gMax", value = gMax
         )
     }
 
@@ -224,11 +225,13 @@ NULL
     }
 
     if (stratifiedAnalysis && !normalApproximation) {
-        stopConflictingArguments("stratified version is not available for Fisher's exact test", functionName = ".getStageResultsRatesEnrichment")
+        stopConflictingArguments("stratified version is not available for Fisher's exact test", 
+		functionName = ".getStageResultsRatesEnrichment")
     }
 
     if (stratifiedAnalysis && !dataInput$isStratified()) {
-        stopIllegalArgument("stratified analysis is only possible for stratified data input", functionName = ".getStageResultsRatesEnrichment")
+        stopIllegalArgument("stratified analysis is only possible for stratified data input", 
+		functionName = ".getStageResultsRatesEnrichment")
     }
 
     if (dataInput$isStratified() && (gMax > 4)) {
@@ -1020,7 +1023,8 @@ NULL
                 paste0("length of 'piTreatments' (%s) ", "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(piTreatments), gMax
             ),
-            functionName = ".getConditionalPowerRatesEnrichment", parameter = "piTreatments",
+            functionName = ".getConditionalPowerRatesEnrichment", 
+		parameter ="piTreatments",
             value = piTreatments,
             relatedParameter = "gMax",
             relatedValue = gMax
@@ -1033,7 +1037,8 @@ NULL
                 paste0("length of 'piControls' (%s) ", "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(piControls), gMax
             ),
-            functionName = ".getConditionalPowerRatesEnrichment", parameter = "piControls",
+            functionName = ".getConditionalPowerRatesEnrichment", 
+		parameter ="piControls",
             value = piControls,
             relatedParameter = "gMax",
             relatedValue = gMax
@@ -1070,7 +1075,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalPowerRatesEnrichment", parameter = "design"
+        functionName = ".getConditionalPowerRatesEnrichment", 
+		parameter ="design"
     )
 }
 

--- a/R/f_analysis_enrichment_rates.R
+++ b/R/f_analysis_enrichment_rates.R
@@ -213,8 +213,8 @@ NULL
 
     if ((gMax > 2) && intersectionTest == "SpiessensDebois") {
         stopIllegalArgument("gMax (", gMax, ") > 2: Spiessens & Debois intersection test test can only be used for one subset",
-            functionName = ".getStageResultsRatesEnrichment", 
-		parameter ="gMax", value = gMax
+            functionName = ".getStageResultsRatesEnrichment",
+            parameter = "gMax", value = gMax
         )
     }
 
@@ -225,13 +225,15 @@ NULL
     }
 
     if (stratifiedAnalysis && !normalApproximation) {
-        stopConflictingArguments("stratified version is not available for Fisher's exact test", 
-		functionName = ".getStageResultsRatesEnrichment")
+        stopConflictingArguments("stratified version is not available for Fisher's exact test",
+            functionName = ".getStageResultsRatesEnrichment"
+        )
     }
 
     if (stratifiedAnalysis && !dataInput$isStratified()) {
-        stopIllegalArgument("stratified analysis is only possible for stratified data input", 
-		functionName = ".getStageResultsRatesEnrichment")
+        stopIllegalArgument("stratified analysis is only possible for stratified data input",
+            functionName = ".getStageResultsRatesEnrichment"
+        )
     }
 
     if (dataInput$isStratified() && (gMax > 4)) {
@@ -1023,8 +1025,8 @@ NULL
                 paste0("length of 'piTreatments' (%s) ", "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(piTreatments), gMax
             ),
-            functionName = ".getConditionalPowerRatesEnrichment", 
-		parameter ="piTreatments",
+            functionName = ".getConditionalPowerRatesEnrichment",
+            parameter = "piTreatments",
             value = piTreatments,
             relatedParameter = "gMax",
             relatedValue = gMax
@@ -1037,8 +1039,8 @@ NULL
                 paste0("length of 'piControls' (%s) ", "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(piControls), gMax
             ),
-            functionName = ".getConditionalPowerRatesEnrichment", 
-		parameter ="piControls",
+            functionName = ".getConditionalPowerRatesEnrichment",
+            parameter = "piControls",
             value = piControls,
             relatedParameter = "gMax",
             relatedValue = gMax
@@ -1075,8 +1077,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalPowerRatesEnrichment", 
-		parameter ="design"
+        functionName = ".getConditionalPowerRatesEnrichment",
+        parameter = "design"
     )
 }
 

--- a/R/f_analysis_enrichment_survival.R
+++ b/R/f_analysis_enrichment_survival.R
@@ -617,7 +617,10 @@ NULL
         if (maxSearchIterations < 0) {
             stopRuntimeIssue(
                 sprintf(
-                    paste0("failed to find theta (k = %s, firstValue = %s, ", "secondValue = %s, levels(firstValue) = %s, theta = %s)"),
+                    paste0(
+                        "failed to find theta (k = %s, firstValue = %s, ",
+                        "secondValue = %s, levels(firstValue) = %s, theta = %s)"
+                    ),
                     stage, stageResults[[firstParameterName]][treatmentArm, stage], secondValue, firstValue, theta
                 ),
                 functionName = ".getUpperLowerThetaSurvivalEnrichment"
@@ -960,7 +963,10 @@ NULL
     if ((length(thetaH1) != 1) && (length(thetaH1) != gMax)) {
         stopIllegalArgument(
             sprintf(
-                paste0("length of 'thetaH1' (%s) must be ", "equal to 'gMax' (%s) or 1"),
+                paste0(
+                    "length of 'thetaH1' (%s) must be ",
+                    "equal to 'gMax' (%s) or 1"
+                ),
                 .arrayToString(thetaH1), gMax
             ),
             functionName = ".getConditionalPowerSurvivalEnrichment",

--- a/R/f_analysis_enrichment_survival.R
+++ b/R/f_analysis_enrichment_survival.R
@@ -157,14 +157,15 @@ NULL
 
     if (gMax > 2 && intersectionTest == "SpiessensDebois") {
         stopIllegalArgument("gMax (", gMax, ") > 2: Spiessens & Debois intersection test test can only be used for one subset",
-            functionName = ".getStageResultsSurvivalEnrichment", 
-		parameter ="gMax", value = gMax
+            functionName = ".getStageResultsSurvivalEnrichment",
+            parameter = "gMax", value = gMax
         )
     }
 
     if (!stratifiedAnalysis) {
-        stopIllegalArgument("only stratified analysis can be performed for enrichment survival designs", 
-		functionName = ".getStageResultsSurvivalEnrichment")
+        stopIllegalArgument("only stratified analysis can be performed for enrichment survival designs",
+            functionName = ".getStageResultsSurvivalEnrichment"
+        )
     }
 
     if (dataInput$isStratified() && gMax > 4) {
@@ -996,8 +997,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalPowerSurvivalEnrichment", 
-		parameter ="design"
+        functionName = ".getConditionalPowerSurvivalEnrichment",
+        parameter = "design"
     )
 }
 

--- a/R/f_analysis_enrichment_survival.R
+++ b/R/f_analysis_enrichment_survival.R
@@ -157,12 +157,14 @@ NULL
 
     if (gMax > 2 && intersectionTest == "SpiessensDebois") {
         stopIllegalArgument("gMax (", gMax, ") > 2: Spiessens & Debois intersection test test can only be used for one subset",
-            functionName = ".getStageResultsSurvivalEnrichment", parameter = "gMax", value = gMax
+            functionName = ".getStageResultsSurvivalEnrichment", 
+		parameter ="gMax", value = gMax
         )
     }
 
     if (!stratifiedAnalysis) {
-        stopIllegalArgument("only stratified analysis can be performed for enrichment survival designs", functionName = ".getStageResultsSurvivalEnrichment")
+        stopIllegalArgument("only stratified analysis can be performed for enrichment survival designs", 
+		functionName = ".getStageResultsSurvivalEnrichment")
     }
 
     if (dataInput$isStratified() && gMax > 4) {
@@ -994,7 +996,8 @@ NULL
     }
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal or TrialDesignFisher",
-        functionName = ".getConditionalPowerSurvivalEnrichment", parameter = "design"
+        functionName = ".getConditionalPowerSurvivalEnrichment", 
+		parameter ="design"
     )
 }
 

--- a/R/f_analysis_multiarm.R
+++ b/R/f_analysis_multiarm.R
@@ -502,7 +502,7 @@ getClosedCombinationTestResults <- function(stageResults) {
 
     if (.isTrialDesignInverseNormal(design)) {
         if (design$typeOfDesign == C_TYPE_OF_DESIGN_AS_USER) {
-            warning("Repeated p-values not available for 'typeOfDesign' = ", 
+            warning("Repeated p-values not available for 'typeOfDesign' = ",
                 .vQuote(C_TYPE_OF_DESIGN_AS_USER),
                 call. = FALSE
             )
@@ -510,7 +510,7 @@ getClosedCombinationTestResults <- function(stageResults) {
         }
 
         if (design$typeOfDesign == C_TYPE_OF_DESIGN_WT_OPTIMUM) {
-            warning("Repeated p-values not available for 'typeOfDesign' = ", 
+            warning("Repeated p-values not available for 'typeOfDesign' = ",
                 .vQuote(C_TYPE_OF_DESIGN_WT_OPTIMUM),
                 call. = FALSE
             )
@@ -519,7 +519,7 @@ getClosedCombinationTestResults <- function(stageResults) {
     }
 
     if (.isTrialDesignFisher(design) && design$method == C_FISHER_METHOD_USER_DEFINED_ALPHA) {
-        warning("Repeated p-values not available for 'method' = ", 
+        warning("Repeated p-values not available for 'method' = ",
             .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA),
             call. = FALSE
         )

--- a/R/f_analysis_multiarm.R
+++ b/R/f_analysis_multiarm.R
@@ -502,16 +502,16 @@ getClosedCombinationTestResults <- function(stageResults) {
 
     if (.isTrialDesignInverseNormal(design)) {
         if (design$typeOfDesign == C_TYPE_OF_DESIGN_AS_USER) {
-            warning("Repeated p-values not available for 'typeOfDesign' = '",
-                C_TYPE_OF_DESIGN_AS_USER, "'",
+            warning("Repeated p-values not available for 'typeOfDesign' = ", 
+                .vQuote(C_TYPE_OF_DESIGN_AS_USER),
                 call. = FALSE
             )
             return(repeatedPValues)
         }
 
         if (design$typeOfDesign == C_TYPE_OF_DESIGN_WT_OPTIMUM) {
-            warning("Repeated p-values not available for 'typeOfDesign' = '",
-                C_TYPE_OF_DESIGN_WT_OPTIMUM, "'",
+            warning("Repeated p-values not available for 'typeOfDesign' = ", 
+                .vQuote(C_TYPE_OF_DESIGN_WT_OPTIMUM),
                 call. = FALSE
             )
             return(repeatedPValues)
@@ -519,8 +519,8 @@ getClosedCombinationTestResults <- function(stageResults) {
     }
 
     if (.isTrialDesignFisher(design) && design$method == C_FISHER_METHOD_USER_DEFINED_ALPHA) {
-        warning("Repeated p-values not available for 'method' = '",
-            C_FISHER_METHOD_USER_DEFINED_ALPHA, "'",
+        warning("Repeated p-values not available for 'method' = ", 
+            .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA),
             call. = FALSE
         )
         return(repeatedPValues)

--- a/R/f_analysis_multiarm_rates.R
+++ b/R/f_analysis_multiarm_rates.R
@@ -1118,7 +1118,8 @@ NULL
     if ((length(piTreatments) != 1) && (length(piTreatments) != gMax)) {
         stopIllegalArgument(
             sprintf(
-                paste0("length of 'piTreatments' (%s) ", "must be equal to 'gMax' (%s) or 1"),
+                paste0("length of 'piTreatments' (%s) ", 
+                "must be equal to 'gMax' (%s) or 1"),
                 .arrayToString(piTreatments), gMax
             ),
             functionName = ".getConditionalPowerRatesMultiArm",

--- a/R/f_analysis_multiarm_rates.R
+++ b/R/f_analysis_multiarm_rates.R
@@ -1184,7 +1184,8 @@ NULL
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal, TrialDesignFisher, ",
         "or TrialDesignConditionalDunnett",
-        functionName = ".getConditionalPowerRatesMultiArm", parameter = "design"
+        functionName = ".getConditionalPowerRatesMultiArm", 
+		parameter ="design"
     )
 }
 

--- a/R/f_analysis_multiarm_rates.R
+++ b/R/f_analysis_multiarm_rates.R
@@ -1184,8 +1184,8 @@ NULL
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal, TrialDesignFisher, ",
         "or TrialDesignConditionalDunnett",
-        functionName = ".getConditionalPowerRatesMultiArm", 
-		parameter ="design"
+        functionName = ".getConditionalPowerRatesMultiArm",
+        parameter = "design"
     )
 }
 

--- a/R/f_analysis_multiarm_survival.R
+++ b/R/f_analysis_multiarm_survival.R
@@ -1064,8 +1064,8 @@ NULL
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal, TrialDesignFisher, ",
         "or TrialDesignConditionalDunnett",
-        functionName = ".getConditionalPowerSurvivalMultiArm", 
-		parameter ="design"
+        functionName = ".getConditionalPowerSurvivalMultiArm",
+        parameter = "design"
     )
 }
 

--- a/R/f_analysis_multiarm_survival.R
+++ b/R/f_analysis_multiarm_survival.R
@@ -1064,7 +1064,8 @@ NULL
 
     stopIllegalArgument("'design' must be an instance of TrialDesignInverseNormal, TrialDesignFisher, ",
         "or TrialDesignConditionalDunnett",
-        functionName = ".getConditionalPowerSurvivalMultiArm", parameter = "design"
+        functionName = ".getConditionalPowerSurvivalMultiArm", 
+		parameter ="design"
     )
 }
 

--- a/R/f_analysis_multiarm_survival.R
+++ b/R/f_analysis_multiarm_survival.R
@@ -1014,7 +1014,8 @@ NULL
     if ((length(thetaH1) != 1) && (length(thetaH1) != gMax)) {
         stopIllegalArgument(
             sprintf(
-                paste0("length of 'thetaH1' (%s) must be ", "equal to 'gMax' (%s) or 1"),
+                paste0("length of 'thetaH1' (%s) must be ", 
+                "equal to 'gMax' (%s) or 1"),
                 .arrayToString(thetaH1), gMax
             ),
             functionName = ".getConditionalPowerSurvivalMultiArm",

--- a/R/f_analysis_utilities.R
+++ b/R/f_analysis_utilities.R
@@ -49,7 +49,7 @@ NULL
     if (!.isConditionalPowerEnabled(nPlanned)) {
         if (length(paramValues) > 0 && !all(is.na(paramValues)) &&
                 !results$isGeneratedParameter(paramName)) {
-            warning("'", paramName, "' (", .arrayToString(paramValues), ") ",
+            warning(.pQuote(paramName), " (", .arrayToString(paramValues), ") ",
                 "will be ignored because 'nPlanned' is not defined",
                 call. = FALSE
             )
@@ -59,7 +59,7 @@ NULL
     if (results$.design$kMax == 1) {
         if (length(paramValues) > 0 && !all(is.na(paramValues)) &&
                 !results$isGeneratedParameter(paramName)) {
-            warning("'", paramName, "' (", .arrayToString(paramValues), ") ",
+            warning(.pQuote(paramName), " (", .arrayToString(paramValues), ") ",
                 "will be ignored because design is fixed",
                 call. = FALSE
             )
@@ -331,7 +331,8 @@ NULL
     args <- .removeDesignFromArgs(args)
     argNames <- .getArgumentNames(...)
     if (length(args) == 0 || length(argNames) == 0) {
-        stopMissingArgument("data.frame or data vectors expected", functionName = ".createDataFrame")
+        stopMissingArgument("data.frame or data vectors expected", 
+		functionName = ".createDataFrame")
     }
 
     multiArmEnabled <- any(grep("3", argNames))
@@ -355,29 +356,34 @@ NULL
     for (argName in argNames) {
         argValues <- args[[argName]]
         if (is.null(argValues) || length(argValues) == 0) {
-            stopIllegalArgument("'", argName, "' is not a valid numeric vector",
+            stopIllegalArgument(.pQuote(argName), " is not a valid numeric vector",
                 functionName = ".createDataFrame",
                 parameter = argName
             )
         }
 
         if (is.na(argValues[1])) {
-            stopIllegalArgument("'", argName, "' is NA at first stage; a valid numeric value must be specified at stage 1",
-                functionName = ".createDataFrame", parameter = argName
+            stopIllegalArgument(.pQuote(argName), " is NA at first stage; a valid numeric value must be specified at stage 1",
+                functionName = ".createDataFrame", 
+		parameter =argName
             )
         }
 
         if (length(argValues) != numberOfValues) {
-            stopConflictingArguments("all data vectors must have the same length: '", argName, "' (", length(argValues),
-                ") differs from '", argNames[1], "' (", numberOfValues, ")",
-                functionName = ".createDataFrame", parameter = argName,
-                relatedParameter = "argValues", relatedValue = length(argValues)
+            stopConflictingArguments("all data vectors must have the same length: ", 
+                .pQuote(argName), " (", length(argValues), ") differs from ", 
+                .pQuote(argNames[1]), " (", numberOfValues, ")",
+                functionName = ".createDataFrame", 
+		parameter =argName,
+                relatedParameter = "argValues", 
+		relatedValue = length(argValues)
             )
         }
 
         if (.equalsRegexpIgnoreCase(argName, "^stages?$")) {
             if (length(stats::na.omit(argValues)) != length(argValues)) {
-                stopIllegalArgument("NA's not allowed for '", argName, "'; stages must be defined completely",
+                stopIllegalArgument("NA's not allowed for ", .pQuote(argName), "; ",
+                    "stages must be defined completely",
                     functionName = ".createDataFrame",
                     parameter = argName, value = argValues
                 )
@@ -386,8 +392,8 @@ NULL
             definedStages <- sort(intersect(unique(argValues), 1:numberOfValues))
             if (length(definedStages) < numberOfValues) {
                 if (length(definedStages) == 0) {
-                    stopIllegalArgument("no valid stages are defined; ", "stages must be defined completely (", .arrayToString(1:numberOfValues),
-                        ")",
+                    stopIllegalArgument("no valid stages are defined; ", 
+                        "stages must be defined completely (", .arrayToString(1:numberOfValues), ")",
                         functionName = ".createDataFrame"
                     )
                 }
@@ -406,8 +412,12 @@ NULL
 
         if (!survivalDataEnabled && .isControlGroupArgument(argName, numberOfGroups) &&
                 length(na.omit(argValues)) < numberOfStages) {
-            stopIllegalArgument("control group '", argName, "' (", .arrayToString(argValues, digits = 2), ") must be defined for all stages",
-                functionName = ".createDataFrame", parameter = argName, relatedParameter = "argValues", relatedValue = argValues
+            stopIllegalArgument("control group ", .pQuote(argName), 
+                " (", .arrayToString(argValues, digits = 2), ") must be defined for all stages",
+                functionName = ".createDataFrame", 
+		parameter =argName, 
+		relatedParameter ="argValues", 
+		relatedValue = argValues
             )
         }
 
@@ -415,8 +425,12 @@ NULL
         if (length(naIndices) > 0) {
             stageIndex <- naIndices[length(naIndices)]
             if (stageIndex != numberOfValues) {
-                stopIllegalArgument("'", argName, "' contains a NA at stage ", stageIndex, " followed by a value for a higher stage; NA's must be the last values",
-                    functionName = ".createDataFrame", parameter = argName, relatedParameter = "stageIndex", relatedValue = stageIndex
+                stopIllegalArgument(.pQuote(argName), " contains a NA at stage ", stageIndex, 
+                    " followed by a value for a higher stage; NA's must be the last values",
+                    functionName = ".createDataFrame", 
+		parameter =argName, 
+		relatedParameter ="stageIndex", 
+		relatedValue = stageIndex
                 )
             }
         }
@@ -426,8 +440,10 @@ NULL
             for (i in (length(naIndices) - 1):1) {
                 index <- naIndices[i]
                 if (indexBefore - index > 1) {
-                    stopIllegalArgument("'", argName, "' contains alternating values and NA's; ", "NA's must be the last values",
-                        functionName = ".createDataFrame", parameter = argName, value = argValues
+                    stopIllegalArgument(.pQuote(argName), " contains alternating values and NA's; ", 
+                        "NA's must be the last values",
+                        functionName = ".createDataFrame", 
+		parameter =argName, value = argValues
                     )
                 }
                 indexBefore <- index
@@ -438,7 +454,8 @@ NULL
             if (!multiArmEnabled && !survivalDataEnabled) {
                 if (!is.null(naIndicesBefore) && !.equalsRegexpIgnoreCase(argName, "^stages?$")) {
                     if (!.arraysAreEqual(naIndicesBefore, naIndices)) {
-                        stopConflictingArguments("inconsistent NA definition; ", "if NA's exist, then they are mandatory for each group at the same stage",
+                        stopConflictingArguments("inconsistent NA definition; ", 
+                            "if NA's exist, then they are mandatory for each group at the same stage",
                             functionName = ".createDataFrame"
                         )
                     }
@@ -450,8 +467,10 @@ NULL
                         !.equalsRegexpIgnoreCase(argName, "^stages?$") &&
                         !.isControlGroupArgument(argName, numberOfGroups)) {
                     if (!.arraysAreEqual(naIndicesBefore[[as.character(groupNumber)]], naIndices)) {
-                        stopConflictingArguments("values of treatment ", groupNumber, " not correctly specified; ", "if NA's exist, then they are mandatory for each parameter at the same stage",
-                            functionName = ".createDataFrame", parameter = "groupNumber", value = groupNumber
+                        stopConflictingArguments("values of treatment ", groupNumber, " not correctly specified; ", 
+                            "if NA's exist, then they are mandatory for each parameter at the same stage",
+                            functionName = ".createDataFrame", 
+		parameter ="groupNumber", value = groupNumber
                         )
                     }
                 }
@@ -462,23 +481,28 @@ NULL
         }
 
         if (sum(is.infinite(argValues)) > 0) {
-            stopIllegalArgument("all data values must be finite; ", "'", argName, "' contains infinite values",
+            stopIllegalArgument("all data values must be finite; ", .pQuote(argName), " contains infinite values",
                 functionName = ".createDataFrame",
                 parameter = argName
             )
         }
 
         if (!any(grepl(paste0("^", sub("\\d*$", "", argName), "$"), C_KEY_WORDS_SUBSETS)) && !is.numeric(argValues)) {
-            stopIllegalArgument("all data vectors must be numeric ('", argName, "' is ", .getClassName(argValues),
+            stopIllegalArgument("all data vectors must be numeric (", .pQuote(argName), " is ", .getClassName(argValues),
                 ")",
-                functionName = ".createDataFrame", parameter = argName, relatedParameter = "argValues", relatedValue = argValues
+                functionName = ".createDataFrame", 
+		parameter =argName, 
+		relatedParameter ="argValues", 
+		relatedValue = argValues
             )
         }
 
         if (length(argValues) > C_KMAX_UPPER_BOUND * numberOfSubsets) {
-            stopArgumentLengthOutOfBounds("'", argName, "' is out of bounds [1, ", C_KMAX_UPPER_BOUND, "]",
+            stopArgumentLengthOutOfBounds(.pQuote(argName), " is out of bounds [1, ", C_KMAX_UPPER_BOUND, "]",
                 functionName = ".createDataFrame",
-                parameter = argName, relatedParameter = "C_KMAX_UPPER_BOUND", relatedValue = C_KMAX_UPPER_BOUND
+                parameter = argName, 
+		relatedParameter ="C_KMAX_UPPER_BOUND", 
+		relatedValue = C_KMAX_UPPER_BOUND
             )
         }
     }
@@ -492,8 +516,10 @@ NULL
                 naIndices <- which(is.na(argValues))
                 if (!is.null(naIndicesBefore) && !.equalsRegexpIgnoreCase(argName, "^stages?$")) {
                     if (!.arraysAreEqual(naIndicesBefore, naIndices)) {
-                        stopConflictingArguments("inconsistent NA definition for group ", groupNumber, "; ", "if NA's exist, then they are mandatory for each group at the same stage",
-                            functionName = ".createDataFrame", parameter = "groupNumber", value = groupNumber
+                        stopConflictingArguments("inconsistent NA definition for group ", groupNumber, "; ", 
+                            "if NA's exist, then they are mandatory for each group at the same stage",
+                            functionName = ".createDataFrame", 
+		parameter ="groupNumber", value = groupNumber
                         )
                     }
                 }
@@ -512,7 +538,8 @@ NULL
 .getDataFrameFromArgs <- function(...) {
     args <- list(...)
     if (length(args) == 0) {
-        stopMissingArgument("cannot initialize dataset because no data are defined", functionName = ".getDataFrameFromArgs")
+        stopMissingArgument("cannot initialize dataset because no data are defined", 
+		functionName = ".getDataFrameFromArgs")
     }
 
     dataFrame <- NULL
@@ -646,13 +673,15 @@ NULL
             unknownArgs[i] <- argNames[argNamesLower == unknownArgs[i]][1]
         }
         if (length(unknownArgs) == 1) {
-            stopIllegalArgument("the argument '", unknownArgs, "' is not a valid dataset argument",
+            stopIllegalArgument("the argument ", .pQuote(unknownArgs), " is not a valid dataset argument",
                 functionName = ".assertIsValidDatasetArgument",
                 parameter = "unknownArgs", value = unknownArgs
             )
         } else {
-            stopIllegalArgument("the arguments ", .arrayToString(unknownArgs, encapsulate = TRUE), " are no valid dataset arguments",
-                functionName = ".assertIsValidDatasetArgument", parameter = "unknownArgs", value = unknownArgs
+            stopIllegalArgument("the arguments ", .arrayToString(unknownArgs, encapsulate = TRUE), 
+                " are no valid dataset arguments",
+                functionName = ".assertIsValidDatasetArgument", 
+		parameter ="unknownArgs", value = unknownArgs
             )
         }
     }
@@ -851,7 +880,8 @@ getWideFormat <- function(dataInput) {
         if (numberOfStages == 0) {
             print(dataFrame[, validColNames])
             stopRuntimeIssue("'dataFrame' seems to contain an invalid column",
-                functionName = ".getNumberOfStages", parameter = "dataFrame",
+                functionName = ".getNumberOfStages", 
+		parameter ="dataFrame",
                 value = dataFrame
             )
         }
@@ -906,7 +936,6 @@ getWideFormat <- function(dataInput) {
         }
         df$subset <- subsets
         df <- .moveColumn(df, "subset", "stage")
-        # 		df <- df[with(data.frame(subset = df$subset, index = as.integer(sub("\\D", "", df$subset))), order(index)), ]
     }
 
     return(df)
@@ -962,14 +991,18 @@ getLongFormat <- function(dataInput) {
         return(invisible(results))
     }
 
-    .setValueAndParameterType(results, "allocationRatioPlanned", allocationRatioPlanned, C_ALLOCATION_RATIO_DEFAULT)
+    .setValueAndParameterType(results, "allocationRatioPlanned", 
+        allocationRatioPlanned, C_ALLOCATION_RATIO_DEFAULT)
     return(invisible(results))
 }
 
 .synchronizeIterationsAndSeed <- function(results) {
     if (is.null(results[[".conditionalPowerResults"]])) {
-        stopRuntimeIssue(sQuote(.getClassName(results)), " does not contain field ", sQuote(".conditionalPowerResults"),
-            functionName = ".synchronizeIterationsAndSeed", parameter = .getClassName(results), relatedParameter = ".conditionalPowerResults"
+        stopRuntimeIssue(sQuote(.getClassName(results)), 
+            " does not contain field ", sQuote(".conditionalPowerResults"),
+            functionName = ".synchronizeIterationsAndSeed", 
+		parameter =.getClassName(results), 
+		relatedParameter =".conditionalPowerResults"
         )
     }
 
@@ -1030,7 +1063,7 @@ getLongFormat <- function(dataInput) {
 }
 
 .fireDataInputNotSupportedException <- function(dataInput) {
-    stopIllegalArgument("'dataInput' type ", "'", .getClassName(dataInput), "' is not supported",
+    stopIllegalArgument("'dataInput' type ", "", .getClassName(dataInput, quote = TRUE), " is not supported",
         functionName = ".fireDataInputNotSupportedException",
         parameter = "dataInput", value = dataInput
     )

--- a/R/f_analysis_utilities.R
+++ b/R/f_analysis_utilities.R
@@ -331,8 +331,9 @@ NULL
     args <- .removeDesignFromArgs(args)
     argNames <- .getArgumentNames(...)
     if (length(args) == 0 || length(argNames) == 0) {
-        stopMissingArgument("data.frame or data vectors expected", 
-		functionName = ".createDataFrame")
+        stopMissingArgument("data.frame or data vectors expected",
+            functionName = ".createDataFrame"
+        )
     }
 
     multiArmEnabled <- any(grep("3", argNames))
@@ -364,19 +365,19 @@ NULL
 
         if (is.na(argValues[1])) {
             stopIllegalArgument(.pQuote(argName), " is NA at first stage; a valid numeric value must be specified at stage 1",
-                functionName = ".createDataFrame", 
-		parameter =argName
+                functionName = ".createDataFrame",
+                parameter = argName
             )
         }
 
         if (length(argValues) != numberOfValues) {
-            stopConflictingArguments("all data vectors must have the same length: ", 
-                .pQuote(argName), " (", length(argValues), ") differs from ", 
+            stopConflictingArguments("all data vectors must have the same length: ",
+                .pQuote(argName), " (", length(argValues), ") differs from ",
                 .pQuote(argNames[1]), " (", numberOfValues, ")",
-                functionName = ".createDataFrame", 
-		parameter =argName,
-                relatedParameter = "argValues", 
-		relatedValue = length(argValues)
+                functionName = ".createDataFrame",
+                parameter = argName,
+                relatedParameter = "argValues",
+                relatedValue = length(argValues)
             )
         }
 
@@ -392,7 +393,7 @@ NULL
             definedStages <- sort(intersect(unique(argValues), 1:numberOfValues))
             if (length(definedStages) < numberOfValues) {
                 if (length(definedStages) == 0) {
-                    stopIllegalArgument("no valid stages are defined; ", 
+                    stopIllegalArgument("no valid stages are defined; ",
                         "stages must be defined completely (", .arrayToString(1:numberOfValues), ")",
                         functionName = ".createDataFrame"
                     )
@@ -412,12 +413,12 @@ NULL
 
         if (!survivalDataEnabled && .isControlGroupArgument(argName, numberOfGroups) &&
                 length(na.omit(argValues)) < numberOfStages) {
-            stopIllegalArgument("control group ", .pQuote(argName), 
+            stopIllegalArgument("control group ", .pQuote(argName),
                 " (", .arrayToString(argValues, digits = 2), ") must be defined for all stages",
-                functionName = ".createDataFrame", 
-		parameter =argName, 
-		relatedParameter ="argValues", 
-		relatedValue = argValues
+                functionName = ".createDataFrame",
+                parameter = argName,
+                relatedParameter = "argValues",
+                relatedValue = argValues
             )
         }
 
@@ -425,12 +426,12 @@ NULL
         if (length(naIndices) > 0) {
             stageIndex <- naIndices[length(naIndices)]
             if (stageIndex != numberOfValues) {
-                stopIllegalArgument(.pQuote(argName), " contains a NA at stage ", stageIndex, 
+                stopIllegalArgument(.pQuote(argName), " contains a NA at stage ", stageIndex,
                     " followed by a value for a higher stage; NA's must be the last values",
-                    functionName = ".createDataFrame", 
-		parameter =argName, 
-		relatedParameter ="stageIndex", 
-		relatedValue = stageIndex
+                    functionName = ".createDataFrame",
+                    parameter = argName,
+                    relatedParameter = "stageIndex",
+                    relatedValue = stageIndex
                 )
             }
         }
@@ -440,10 +441,10 @@ NULL
             for (i in (length(naIndices) - 1):1) {
                 index <- naIndices[i]
                 if (indexBefore - index > 1) {
-                    stopIllegalArgument(.pQuote(argName), " contains alternating values and NA's; ", 
+                    stopIllegalArgument(.pQuote(argName), " contains alternating values and NA's; ",
                         "NA's must be the last values",
-                        functionName = ".createDataFrame", 
-		parameter =argName, value = argValues
+                        functionName = ".createDataFrame",
+                        parameter = argName, value = argValues
                     )
                 }
                 indexBefore <- index
@@ -454,7 +455,7 @@ NULL
             if (!multiArmEnabled && !survivalDataEnabled) {
                 if (!is.null(naIndicesBefore) && !.equalsRegexpIgnoreCase(argName, "^stages?$")) {
                     if (!.arraysAreEqual(naIndicesBefore, naIndices)) {
-                        stopConflictingArguments("inconsistent NA definition; ", 
+                        stopConflictingArguments("inconsistent NA definition; ",
                             "if NA's exist, then they are mandatory for each group at the same stage",
                             functionName = ".createDataFrame"
                         )
@@ -467,10 +468,10 @@ NULL
                         !.equalsRegexpIgnoreCase(argName, "^stages?$") &&
                         !.isControlGroupArgument(argName, numberOfGroups)) {
                     if (!.arraysAreEqual(naIndicesBefore[[as.character(groupNumber)]], naIndices)) {
-                        stopConflictingArguments("values of treatment ", groupNumber, " not correctly specified; ", 
+                        stopConflictingArguments("values of treatment ", groupNumber, " not correctly specified; ",
                             "if NA's exist, then they are mandatory for each parameter at the same stage",
-                            functionName = ".createDataFrame", 
-		parameter ="groupNumber", value = groupNumber
+                            functionName = ".createDataFrame",
+                            parameter = "groupNumber", value = groupNumber
                         )
                     }
                 }
@@ -490,19 +491,19 @@ NULL
         if (!any(grepl(paste0("^", sub("\\d*$", "", argName), "$"), C_KEY_WORDS_SUBSETS)) && !is.numeric(argValues)) {
             stopIllegalArgument("all data vectors must be numeric (", .pQuote(argName), " is ", .getClassName(argValues),
                 ")",
-                functionName = ".createDataFrame", 
-		parameter =argName, 
-		relatedParameter ="argValues", 
-		relatedValue = argValues
+                functionName = ".createDataFrame",
+                parameter = argName,
+                relatedParameter = "argValues",
+                relatedValue = argValues
             )
         }
 
         if (length(argValues) > C_KMAX_UPPER_BOUND * numberOfSubsets) {
             stopArgumentLengthOutOfBounds(.pQuote(argName), " is out of bounds [1, ", C_KMAX_UPPER_BOUND, "]",
                 functionName = ".createDataFrame",
-                parameter = argName, 
-		relatedParameter ="C_KMAX_UPPER_BOUND", 
-		relatedValue = C_KMAX_UPPER_BOUND
+                parameter = argName,
+                relatedParameter = "C_KMAX_UPPER_BOUND",
+                relatedValue = C_KMAX_UPPER_BOUND
             )
         }
     }
@@ -516,10 +517,10 @@ NULL
                 naIndices <- which(is.na(argValues))
                 if (!is.null(naIndicesBefore) && !.equalsRegexpIgnoreCase(argName, "^stages?$")) {
                     if (!.arraysAreEqual(naIndicesBefore, naIndices)) {
-                        stopConflictingArguments("inconsistent NA definition for group ", groupNumber, "; ", 
+                        stopConflictingArguments("inconsistent NA definition for group ", groupNumber, "; ",
                             "if NA's exist, then they are mandatory for each group at the same stage",
-                            functionName = ".createDataFrame", 
-		parameter ="groupNumber", value = groupNumber
+                            functionName = ".createDataFrame",
+                            parameter = "groupNumber", value = groupNumber
                         )
                     }
                 }
@@ -538,8 +539,9 @@ NULL
 .getDataFrameFromArgs <- function(...) {
     args <- list(...)
     if (length(args) == 0) {
-        stopMissingArgument("cannot initialize dataset because no data are defined", 
-		functionName = ".getDataFrameFromArgs")
+        stopMissingArgument("cannot initialize dataset because no data are defined",
+            functionName = ".getDataFrameFromArgs"
+        )
     }
 
     dataFrame <- NULL
@@ -678,10 +680,10 @@ NULL
                 parameter = "unknownArgs", value = unknownArgs
             )
         } else {
-            stopIllegalArgument("the arguments ", .arrayToString(unknownArgs, encapsulate = TRUE), 
+            stopIllegalArgument("the arguments ", .arrayToString(unknownArgs, encapsulate = TRUE),
                 " are no valid dataset arguments",
-                functionName = ".assertIsValidDatasetArgument", 
-		parameter ="unknownArgs", value = unknownArgs
+                functionName = ".assertIsValidDatasetArgument",
+                parameter = "unknownArgs", value = unknownArgs
             )
         }
     }
@@ -880,8 +882,8 @@ getWideFormat <- function(dataInput) {
         if (numberOfStages == 0) {
             print(dataFrame[, validColNames])
             stopRuntimeIssue("'dataFrame' seems to contain an invalid column",
-                functionName = ".getNumberOfStages", 
-		parameter ="dataFrame",
+                functionName = ".getNumberOfStages",
+                parameter = "dataFrame",
                 value = dataFrame
             )
         }
@@ -991,18 +993,20 @@ getLongFormat <- function(dataInput) {
         return(invisible(results))
     }
 
-    .setValueAndParameterType(results, "allocationRatioPlanned", 
-        allocationRatioPlanned, C_ALLOCATION_RATIO_DEFAULT)
+    .setValueAndParameterType(
+        results, "allocationRatioPlanned",
+        allocationRatioPlanned, C_ALLOCATION_RATIO_DEFAULT
+    )
     return(invisible(results))
 }
 
 .synchronizeIterationsAndSeed <- function(results) {
     if (is.null(results[[".conditionalPowerResults"]])) {
-        stopRuntimeIssue(sQuote(.getClassName(results)), 
+        stopRuntimeIssue(sQuote(.getClassName(results)),
             " does not contain field ", sQuote(".conditionalPowerResults"),
-            functionName = ".synchronizeIterationsAndSeed", 
-		parameter =.getClassName(results), 
-		relatedParameter =".conditionalPowerResults"
+            functionName = ".synchronizeIterationsAndSeed",
+            parameter = .getClassName(results),
+            relatedParameter = ".conditionalPowerResults"
         )
     }
 

--- a/R/f_analysis_utilities.R
+++ b/R/f_analysis_utilities.R
@@ -155,7 +155,10 @@ NULL
 }
 
 .getSortedSubsets <- function(subsets) {
-    return(subsets[with(data.frame(subsets = subsets, index = as.integer(sub("\\D", "", subsets))), order(index))])
+    return(subsets[with(data.frame(
+        subsets = subsets,
+        index = as.integer(sub("\\D", "", subsets))
+    ), order(index))])
 }
 
 .getAllAvailableSubsets <- function(numbers, ..., sort = TRUE, digits = NA_integer_) {
@@ -1067,7 +1070,8 @@ getLongFormat <- function(dataInput) {
 }
 
 .fireDataInputNotSupportedException <- function(dataInput) {
-    stopIllegalArgument("'dataInput' type ", "", .getClassName(dataInput, quote = TRUE), " is not supported",
+    stopIllegalArgument("'dataInput' type ",
+        .getClassName(dataInput, quote = TRUE), " is not supported",
         functionName = ".fireDataInputNotSupportedException",
         parameter = "dataInput", value = dataInput
     )

--- a/R/f_as251.R
+++ b/R/f_as251.R
@@ -62,8 +62,9 @@ mvnprd <- function(..., A, B, BPD, EPS = 1e-06, INF, IERC = 1, HINC = 0) {
         stopIllegalArgument("input vectors must have the same length (", paste0(sort(unique(c(
             length(A), length(B),
             length(BPD), length(INF)
-        ))), collapse = " != "), ")", 
-		functionName = "mvnprd")
+        ))), collapse = " != "), ")",
+        functionName = "mvnprd"
+        )
     }
 
     result <- .mvnprd(A, B, BPD, EPS, INF, IERC, HINC)
@@ -188,8 +189,9 @@ mvstud <- function(..., NDF, A, B, BPD, D, EPS = 1e-06, INF, IERC = 1, HINC = 0)
         stopIllegalArgument("input vectors must have the same length (", paste0(sort(unique(c(
             length(A), length(B),
             length(BPD), length(INF), length(D)
-        ))), collapse = " != "), ")", 
-		functionName = "mvstud")
+        ))), collapse = " != "), ")",
+        functionName = "mvstud"
+        )
     }
 
     result <- .mvstud(NDF, A, B, BPD, D, EPS, INF, IERC, HINC)

--- a/R/f_as251.R
+++ b/R/f_as251.R
@@ -62,7 +62,8 @@ mvnprd <- function(..., A, B, BPD, EPS = 1e-06, INF, IERC = 1, HINC = 0) {
         stopIllegalArgument("input vectors must have the same length (", paste0(sort(unique(c(
             length(A), length(B),
             length(BPD), length(INF)
-        ))), collapse = " != "), ")", functionName = "mvnprd")
+        ))), collapse = " != "), ")", 
+		functionName = "mvnprd")
     }
 
     result <- .mvnprd(A, B, BPD, EPS, INF, IERC, HINC)
@@ -187,7 +188,8 @@ mvstud <- function(..., NDF, A, B, BPD, D, EPS = 1e-06, INF, IERC = 1, HINC = 0)
         stopIllegalArgument("input vectors must have the same length (", paste0(sort(unique(c(
             length(A), length(B),
             length(BPD), length(INF), length(D)
-        ))), collapse = " != "), ")", functionName = "mvstud")
+        ))), collapse = " != "), ")", 
+		functionName = "mvstud")
     }
 
     result <- .mvstud(NDF, A, B, BPD, D, EPS, INF, IERC, HINC)

--- a/R/f_core_assertions.R
+++ b/R/f_core_assertions.R
@@ -399,8 +399,10 @@ NULL
     }
 
     functionName <- paste(deparse(sys.call()), collapse = "")
-    .assertIsNumericVector(x, xName, naAllowed = naAllowed, 
-		functionName = functionName, call. = call.)
+    .assertIsNumericVector(x, xName,
+        naAllowed = naAllowed,
+        functionName = functionName, call. = call.
+    )
 
     if (is.null(upper) || is.na(upper)) {
         if (any(x < lower, na.rm = TRUE)) {
@@ -418,8 +420,8 @@ NULL
             parameter = xName, value = x, constraint = paste0(
                 sQuote(xName), " >= ", lower, " and ",
                 sQuote(xName), " <= ", upper
-            ), 
-		functionName = functionName, lowerBound = lower, upperBound = upper
+            ),
+            functionName = functionName, lowerBound = lower, upperBound = upper
         )
     }
 }
@@ -1531,8 +1533,8 @@ NULL
             value = informationRates, constraint = sprintf(
                 "must be strictly increasing: 0 < x_1 < .. < x_%s <= 1",
                 kMax
-            ), 
-		functionName = ".assertAreValidInformationRates"
+            ),
+            functionName = ".assertAreValidInformationRates"
         )
     }
 
@@ -1721,9 +1723,9 @@ NULL
     if (length(futilityBounds) != kMax - 1) {
         stopConflictingArguments("length of 'futilityBounds' (", length(futilityBounds), ") must be equal to 'kMax' (",
             kMax, ") - 1",
-            parameter = "futilityBounds", value = futilityBounds, 
-		relatedParameter ="kMax", 
-		relatedValue = kMax,
+            parameter = "futilityBounds", value = futilityBounds,
+            relatedParameter = "kMax",
+            relatedValue = kMax,
             functionName = ".assertAreValidFutilityBounds"
         )
     }
@@ -1738,8 +1740,8 @@ NULL
 .assertIsValidCipher <- function(key, value) {
     if (!(key %in% names(C_CIPHERS)) || (getCipheredValue(value) != C_CIPHERS[[key]])) {
         stopIllegalArgument("'token' and/or 'secret' unkown",
-            functionName = ".assertIsValidCipher", 
-		parameter ="token",
+            functionName = ".assertIsValidCipher",
+            parameter = "token",
             relatedParameter = "secret"
         )
     }
@@ -1905,8 +1907,8 @@ NULL
                 paste0("'nPlanned' (%s) is invalid: ", "length must be equal to %s (kMax - stage = %s - %s)"),
                 .arrayToString(nPlanned), kMax - stage, kMax, stage
             ),
-            functionName = ".assertIsValidNPlanned", 
-		parameter ="nPlanned",
+            functionName = ".assertIsValidNPlanned",
+            parameter = "nPlanned",
             value = nPlanned
         )
     }
@@ -2029,13 +2031,13 @@ NULL
 .warnInCaseOfUnusedArgument <- function(arg, argName, defaultValue, functionName) {
     if (!identical(arg, defaultValue)) {
         warning("Unused argument in ", functionName, "(...): ", .pQuote(argName), " = ", .arrayToString(
-                arg,
-                vectorLookAndFeelEnabled = (length(arg) > 1),
-                maxLength = 10,
-                encapsulate = !is.null(arg) && any(is.character(arg))
-            ),
-            " will be ignored",
-            call. = FALSE
+            arg,
+            vectorLookAndFeelEnabled = (length(arg) > 1),
+            maxLength = 10,
+            encapsulate = !is.null(arg) && any(is.character(arg))
+        ),
+        " will be ignored",
+        call. = FALSE
         )
     }
 }
@@ -2754,9 +2756,9 @@ NULL
                     "an argument with name ", .pQuote(argNameExpected),
                     parameter = funArgName, value = fun, constraint = paste0(
                         "must contain an argument with name ", .pQuote(argNameExpected)
-                    ), 
-		functionName = ".assertIsValidFunction", 
-		relatedParameter ="functionName",
+                    ),
+                    functionName = ".assertIsValidFunction",
+                    relatedParameter = "functionName",
                     relatedValue = functionName
                 )
             }
@@ -2789,7 +2791,7 @@ NULL
     }
 
     if (showUnusedArgumentsMessage && length(unusedArgs) > 0) {
-        message("Note that the following arguments can optionally be used in ", 
+        message("Note that the following arguments can optionally be used in ",
             .pQuote(funArgName), " (", functionName, "): \n",
             .arrayToString(unusedArgs),
             call. = FALSE
@@ -2859,7 +2861,7 @@ NULL
         if (length(parameterValues) != 1 || !is.na(parameterValues)) {
             if (calcSubjectsFunctionEnabled) {
                 warning(.pQuote(parameterName), " (", .arrayToString(parameterValues), ") ",
-                    "will be ignored because neither 'conditionalPower' nor ", 
+                    "will be ignored because neither 'conditionalPower' nor ",
                     .pQuote(calcSubjectsFunctionName), " is defined",
                     call. = FALSE
                 )
@@ -3309,7 +3311,7 @@ NULL
         )
     }
     if (.isTrialDesignConditionalDunnett(design) && varianceOption != C_VARIANCE_OPTION_DUNNETT) {
-        stopIllegalArgument("variance option (", .pQuote(varianceOption), ") must be ", 
+        stopIllegalArgument("variance option (", .pQuote(varianceOption), ") must be ",
             .pQuote(C_VARIANCE_OPTION_DUNNETT), " because conditional Dunnett test was specified as design",
             functionName = ".assertIsValidVarianceOptionMultiArmed",
             parameter = "varianceOption",
@@ -3569,8 +3571,8 @@ NULL
     .assertIsValidMatrix(decisionMatrix, "decisionMatrix", naAllowed = FALSE)
     if (!(nrow(decisionMatrix) %in% c(2, 4))) {
         stopIllegalArgument("'decisionMatrix' must have two or four rows",
-            functionName = ".assertIsValidDecisionMatrix", 
-		parameter ="decisionMatrix",
+            functionName = ".assertIsValidDecisionMatrix",
+            parameter = "decisionMatrix",
             value = decisionMatrix
         )
     }
@@ -3650,8 +3652,8 @@ NULL
     if (typeOfShape == "userDefined") {
         effectMatrix <- .assertIsValidMatrix(effectMatrix, "effectMatrix",
             expectedNumberOfColumns = gMax, naAllowed = FALSE, returnSingleValueAsMatrix = TRUE,
-            relatedParameter = "typeOfShape", 
-		relatedValue = typeOfShape
+            relatedParameter = "typeOfShape",
+            relatedValue = typeOfShape
         )
         .assertIsNumericVector(valueMaxVector, valueMaxVectorName, naAllowed = TRUE)
         valueMaxVectorDefault <- C_ALTERNATIVE_POWER_SIMULATION_DEFAULT
@@ -3675,13 +3677,13 @@ NULL
         if (!is.null(doseLevels) && !anyNA(doseLevels)) {
             warning("'doseLevels' (", .arrayToString(doseLevels), ") ",
                 "will be ignored because 'typeOfShape' ",
-                "is defined as ", .pQuote(typeOfShape), 
+                "is defined as ", .pQuote(typeOfShape),
                 call. = FALSE
             )
         }
     } else if (!is.null(effectMatrix)) {
         warning("'effectMatrix' will be ignored because 'typeOfShape' ",
-            "is defined as ", .pQuote(typeOfShape), 
+            "is defined as ", .pQuote(typeOfShape),
             call. = FALSE
         )
     }
@@ -3942,8 +3944,8 @@ NULL
     if (sided != 1 && sided != 2) {
         stopIllegalArgument("'sided' (", sided, ") must be defined as 1 or 2",
             parameter = "sided", value = sided,
-            constraint = "must be defined as 1 or 2", 
-		functionName = ".assertIsValidEffectCountData"
+            constraint = "must be defined as 1 or 2",
+            functionName = ".assertIsValidEffectCountData"
         )
     }
     .assertIsSingleNumber(lambda, "lambda", naAllowed = TRUE)
@@ -4317,7 +4319,7 @@ NULL
 
     warning(
         sQuote(argumentName), valueStr, " will be ignored ",
-        "because it is not required for the conversion from ", 
+        "because it is not required for the conversion from ",
         .pQuote(sourceScale), " to ", .pQuote(targetScale),
         call. = FALSE
     )

--- a/R/f_core_assertions.R
+++ b/R/f_core_assertions.R
@@ -24,7 +24,7 @@ NULL
     stopIllegalArgument("'design' must be an instance of ",
         .arrayToString(.getTrialDesignClassNames(inclusiveConditionalDunnett = inclusiveConditionalDunnett),
             vectorLookAndFeelEnabled = FALSE
-        ), " (is '", .getClassName(design), "')",
+        ), " (is ", .getClassName(design, quote = TRUE), ")",
         functionName = ".stopWithWrongDesignMessage",
         parameter = "design",
         value = design
@@ -38,7 +38,7 @@ NULL
     trialDesignClassNames <- c(C_CLASS_NAME_TRIAL_DESIGN_INVERSE_NORMAL, C_CLASS_NAME_TRIAL_DESIGN_FISHER)
     stopIllegalArgument("'design' must be an instance of ",
         .arrayToString(trialDesignClassNames, vectorLookAndFeelEnabled = FALSE),
-        " (is '", .getClassName(design), "')",
+        " (is ", .getClassName(design, quote = TRUE), ")",
         functionName = ".stopWithWrongDesignMessageEnrichment",
         parameter = "design",
         value = design
@@ -51,7 +51,7 @@ NULL
 
 .assertIsParameterSetClass <- function(x, objectName = "x") {
     if (!.isParameterSet(x)) {
-        stopIllegalArgument("'", objectName, "' (", .getClassName(x), ") must be a S4 class ",
+        stopIllegalArgument(.pQuote(objectName), " (", .getClassName(x), ") must be a S4 class ",
             "which inherits from class 'ParameterSet' ",
             functionName = ".assertIsParameterSetClass",
             parameter = "ParameterSet"
@@ -62,7 +62,7 @@ NULL
 .assertIsTrialDesignSet <- function(x, objectName = "x") {
     if (!.isTrialDesignSet(x)) {
         stopIllegalArgument("'designSet' must be an instance of 'TrialDesignSet' ",
-            "(is '", .getClassName(x), "')",
+            "(is ", .getClassName(x, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignSet",
             parameter = "designSet",
             relatedParameter = "TrialDesignSet"
@@ -145,8 +145,7 @@ NULL
 
 .assertIsTrialDesignPlan <- function(designPlan) {
     if (!.isTrialDesignPlan(designPlan)) {
-        stopIllegalArgument("'designPlan' must be an instance of 'TrialDesignPlan' (is '",
-            .getClassName(designPlan), "')",
+        stopIllegalArgument("'designPlan' must be an instance of 'TrialDesignPlan' (is ", .getClassName(designPlan, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignPlan",
             parameter = "designPlan",
             value = designPlan
@@ -158,7 +157,7 @@ NULL
     if (!.isTrialDesign(design)) {
         stopIllegalArgument("'design' must be an instance of ",
             .arrayToString(.getTrialDesignClassNames(), vectorLookAndFeelEnabled = FALSE),
-            " (is '", .getClassName(design), "')",
+            " (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesign",
             parameter = "design",
             value = design
@@ -169,7 +168,7 @@ NULL
 .assertIsTrialDesignInverseNormal <- function(design) {
     if (!.isTrialDesignInverseNormal(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
-            "'TrialDesignInverseNormal' (is '", .getClassName(design), "')",
+            "'TrialDesignInverseNormal' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormal",
             parameter = "design",
             value = design
@@ -180,7 +179,7 @@ NULL
 .assertIsTrialDesignInverseNormalOrFixed <- function(design) {
     if (!.isTrialDesignInverseNormal(design) && !.isTrialDesignFixed(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
-            "'TrialDesignInverseNormal', ", "'TrialDesignFixed' (is '", .getClassName(design), "')",
+            "'TrialDesignInverseNormal', ", "'TrialDesignFixed' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrFixed",
             parameter = "design",
             value = design
@@ -191,7 +190,7 @@ NULL
 .assertIsTrialDesignFisher <- function(design) {
     if (!.isTrialDesignFisher(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
-            "'TrialDesignFisher' (is '", .getClassName(design), "')",
+            "'TrialDesignFisher' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignFisher",
             parameter = "design",
             value = design
@@ -202,7 +201,7 @@ NULL
 .assertIsTrialDesignGroupSequential <- function(design) {
     if (!.isTrialDesignGroupSequential(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
-            "'TrialDesignGroupSequential' (is '", .getClassName(design), "')",
+            "'TrialDesignGroupSequential' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignGroupSequential",
             parameter = "design",
             value = design
@@ -213,7 +212,7 @@ NULL
 .assertIsTrialDesignGroupSequentialOrFixed <- function(design) {
     if (!.isTrialDesignGroupSequential(design) && !.isTrialDesignFixed(design)) {
         stopIllegalArgument("'design' must be an instance of class 'TrialDesignFixed' or ",
-            "'TrialDesignGroupSequential' (is '", .getClassName(design), "')",
+            "'TrialDesignGroupSequential' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignGroupSequentialOrFixed",
             parameter = "design",
             value = design
@@ -224,7 +223,7 @@ NULL
 .assertIsTrialDesignConditionalDunnett <- function(design) {
     if (!.isTrialDesignConditionalDunnett(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
-            "'TrialDesignConditionalDunnett' (is '", .getClassName(design), "')",
+            "'TrialDesignConditionalDunnett' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignConditionalDunnett",
             parameter = "design",
             value = design
@@ -235,7 +234,7 @@ NULL
 .assertIsTrialDesignInverseNormalOrGroupSequential <- function(design) {
     if (!.isTrialDesignInverseNormalOrGroupSequential(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
-            "'TrialDesignInverseNormal' or 'TrialDesignGroupSequential' (is '", .getClassName(design), "')",
+            "'TrialDesignInverseNormal' or 'TrialDesignGroupSequential' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrGroupSequential",
             parameter = "design",
             value = design
@@ -247,7 +246,7 @@ NULL
     if (!.isTrialDesignInverseNormalOrGroupSequential(design) && !.isTrialDesignFixed(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
             "'TrialDesignInverseNormal', ", "'TrialDesignGroupSequential', or ",
-            "'TrialDesignFixed' (is '", .getClassName(design), "')",
+            "'TrialDesignFixed' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrGroupSequentialOrFixed",
             parameter = "design",
             value = design
@@ -267,7 +266,7 @@ NULL
     if (!.isTrialDesignInverseNormalOrGroupSequentialOrFisher(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
             "'TrialDesignInverseNormal', ", "'TrialDesignGroupSequential', or ",
-            "'TrialDesignFisher' (is '", .getClassName(design), "')",
+            "'TrialDesignFisher' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrGroupSequentialOrFisher",
             parameter = "design",
             value = design
@@ -280,7 +279,7 @@ NULL
             !.isTrialDesignFixed(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
             "'TrialDesignInverseNormal', ", "'TrialDesignGroupSequential', ",
-            "'TrialDesignFisher', or ", "'TrialDesignFixed' (is '", .getClassName(design), "')",
+            "'TrialDesignFisher', or ", "'TrialDesignFixed' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrGroupSequentialOrFisherOrFixed",
             parameter = "design",
             value = design
@@ -293,7 +292,7 @@ NULL
             !.isTrialDesignFixed(design)) {
         stopIllegalArgument("'design' must be an instance of class ",
             "'TrialDesignInverseNormal', ", "'TrialDesignFisher', or ",
-            "'TrialDesignFixed' (is '", .getClassName(design), "')",
+            "'TrialDesignFixed' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrFisherOrFixed",
             parameter = "design",
             value = design
@@ -306,8 +305,7 @@ NULL
             !.isTrialDesignConditionalDunnett(design) &&
             !.isTrialDesignFixed(design)) {
         stopIllegalArgument("'design' must be an instance of class 'TrialDesignInverseNormal', ",
-            "'TrialDesignFisher', 'TrialDesignConditionalDunnett', or 'TrialDesignFixed' (is '",
-            .getClassName(design), "')",
+            "'TrialDesignFisher', 'TrialDesignConditionalDunnett', or 'TrialDesignFixed' (is ", .getClassName(design, quote = TRUE), ")",
             functionName = ".assertIsTrialDesignInverseNormalOrFisherOrConditionalDunnettOrFixed",
             parameter = "design",
             value = design
@@ -322,7 +320,7 @@ NULL
 .assertIsSimulationResults <- function(simulationResults) {
     if (!.isSimulationResults(simulationResults)) {
         stopIllegalArgument("'simulationResults' must be an instance of SimulationResults ",
-            "(is '", .getClassName(simulationResults), "')",
+            "(is ", .getClassName(simulationResults, quote = TRUE), ")",
             functionName = ".assertIsSimulationResults",
             parameter = "simulationResults",
             value = simulationResults
@@ -353,7 +351,7 @@ NULL
 .assertIsStageResults <- function(stageResults) {
     if (!.isStageResults(stageResults)) {
         stopIllegalArgument("'stageResults' ", "must be a 'StageResults' object",
-            " (is '", .getClassName(stageResults), "')",
+            " (is ", .getClassName(stageResults, quote = TRUE), ")",
             functionName = ".assertIsStageResults",
             parameter = "stageResults",
             value = stageResults
@@ -401,7 +399,8 @@ NULL
     }
 
     functionName <- paste(deparse(sys.call()), collapse = "")
-    .assertIsNumericVector(x, xName, naAllowed = naAllowed, functionName = functionName, call. = call.)
+    .assertIsNumericVector(x, xName, naAllowed = naAllowed, 
+		functionName = functionName, call. = call.)
 
     if (is.null(upper) || is.na(upper)) {
         if (any(x < lower, na.rm = TRUE)) {
@@ -419,7 +418,8 @@ NULL
             parameter = xName, value = x, constraint = paste0(
                 sQuote(xName), " >= ", lower, " and ",
                 sQuote(xName), " <= ", upper
-            ), functionName = functionName, lowerBound = lower, upperBound = upper
+            ), 
+		functionName = functionName, lowerBound = lower, upperBound = upper
         )
     }
 }
@@ -459,7 +459,7 @@ NULL
     functionName <- paste(deparse(sys.call()), collapse = "")
 
     if (!naAllowed && length(x) > 1 && anyNA(x)) {
-        stopIllegalArgument("'", xName, "' (", .arrayToString(x), ") ",
+        stopIllegalArgument(.pQuote(xName), " (", .arrayToString(x), ") ",
             "must be a valid numeric vector or a single NA",
             functionName = functionName,
             parameter = xName,
@@ -470,7 +470,7 @@ NULL
     if (is.null(upper) || is.na(upper)) {
         if (any(x <= lower, na.rm = TRUE)) {
             prefix <- ifelse(length(x) > 1, "each value of ", "")
-            stopArgumentOutOfBounds(prefix, "'", xName, "' (", .arrayToString(x), ") must be > ", lower,
+            stopArgumentOutOfBounds(prefix, .pQuote(xName), " (", .arrayToString(x), ") must be > ", lower,
                 functionName = functionName,
                 parameter = xName,
                 value = x,
@@ -480,7 +480,7 @@ NULL
             )
         }
     } else if (any(x <= lower, na.rm = TRUE) || any(x >= upper, na.rm = TRUE)) {
-        stopArgumentOutOfBounds("'", xName, "' (", .arrayToString(x),
+        stopArgumentOutOfBounds(.pQuote(xName), " (", .arrayToString(x),
             ") is out of bounds (", lower, "; ", upper, ")",
             functionName = functionName,
             parameter = xName,
@@ -512,7 +512,7 @@ NULL
         l2 <- length(dataInput[[fieldName]])
         if (fieldName != "stages" && l1 != l2) {
             stopIllegalDataInput("all parameters must have the same length ",
-                "('stages' has length ", l1, ", '", fieldName, "' has length ", l2, ")",
+                "('stages' has length ", l1, ", ", .pQuote(fieldName), " has length ", l2, ")",
                 functionName = ".assertIsValidDataInput",
                 parameter = "stages"
             )
@@ -626,7 +626,7 @@ NULL
     if (!.isDataset(dataInput)) {
         stopIllegalArgument("'dataInput' must be an instance of class ",
             "'DatasetMeans', 'DatasetRates' or 'DatasetSurvival' ",
-            "(is '", .getClassName(dataInput), "')",
+            "(is ", .getClassName(dataInput, quote = TRUE), ")",
             functionName = ".assertIsDataset",
             parameter = "dataInput",
             value = dataInput
@@ -637,7 +637,7 @@ NULL
 .assertIsDatasetMeans <- function(dataInput) {
     if (!.isDatasetMeans(dataInput = dataInput)) {
         stopIllegalArgument("'dataInput' must be an instance of class ",
-            "'DatasetMeans' (is '", .getClassName(dataInput), "')",
+            "'DatasetMeans' (is ", .getClassName(dataInput, quote = TRUE), ")",
             functionName = ".assertIsDatasetMeans",
             parameter = "dataInput",
             value = dataInput
@@ -648,7 +648,7 @@ NULL
 .assertIsDatasetRates <- function(dataInput) {
     if (!.isDatasetRates(dataInput = dataInput)) {
         stopIllegalArgument("'dataInput' must be an instance of class ",
-            "'DatasetRates' (is '", .getClassName(dataInput), "')",
+            "'DatasetRates' (is ", .getClassName(dataInput, quote = TRUE), ")",
             functionName = ".assertIsDatasetRates",
             parameter = "dataInput",
             value = dataInput
@@ -660,7 +660,7 @@ NULL
     if (!.isDatasetSurvival(dataInput = dataInput)) {
         stopIllegalArgument("'dataInput' must be an instance of class ",
             "'DatasetSurvival' or 'DatasetEnrichmentSurvival' ",
-            "(is '", .getClassName(dataInput), "')",
+            "(is ", .getClassName(dataInput, quote = TRUE), ")",
             functionName = ".assertIsDatasetSurvival",
             parameter = "dataInput",
             value = dataInput
@@ -752,7 +752,7 @@ NULL
         call. = FALSE) {
     if (missing(x) || is.null(x) || length(x) == 0) {
         .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = FALSE)
-        stopMissingArgument("'", argumentName, "' must be a valid integer value or vector",
+        stopMissingArgument(.pQuote(argumentName), " must be a valid integer value or vector",
             functionName = ".assertIsIntegerVector",
             parameter = argumentName,
             value = if (!missing(x)) x else NULL
@@ -767,7 +767,7 @@ NULL
 
     if (!is.numeric(x) || (!naAllowed && anyNA(x)) || (validateType && !is.integer(x)) ||
             (!validateType && any(as.integer(na.omit(x)) != na.omit(x)))) {
-        stopIllegalArgument("'", argumentName, "' (", .arrayToString(x),
+        stopIllegalArgument(.pQuote(argumentName), " (", .arrayToString(x),
             ") must be a valid integer value or vector",
             functionName = ".assertIsIntegerVector",
             parameter = argumentName,
@@ -787,7 +787,7 @@ NULL
         call. = FALSE) {
     if (missing(x) || is.null(x) || length(x) == 0) {
         .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = FALSE)
-        stopMissingArgument("'", argumentName, "' ", "must be a valid logical value or vector",
+        stopMissingArgument(.pQuote(argumentName), " ", "must be a valid logical value or vector",
             functionName = ".assertIsLogicalVector",
             parameter = argumentName,
             value = if (!missing(x)) x else NULL
@@ -797,7 +797,7 @@ NULL
     .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = TRUE)
 
     if ((!naAllowed && anyNA(x)) || !is.logical(x)) {
-        stopIllegalArgument("'", argumentName, "' (", x, ") ",
+        stopIllegalArgument(.pQuote(argumentName), " (", x, ") ",
             "must be a valid logical value or vector",
             functionName = ".assertIsLogicalVector",
             parameter = argumentName,
@@ -810,7 +810,7 @@ NULL
 
 .assertIsNoDefault <- function(x, argumentName, noDefaultAvailable, ..., checkNA = FALSE) {
     if (noDefaultAvailable && (!checkNA || all(is.na(x)))) {
-        stopMissingArgument("'", argumentName, "' ",
+        stopMissingArgument(.pQuote(argumentName), " ",
             "must be specified, there is no default value",
             functionName = ".assertIsNoDefault",
             parameter = argumentName,
@@ -822,7 +822,7 @@ NULL
 .assertIsSingleLogical <- function(x, argumentName, ..., naAllowed = FALSE, noDefaultAvailable = FALSE) {
     if (missing(x) || is.null(x) || length(x) == 0) {
         .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = FALSE)
-        stopMissingArgument("'", argumentName, "' ",
+        stopMissingArgument(.pQuote(argumentName), " ",
             "must be a single logical value",
             functionName = ".assertIsSingleLogical",
             parameter = argumentName,
@@ -833,7 +833,7 @@ NULL
     .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = TRUE)
 
     if (length(x) > 1) {
-        stopIllegalArgument("'", argumentName, "' ",
+        stopIllegalArgument(.pQuote(argumentName), " ",
             .arrayToString(x, vectorLookAndFeelEnabled = TRUE), " must be a single logical value",
             functionName = ".assertIsSingleLogical",
             parameter = argumentName,
@@ -842,7 +842,7 @@ NULL
     }
 
     if ((!naAllowed && is.na(x)) || !is.logical(x)) {
-        stopIllegalArgument("'", argumentName, "' (",
+        stopIllegalArgument(.pQuote(argumentName), " (",
             ifelse(.isResultObjectBaseClass(x), .getClassName(x), x),
             ") must be a single logical value",
             functionName = ".assertIsSingleLogical",
@@ -863,7 +863,7 @@ NULL
         call. = FALSE) {
     if (missing(x) || is.null(x) || length(x) == 0) {
         .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = FALSE)
-        stopMissingArgument("'", argumentName, "' must be a valid numeric value",
+        stopMissingArgument(.pQuote(argumentName), " must be a valid numeric value",
             functionName = ".assertIsSingleNumber",
             parameter = argumentName,
             value = if (!missing(x)) x else NULL
@@ -873,7 +873,7 @@ NULL
     .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = TRUE)
 
     if (length(x) > 1) {
-        stopIllegalArgument("'", argumentName, "' ",
+        stopIllegalArgument(.pQuote(argumentName), " ",
             .arrayToString(x, vectorLookAndFeelEnabled = TRUE),
             " must be a single numeric value",
             functionName = ".assertIsSingleNumber",
@@ -883,7 +883,7 @@ NULL
     }
 
     if ((!naAllowed && is.na(x)) || !is.numeric(x)) {
-        stopIllegalArgument("'", argumentName, "' (",
+        stopIllegalArgument(.pQuote(argumentName), " (",
             ifelse(.isResultObjectBaseClass(x), .getClassName(x), x), ") must be a valid numeric value",
             functionName = ".assertIsSingleNumber",
             parameter = argumentName,
@@ -925,7 +925,7 @@ NULL
     prefix <- ifelse(mustBePositive, "single positive ", "single ")
     if (missing(x) || is.null(x) || length(x) == 0) {
         .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = FALSE)
-        stopMissingArgument("'", argumentName, "' must be a ", prefix, "integer value",
+        stopMissingArgument(.pQuote(argumentName), " must be a ", prefix, "integer value",
             functionName = ".assertIsSinglePositiveInteger",
             parameter = argumentName,
             relatedParameter = "prefix",
@@ -937,7 +937,7 @@ NULL
     .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = TRUE)
 
     if (length(x) > 1) {
-        stopIllegalArgument("'", argumentName, "' ",
+        stopIllegalArgument(.pQuote(argumentName), " ",
             .arrayToString(x, vectorLookAndFeelEnabled = TRUE), " must be a ",
             prefix, "integer value",
             functionName = ".assertIsSinglePositiveInteger",
@@ -948,7 +948,7 @@ NULL
 
     if (!is.numeric(x) || (!naAllowed && is.na(x)) || (validateType && !is.integer(x)) ||
             (!validateType && !is.na(x) && !is.infinite(x) && as.integer(x) != x)) {
-        stopIllegalArgument("'", argumentName, "' (",
+        stopIllegalArgument(.pQuote(argumentName), " (",
             ifelse(.isResultObjectBaseClass(x), .getClassName(x), x),
             ") must be a ", prefix, "integer value",
             functionName = ".assertIsSinglePositiveInteger",
@@ -958,7 +958,7 @@ NULL
     }
 
     if (mustBePositive && !is.na(x) && !is.infinite(x) && x <= 0) {
-        stopIllegalArgument("'", argumentName, "' (",
+        stopIllegalArgument(.pQuote(argumentName), " (",
             ifelse(.isResultObjectBaseClass(x), .getClassName(x), x), ") must be a ", prefix,
             "integer value",
             functionName = ".assertIsSinglePositiveInteger",
@@ -979,7 +979,7 @@ NULL
         call. = FALSE) {
     if (missing(x) || is.null(x) || length(x) == 0) {
         .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = FALSE)
-        stopMissingArgument("'", argumentName, "' must be a valid character value",
+        stopMissingArgument(.pQuote(argumentName), " must be a valid character value",
             functionName = ".assertIsSingleCharacter",
             parameter = argumentName,
             value = if (!missing(x)) x else NULL
@@ -989,7 +989,7 @@ NULL
     .assertIsNoDefault(x, argumentName, noDefaultAvailable, checkNA = TRUE)
 
     if (length(x) > 1) {
-        stopIllegalArgument("'", argumentName, "' ",
+        stopIllegalArgument(.pQuote(argumentName), " ",
             .arrayToString(x, vectorLookAndFeelEnabled = TRUE), " must be a single character value",
             functionName = ".assertIsSingleCharacter",
             parameter = argumentName,
@@ -1024,7 +1024,7 @@ NULL
 
 .assertIsCharacter <- function(x, argumentName, ..., naAllowed = FALSE) {
     if (missing(x) || is.null(x) || length(x) == 0) {
-        stopMissingArgument("'", argumentName, "' must be a valid character value or vector",
+        stopMissingArgument(.pQuote(argumentName), " must be a valid character value or vector",
             functionName = ".assertIsCharacter",
             parameter = argumentName,
             value = if (!missing(x)) x else NULL
@@ -1093,11 +1093,11 @@ NULL
         constraint <- NULL
         if (identical(relatedParameter, "typeOfDesign") && !is.null(relatedValue)) {
             constraint <- paste0(
-                "must be specified for '", relatedParameter, "' = '", relatedValue, "'"
+                "must be specified for ", .pQuote(relatedParameter), " = ", .pQuote(relatedValue)
             )
         }
 
-        stopMissingArgument("parameter '", parameterName, "' must be specified in design",
+        stopMissingArgument("parameter ", .pQuote(parameterName), " must be specified in design",
             functionName = ".assertDesignParameterExists",
             parameter = parameterName,
             relatedParameter = relatedParameter,
@@ -1253,7 +1253,7 @@ NULL
     }
 
     if (anyNA(lambda)) {
-        stopIllegalArgument("'", argumentName, "' (", .arrayToString(lambda),
+        stopIllegalArgument(.pQuote(argumentName), " (", .arrayToString(lambda),
             ") must be a valid numeric vector",
             functionName = ".assertIsValidLambda",
             parameter = argumentName,
@@ -1264,7 +1264,7 @@ NULL
 
     .assertIsInClosedInterval(lambda, argumentName, lower = 0, upper = NULL)
     if (all(lambda == 0)) {
-        stopIllegalArgument("'", argumentName, "' (", .arrayToString(lambda),
+        stopIllegalArgument(.pQuote(argumentName), " (", .arrayToString(lambda),
             ") not allowed: ", "at least one lambda value must be > 0",
             functionName = ".assertIsValidLambda",
             parameter = argumentName,
@@ -1341,7 +1341,7 @@ NULL
     }
 
     if (any(stDev <= 0)) {
-        stopArgumentOutOfBounds("standard deviation '", name, "' ",
+        stopArgumentOutOfBounds("standard deviation ", .pQuote(name), " ",
             "(", .arrayToString(stDev), ") must be > 0",
             functionName = ".assertIsValidStandardDeviation",
             parameter = "name",
@@ -1531,7 +1531,8 @@ NULL
             value = informationRates, constraint = sprintf(
                 "must be strictly increasing: 0 < x_1 < .. < x_%s <= 1",
                 kMax
-            ), functionName = ".assertAreValidInformationRates"
+            ), 
+		functionName = ".assertAreValidInformationRates"
         )
     }
 
@@ -1720,7 +1721,9 @@ NULL
     if (length(futilityBounds) != kMax - 1) {
         stopConflictingArguments("length of 'futilityBounds' (", length(futilityBounds), ") must be equal to 'kMax' (",
             kMax, ") - 1",
-            parameter = "futilityBounds", value = futilityBounds, relatedParameter = "kMax", relatedValue = kMax,
+            parameter = "futilityBounds", value = futilityBounds, 
+		relatedParameter ="kMax", 
+		relatedValue = kMax,
             functionName = ".assertAreValidFutilityBounds"
         )
     }
@@ -1735,7 +1738,8 @@ NULL
 .assertIsValidCipher <- function(key, value) {
     if (!(key %in% names(C_CIPHERS)) || (getCipheredValue(value) != C_CIPHERS[[key]])) {
         stopIllegalArgument("'token' and/or 'secret' unkown",
-            functionName = ".assertIsValidCipher", parameter = "token",
+            functionName = ".assertIsValidCipher", 
+		parameter ="token",
             relatedParameter = "secret"
         )
     }
@@ -1901,7 +1905,8 @@ NULL
                 paste0("'nPlanned' (%s) is invalid: ", "length must be equal to %s (kMax - stage = %s - %s)"),
                 .arrayToString(nPlanned), kMax - stage, kMax, stage
             ),
-            functionName = ".assertIsValidNPlanned", parameter = "nPlanned",
+            functionName = ".assertIsValidNPlanned", 
+		parameter ="nPlanned",
             value = nPlanned
         )
     }
@@ -2004,8 +2009,7 @@ NULL
                 argValue <- paste0(" = ", argValue)
             }, error = function(e) {})
             if (exceptionEnabled) {
-                stopIllegalArgument("argument unknown in ", functionName, "(...): '",
-                    argName, "'", argValue, " is not allowed",
+                stopIllegalArgument("argument unknown in ", functionName, "(...): ", .pQuote(argName), argValue, " is not allowed",
                     functionName = ".warnInCaseOfUnknownArguments",
                     parameter = "functionName",
                     value = functionName,
@@ -2013,7 +2017,7 @@ NULL
                     relatedValue = argName
                 )
             } else {
-                warning("Argument unknown in ", functionName, "(...): '", argName, "'",
+                warning("Argument unknown in ", functionName, "(...): ", .pQuote(argName),
                     argValue, " will be ignored",
                     call. = FALSE
                 )
@@ -2024,8 +2028,7 @@ NULL
 
 .warnInCaseOfUnusedArgument <- function(arg, argName, defaultValue, functionName) {
     if (!identical(arg, defaultValue)) {
-        warning("Unused argument in ", functionName, "(...): '",
-            argName, "' = ", .arrayToString(
+        warning("Unused argument in ", functionName, "(...): ", .pQuote(argName), " = ", .arrayToString(
                 arg,
                 vectorLookAndFeelEnabled = (length(arg) > 1),
                 maxLength = 10,
@@ -2246,7 +2249,7 @@ NULL
 
 .assertIsValidPi <- function(piValue, piName) {
     if (is.null(piValue) || length(piValue) == 0) {
-        stopIllegalArgument("'", piName, "' must be a valid numeric value",
+        stopIllegalArgument(.pQuote(piName), " must be a valid numeric value",
             functionName = ".assertIsValidPi",
             parameter = "piName", value = piName
         )
@@ -2257,7 +2260,7 @@ NULL
     }
 
     if (!is.numeric(piValue) || anyNA(piValue)) {
-        stopIllegalArgument("'", piName, "' (", .arrayToString(piValue),
+        stopIllegalArgument(.pQuote(piName), " (", .arrayToString(piValue),
             ") must be a valid numeric value",
             functionName = ".assertIsValidPi",
             parameter = "piName",
@@ -2268,7 +2271,7 @@ NULL
     }
 
     if (any(piValue <= -1e-16) || any(piValue >= 1 + 1e-16)) {
-        stopArgumentOutOfBounds("'", piName, "' (",
+        stopArgumentOutOfBounds(.pQuote(piName), " (",
             .arrayToString(piValue), ") ", "is out of bounds (0; 1) or event time too long",
             functionName = ".assertIsValidPi",
             parameter = "piName",
@@ -2668,7 +2671,7 @@ NULL
     }
 
     if (!is.function(fun)) {
-        stopIllegalArgument("'", funArgName, "' must be a function",
+        stopIllegalArgument(.pQuote(funArgName), " must be a function",
             parameter = funArgName,
             value = fun,
             constraint = "must be a function",
@@ -2698,7 +2701,7 @@ NULL
 
     if (validateThreeDots) {
         if (!("..." %in% argNames)) {
-            stopIllegalArgument("'", funArgName, "' ",
+            stopIllegalArgument(.pQuote(funArgName), " ",
                 "must contain the three-dots argument '...', e.g., ", funArgName,
                 " = ", functionName, "(", .arrayToString(argNames), ", ...)",
                 parameter = funArgName,
@@ -2719,11 +2722,10 @@ NULL
     for (argName in argNames) {
         if (argName != "..." && !(argName %in% argNamesExpected)) {
             msg <- paste0(
-                "the argument '", argName, "' in '", funArgName,
-                "' (", functionName, ") is not allowed."
+                "the argument ", .pQuote(argName), " in ", .pQuote(funArgName), " (", functionName, ") is not allowed."
             )
             if (length(argNamesExpected) == 1) {
-                stopIllegalArgument(msg, " Expected: '", argNamesExpected, "'",
+                stopIllegalArgument(msg, " Expected: ", .pQuote(argNamesExpected),
                     parameter = argName,
                     value = fun,
                     relatedParameter = funArgName,
@@ -2748,12 +2750,13 @@ NULL
     if (identical) {
         for (argNameExpected in argNamesExpected) {
             if (argNameExpected != "..." && !(argNameExpected %in% argNames)) {
-                stopIllegalArgument("'", funArgName, "' (", functionName, ") must contain ",
-                    "an argument with name '", argNameExpected, "'",
+                stopIllegalArgument(.pQuote(funArgName), " (", functionName, ") must contain ",
+                    "an argument with name ", .pQuote(argNameExpected),
                     parameter = funArgName, value = fun, constraint = paste0(
-                        "must contain an argument with name '",
-                        argNameExpected, "'"
-                    ), functionName = ".assertIsValidFunction", relatedParameter = "functionName",
+                        "must contain an argument with name ", .pQuote(argNameExpected)
+                    ), 
+		functionName = ".assertIsValidFunction", 
+		relatedParameter ="functionName",
                     relatedValue = functionName
                 )
             }
@@ -2772,7 +2775,7 @@ NULL
     }
 
     if (counter == 0) {
-        stopIllegalArgument("'", funArgName, "' (", functionName, ") must contain at ",
+        stopIllegalArgument(.pQuote(funArgName), " (", functionName, ") must contain at ",
             "least one of the following arguments: ",
             .arrayToString(argNamesExpected),
             parameter = funArgName, value = fun, constraint = paste0(
@@ -2786,8 +2789,8 @@ NULL
     }
 
     if (showUnusedArgumentsMessage && length(unusedArgs) > 0) {
-        message("Note that the following arguments can optionally be used in '",
-            funArgName, "' (", functionName, "): \n",
+        message("Note that the following arguments can optionally be used in ", 
+            .pQuote(funArgName), " (", functionName, "): \n",
             .arrayToString(unusedArgs),
             call. = FALSE
         )
@@ -2814,7 +2817,7 @@ NULL
     parameterName <- match.arg(parameterName)
     .assertIsIntegerVector(plannedValues, parameterName, validateType = FALSE)
     if (length(plannedValues) != design$kMax) {
-        stopIllegalArgument("'", parameterName, "' (",
+        stopIllegalArgument(.pQuote(parameterName), " (",
             .arrayToString(plannedValues), ") ", "must have length ",
             design$kMax,
             functionName = ".assertIsValidPlannedSubjectsOrEvents",
@@ -2855,13 +2858,13 @@ NULL
     if (is.na(conditionalPower) && is.null(calcSubjectsFunction)) {
         if (length(parameterValues) != 1 || !is.na(parameterValues)) {
             if (calcSubjectsFunctionEnabled) {
-                warning("'", parameterName, "' (", .arrayToString(parameterValues), ") ",
-                    "will be ignored because neither 'conditionalPower' nor '",
-                    calcSubjectsFunctionName, "' is defined",
+                warning(.pQuote(parameterName), " (", .arrayToString(parameterValues), ") ",
+                    "will be ignored because neither 'conditionalPower' nor ", 
+                    .pQuote(calcSubjectsFunctionName), " is defined",
                     call. = FALSE
                 )
             } else {
-                warning("'", parameterName, "' (", .arrayToString(parameterValues), ") ",
+                warning(.pQuote(parameterName), " (", .arrayToString(parameterValues), ") ",
                     "will be ignored because 'conditionalPower' is not defined",
                     call. = FALSE
                 )
@@ -2873,16 +2876,15 @@ NULL
     if (!is.na(conditionalPower) && length(parameterValues) == 0 ||
             (length(parameterValues) == 1 && is.na(parameterValues))) {
         if (calcSubjectsFunctionEnabled) {
-            stopMissingArgument("'", parameterName, "' must be defined ",
-                "because 'conditionalPower' or '", calcSubjectsFunctionName,
-                "' is defined",
+            stopMissingArgument(.pQuote(parameterName), " must be defined ",
+                "because 'conditionalPower' or ", .pQuote(calcSubjectsFunctionName), " is defined",
                 functionName = ".assertIsValidNumberOfSubjectsPerStage",
                 parameter = parameterName,
                 relatedParameter = "conditionalPower",
                 relatedValue = conditionalPower
             )
         } else {
-            stopMissingArgument("'", parameterName, "' must be defined ",
+            stopMissingArgument(.pQuote(parameterName), " must be defined ",
                 "because 'conditionalPower' is defined",
                 functionName = ".assertIsValidNumberOfSubjectsPerStage",
                 parameter = parameterName,
@@ -2893,7 +2895,7 @@ NULL
     }
 
     if (length(parameterValues) != kMax) {
-        stopIllegalArgument("'", parameterName, "' (",
+        stopIllegalArgument(.pQuote(parameterName), " (",
             .arrayToString(parameterValues), ") must have length ", kMax,
             functionName = ".assertIsValidNumberOfSubjectsPerStage",
             parameter = parameterName,
@@ -2902,7 +2904,7 @@ NULL
     }
 
     if (any(is.na(parameterValues[2:length(parameterValues)]))) {
-        stopIllegalArgument("'", parameterName, "' (", .arrayToString(parameterValues),
+        stopIllegalArgument(.pQuote(parameterName), " (", .arrayToString(parameterValues),
             ") must contain valid numeric values",
             functionName = ".assertIsValidNumberOfSubjectsPerStage",
             parameter = parameterName,
@@ -2911,7 +2913,7 @@ NULL
     }
 
     if (!is.na(parameterValues[1]) && parameterValues[1] != plannedSubjects[1]) {
-        warning("First value of '", parameterName, "' ",
+        warning("First value of ", .pQuote(parameterName), " ",
             "(", parameterValues[1], ") will be ignored",
             call. = FALSE
         )
@@ -3100,7 +3102,7 @@ NULL
     if (!(.getClassName(stageResults) %in% allowedClasses)) {
         stopIllegalArgument("'stageResults' must be an instance of ",
             .arrayToString(allowedClasses, vectorLookAndFeelEnabled = FALSE),
-            " (is '", .getClassName(stageResults), "')",
+            " (is ", .getClassName(stageResults, quote = TRUE), ")",
             functionName = ".assertIsStageResultsNonMultiHypotheses",
             parameter = "stageResults",
             value = stageResults
@@ -3131,7 +3133,7 @@ NULL
     if (!inherits(analysisResults, "AnalysisResults")) {
         stopIllegalArgument("'analysisResults' ",
             "must be a valid 'AnalysisResults' object ",
-            " (is '", .getClassName(analysisResults), "')",
+            " (is ", .getClassName(analysisResults, quote = TRUE), ")",
             functionName = ".assertIsAnalysisResults",
             parameter = "analysisResults",
             value = analysisResults,
@@ -3155,7 +3157,7 @@ NULL
     intersectionTest <- intersectionTest[1]
     if (.isTrialDesignConditionalDunnett(design) && intersectionTest != "Dunnett") {
         if (userFunctionCallEnabled) {
-            message <- paste0("Intersection test '", intersectionTest, "' ")
+            message <- paste0("Intersection test ", .pQuote(intersectionTest), " ")
             if (!.isValidIntersectionTestMultiArm(intersectionTest)) {
                 message <- paste0(message, "is invalid, ")
             }
@@ -3189,7 +3191,7 @@ NULL
     if (.isTrialDesignConditionalDunnett(design) &&
             intersectionTest != "Dunnett") {
         stopIllegalArgument("intersection test ",
-            "('", intersectionTest, "') must be 'Dunnett' ",
+            "(", .pQuote(intersectionTest), ") must be 'Dunnett' ",
             "because conditional Dunnett test was specified as design",
             functionName = ".assertIsValidIntersectionTestMultiArm",
             parameter = "intersectionTest",
@@ -3240,7 +3242,7 @@ NULL
         prefix <- paste0(trimws(prefix), " ")
     }
 
-    warning(prefix, "'", paramName, "' (",
+    warning(prefix, .pQuote(paramName), " (",
         .arrayToString(paramValue), ") will be ignored because ",
         requirementFailedReason,
         call. = FALSE
@@ -3307,9 +3309,8 @@ NULL
         )
     }
     if (.isTrialDesignConditionalDunnett(design) && varianceOption != C_VARIANCE_OPTION_DUNNETT) {
-        stopIllegalArgument("variance option ('", varianceOption,
-            "') must be '", C_VARIANCE_OPTION_DUNNETT,
-            "' ", "because conditional Dunnett test was specified as design",
+        stopIllegalArgument("variance option (", .pQuote(varianceOption), ") must be ", 
+            .pQuote(C_VARIANCE_OPTION_DUNNETT), " because conditional Dunnett test was specified as design",
             functionName = ".assertIsValidVarianceOptionMultiArmed",
             parameter = "varianceOption",
             value = varianceOption,
@@ -3496,7 +3497,7 @@ NULL
         relatedParameter = NULL,
         relatedValue = NULL) {
     if (missing(x) || is.null(x) || length(x) == 0) {
-        stopMissingArgument("'", argumentName, "' must be specified",
+        stopMissingArgument(.pQuote(argumentName), " must be specified",
             functionName = ".assertIsValidMatrix",
             parameter = argumentName,
             value = if (!missing(x)) x else NULL,
@@ -3512,7 +3513,7 @@ NULL
         } else if (length(x) > 1 && !is.na(expectedNumberOfColumns)) {
             if (length(x) %% expectedNumberOfColumns != 0) {
                 stopIllegalArgument("the length of ",
-                    "'", argumentName, "' (", .arrayToString(x), ") must be a divisor or a multiple ",
+                    .pQuote(argumentName), " (", .arrayToString(x), ") must be a divisor or a multiple ",
                     expectedNumberOfColumns,
                     functionName = ".assertIsValidMatrix",
                     parameter = argumentName,
@@ -3525,7 +3526,7 @@ NULL
     }
 
     if (!is.matrix(x)) {
-        stopIllegalArgument("'", argumentName, "' (", .getClassName(x), ") ",
+        stopIllegalArgument(.pQuote(argumentName), " (", .getClassName(x), ") ",
             "must be a valid matrix",
             functionName = ".assertIsValidMatrix",
             parameter = argumentName,
@@ -3534,7 +3535,7 @@ NULL
     }
 
     if (!naAllowed && anyNA(x)) {
-        stopIllegalArgument("'", argumentName, "' (", .arrayToString(x), ") ",
+        stopIllegalArgument(.pQuote(argumentName), " (", .arrayToString(x), ") ",
             "must not contain NA's",
             functionName = ".assertIsValidMatrix",
             parameter = argumentName,
@@ -3543,7 +3544,7 @@ NULL
     }
 
     if (!is.numeric(x)) {
-        stopIllegalArgument("'", argumentName, "' (", .arrayToString(x), ") ",
+        stopIllegalArgument(.pQuote(argumentName), " (", .arrayToString(x), ") ",
             "must be a valid numeric matrix",
             functionName = ".assertIsValidMatrix",
             parameter = argumentName,
@@ -3552,7 +3553,7 @@ NULL
     }
 
     if (!is.na(expectedNumberOfColumns) && ncol(x) != expectedNumberOfColumns) {
-        stopIllegalArgument("'", argumentName, "' (", .arrayToString(x), ") ",
+        stopIllegalArgument(.pQuote(argumentName), " (", .arrayToString(x), ") ",
             "must be a numeric matrix with ",
             expectedNumberOfColumns, " columns",
             functionName = ".assertIsValidMatrix",
@@ -3568,7 +3569,8 @@ NULL
     .assertIsValidMatrix(decisionMatrix, "decisionMatrix", naAllowed = FALSE)
     if (!(nrow(decisionMatrix) %in% c(2, 4))) {
         stopIllegalArgument("'decisionMatrix' must have two or four rows",
-            functionName = ".assertIsValidDecisionMatrix", parameter = "decisionMatrix",
+            functionName = ".assertIsValidDecisionMatrix", 
+		parameter ="decisionMatrix",
             value = decisionMatrix
         )
     }
@@ -3648,7 +3650,8 @@ NULL
     if (typeOfShape == "userDefined") {
         effectMatrix <- .assertIsValidMatrix(effectMatrix, "effectMatrix",
             expectedNumberOfColumns = gMax, naAllowed = FALSE, returnSingleValueAsMatrix = TRUE,
-            relatedParameter = "typeOfShape", relatedValue = typeOfShape
+            relatedParameter = "typeOfShape", 
+		relatedValue = typeOfShape
         )
         .assertIsNumericVector(valueMaxVector, valueMaxVectorName, naAllowed = TRUE)
         valueMaxVectorDefault <- C_ALTERNATIVE_POWER_SIMULATION_DEFAULT
@@ -3672,13 +3675,13 @@ NULL
         if (!is.null(doseLevels) && !anyNA(doseLevels)) {
             warning("'doseLevels' (", .arrayToString(doseLevels), ") ",
                 "will be ignored because 'typeOfShape' ",
-                "is defined as '", typeOfShape, "'",
+                "is defined as ", .pQuote(typeOfShape), 
                 call. = FALSE
             )
         }
     } else if (!is.null(effectMatrix)) {
         warning("'effectMatrix' will be ignored because 'typeOfShape' ",
-            "is defined as '", typeOfShape, "'",
+            "is defined as ", .pQuote(typeOfShape), 
             call. = FALSE
         )
     }
@@ -3939,7 +3942,8 @@ NULL
     if (sided != 1 && sided != 2) {
         stopIllegalArgument("'sided' (", sided, ") must be defined as 1 or 2",
             parameter = "sided", value = sided,
-            constraint = "must be defined as 1 or 2", functionName = ".assertIsValidEffectCountData"
+            constraint = "must be defined as 1 or 2", 
+		functionName = ".assertIsValidEffectCountData"
         )
     }
     .assertIsSingleNumber(lambda, "lambda", naAllowed = TRUE)
@@ -4313,8 +4317,8 @@ NULL
 
     warning(
         sQuote(argumentName), valueStr, " will be ignored ",
-        "because it is not required for the conversion from '",
-        sourceScale, "' to '", targetScale, "'",
+        "because it is not required for the conversion from ", 
+        .pQuote(sourceScale), " to ", .pQuote(targetScale),
         call. = FALSE
     )
 }

--- a/R/f_core_constants.R
+++ b/R/f_core_constants.R
@@ -1216,14 +1216,13 @@ C_PARAMETER_NAMES_PLOT_SETTINGS <- createDictionary("C_PARAMETER_NAMES_PLOT_SETT
             }
         }
     }
-    
+
     if (parameterName %in% c("rejectAtLeastOne", "rejectedArmsPerStage") &&
             inherits(obj, "SimulationResultsMultiArmSurvival") &&
             !is.null(obj$activeArms) && obj$activeArms == 1) {
         if (identical(parameterName, "rejectAtLeastOne")) {
             paramCaption <- "Overall reject"
-        }
-        else if (identical(parameterName, "rejectedArmsPerStage")) {
+        } else if (identical(parameterName, "rejectedArmsPerStage")) {
             paramCaption <- "Reject per stage"
         }
     }

--- a/R/f_core_constants.R
+++ b/R/f_core_constants.R
@@ -668,7 +668,7 @@ C_PARAMETER_NAMES <- createDictionary("C_PARAMETER_NAMES", list(
     epsilonValue = "Epsilon value",
     rValue = "r value",
     threshold = "Threshold",
-    rejectAtLeastOne = "Reject at least one",
+    rejectAtLeastOne = "Overall reject at least one",
     selectedArms = "Selected arms",
     rejectedArmsPerStage = "Rejected arms per stage",
     selectedPopulations = "Selected populations",
@@ -984,7 +984,7 @@ C_TABLE_COLUMN_NAMES <- createDictionary("C_TABLE_COLUMN_NAMES", list(
     epsilonValue = "Epsilon value",
     rValue = "r value",
     threshold = "Threshold",
-    rejectAtLeastOne = "Reject at least one",
+    rejectAtLeastOne = "Overall reject at least one",
     selectedArms = "Selected arm",
     rejectedArmsPerStage = "Rejected arm per stage",
     successPerStage = "Success per stage",
@@ -1214,6 +1214,17 @@ C_PARAMETER_NAMES_PLOT_SETTINGS <- createDictionary("C_PARAMETER_NAMES_PLOT_SETT
             } else {
                 paramCaption <- sub("Upper bounds of continuation", "Lower bounds of continuation", paramCaption)
             }
+        }
+    }
+    
+    if (parameterName %in% c("rejectAtLeastOne", "rejectedArmsPerStage") &&
+            inherits(obj, "SimulationResultsMultiArmSurvival") &&
+            !is.null(obj$activeArms) && obj$activeArms == 1) {
+        if (identical(parameterName, "rejectAtLeastOne")) {
+            paramCaption <- "Overall reject"
+        }
+        else if (identical(parameterName, "rejectedArmsPerStage")) {
+            paramCaption <- "Reject per stage"
         }
     }
 

--- a/R/f_core_output_formats.R
+++ b/R/f_core_output_formats.R
@@ -62,7 +62,9 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
     }
 
     if (!is.numeric(value)) {
-        stopRuntimeIssue("'value' must be a numeric vector", functionName = ".getFormattedValue", parameter = "value", value = value)
+        stopRuntimeIssue("'value' must be a numeric vector", 
+		functionName = ".getFormattedValue", 
+		parameter ="value", value = value)
     }
 
     if (futilityProbabilityEnabled) {
@@ -92,7 +94,8 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
     } else if (digits <= 0) {
         stopIllegalArgument("'digits' must be greater than 0 if no 'roundFunction' is specified",
             functionName = ".getFormattedValue",
-            parameter = "digits", relatedParameter = "roundFunction", value = digits
+            parameter = "digits", 
+		relatedParameter ="roundFunction", value = digits
         )
     }
 
@@ -163,46 +166,55 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
 
     parts <- base::strsplit(optionValue, " *, *", fixed = FALSE)[[1]]
     if (length(parts) == 0) {
-        stopIllegalArgument("the value (", optionValue, ") of output format option '", optionKey, "' is invalid",
-            functionName = ".assertIsValitOutputFormatOptionValue", parameter = "optionValue", value = optionValue,
-            relatedParameter = "optionKey", relatedValue = optionKey
+        stopIllegalArgument("the value ", .vQuote(optionValue), " of output format option ", .pQuote(optionKey), " is invalid",
+            functionName = ".assertIsValitOutputFormatOptionValue", 
+		parameter ="optionValue", value = optionValue,
+            relatedParameter = "optionKey", 
+		relatedValue = optionKey
         )
     }
 
     for (part in parts) {
         if (!grepl(" *= *", part)) {
-            stopIllegalArgument("'", optionKey, "' (", part, ") must contain a valid argument-value-pair: \"argument = value\"",
-                functionName = ".assertIsValitOutputFormatOptionValue", parameter = "optionKey", value = optionKey,
-                relatedParameter = "part", relatedValue = part
+            stopIllegalArgument(.pQuote(optionKey), " (", part, ") must ",
+                "contain a valid argument-value-pair: \"argument = value\"",
+                functionName = ".assertIsValitOutputFormatOptionValue", 
+		parameter ="optionKey", value = optionKey,
+                relatedParameter = "part", 
+		relatedValue = part
             )
         }
 
         keyValuePair <- base::strsplit(part, " *= *", fixed = FALSE)[[1]]
         if (length(keyValuePair) != 2) {
-            stopIllegalArgument("'", optionKey, "' contains an invalid argument-value-pair: ", part,
+            stopIllegalArgument(.pQuote(optionKey), " contains an invalid argument-value-pair: ", part,
                 functionName = ".assertIsValitOutputFormatOptionValue",
-                parameter = "optionKey", value = optionKey, relatedParameter = "part", relatedValue = part
+                parameter = "optionKey", value = optionKey, 
+		relatedParameter ="part", 
+		relatedValue = part
             )
         }
 
         key <- trimws(keyValuePair[1])
         if (nchar(key) == 0) {
-            stopIllegalArgument("'", optionKey, "' contains an invalid argument",
+            stopIllegalArgument(.pQuote(optionKey), " contains an invalid argument",
                 functionName = ".assertIsValitOutputFormatOptionValue",
                 parameter = "optionKey", value = optionKey
             )
         }
 
         if (!(key %in% C_OUTPUT_FORMAT_ARGUMENTS)) {
-            stopIllegalArgument("'", optionKey, "' contains an invalid argument: ", key,
+            stopIllegalArgument(.pQuote(optionKey), " contains an invalid argument: ", key,
                 functionName = ".assertIsValitOutputFormatOptionValue",
-                parameter = "optionKey", value = optionKey, relatedParameter = "key", relatedValue = key
+                parameter = "optionKey", value = optionKey, 
+		relatedParameter ="key", 
+		relatedValue = key
             )
         }
 
         value <- trimws(keyValuePair[2])
         if (nchar(value) == 0) {
-            stopIllegalArgument("'", optionKey, "' contains an invalid value",
+            stopIllegalArgument(.pQuote(optionKey), " contains an invalid value",
                 functionName = ".assertIsValitOutputFormatOptionValue",
                 parameter = "optionKey", value = optionKey
             )
@@ -210,24 +222,30 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
 
         if (key %in% c("digits", "nsmall")) {
             if (grepl("\\D", value)) {
-                stopIllegalArgument("the value (", value, ") of '", optionKey, "' must be an integer value",
+                stopIllegalArgument("the value (", value, ") of ", .pQuote(optionKey), " must be an integer value",
                     functionName = ".assertIsValitOutputFormatOptionValue",
-                    parameter = "value", value = value, relatedParameter = "optionKey", relatedValue = optionKey
+                    parameter = "value", value = value, 
+		relatedParameter ="optionKey", 
+		relatedValue = optionKey
                 )
             }
         } else if (key %in% c("roundFunction")) {
             if (!(value %in% C_ROUND_FUNCTIONS)) {
-                stopIllegalArgument("the value (", value, ") of '", optionKey, "' must be one of these character values: ",
+                stopIllegalArgument("the value (", value, ") of ", .pQuote(optionKey), " must be one of these character values: ",
                     .arrayToString(C_ROUND_FUNCTIONS, encapsulate = TRUE),
                     functionName = ".assertIsValitOutputFormatOptionValue",
-                    parameter = "value", value = value, relatedParameter = "optionKey", relatedValue = optionKey
+                    parameter = "value", value = value, 
+		relatedParameter ="optionKey", 
+		relatedValue = optionKey
                 )
             }
         } else if (key %in% c("trimSingleZeros", "futilityProbabilityEnabled")) {
             if (!grepl("TRUE|FALSE", toupper(value))) {
-                stopIllegalArgument("the value (", value, ") of '", optionKey, "' must be a logical value",
+                stopIllegalArgument("the value (", value, ") of ", .pQuote(optionKey), " must be a logical value",
                     functionName = ".assertIsValitOutputFormatOptionValue",
-                    parameter = "value", value = value, relatedParameter = "optionKey", relatedValue = optionKey
+                    parameter = "value", value = value, 
+		relatedParameter ="optionKey", 
+		relatedValue = optionKey
                 )
             }
         }
@@ -784,16 +802,18 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
 
 .getFormattedVariableName <- function(name, n, prefix = "", postfix = "") {
     if (!is.character(name)) {
-        stopIllegalArgument("'name' must be of type 'character' (is '", .getClassName(name), "')",
+        stopIllegalArgument("'name' must be of type 'character' (is ", .getClassName(name, quote = TRUE), ")",
             functionName = ".getFormattedVariableName",
-            parameter = "name", value = name, relatedParameter = "character"
+            parameter = "name", value = name, 
+		relatedParameter ="character"
         )
     }
 
     if (!is.numeric(n)) {
-        stopIllegalArgument("'n' must be of type 'numeric' (is '", .getClassName(n), "')",
+        stopIllegalArgument("'n' must be of type 'numeric' (is ", .getClassName(n, quote = TRUE), ")",
             functionName = ".getFormattedVariableName",
-            parameter = "n", value = n, relatedParameter = "numeric"
+            parameter = "n", value = n, 
+		relatedParameter ="numeric"
         )
     }
 
@@ -908,7 +928,8 @@ setOutputFormat <- function(
     if (!is.na(file)) {
         if (!file.exists(file)) {
             stopIllegalArgument("'file' (", file, ") does not exist",
-                functionName = "setOutputFormat", parameter = "file",
+                functionName = "setOutputFormat", 
+		parameter ="file",
                 value = file
             )
         }
@@ -1048,7 +1069,8 @@ setOutputFormat <- function(
     }
 
     stopIllegalArgument("output format key for 'parameterName' (", parameterName, ") could not be found",
-        functionName = ".getOutputFormatKey", parameter = parameterName
+        functionName = ".getOutputFormatKey", 
+		parameter =parameterName
     )
 }
 

--- a/R/f_core_output_formats.R
+++ b/R/f_core_output_formats.R
@@ -62,9 +62,10 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
     }
 
     if (!is.numeric(value)) {
-        stopRuntimeIssue("'value' must be a numeric vector", 
-		functionName = ".getFormattedValue", 
-		parameter ="value", value = value)
+        stopRuntimeIssue("'value' must be a numeric vector",
+            functionName = ".getFormattedValue",
+            parameter = "value", value = value
+        )
     }
 
     if (futilityProbabilityEnabled) {
@@ -94,8 +95,8 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
     } else if (digits <= 0) {
         stopIllegalArgument("'digits' must be greater than 0 if no 'roundFunction' is specified",
             functionName = ".getFormattedValue",
-            parameter = "digits", 
-		relatedParameter ="roundFunction", value = digits
+            parameter = "digits",
+            relatedParameter = "roundFunction", value = digits
         )
     }
 
@@ -167,10 +168,10 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
     parts <- base::strsplit(optionValue, " *, *", fixed = FALSE)[[1]]
     if (length(parts) == 0) {
         stopIllegalArgument("the value ", .vQuote(optionValue), " of output format option ", .pQuote(optionKey), " is invalid",
-            functionName = ".assertIsValitOutputFormatOptionValue", 
-		parameter ="optionValue", value = optionValue,
-            relatedParameter = "optionKey", 
-		relatedValue = optionKey
+            functionName = ".assertIsValitOutputFormatOptionValue",
+            parameter = "optionValue", value = optionValue,
+            relatedParameter = "optionKey",
+            relatedValue = optionKey
         )
     }
 
@@ -178,10 +179,10 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
         if (!grepl(" *= *", part)) {
             stopIllegalArgument(.pQuote(optionKey), " (", part, ") must ",
                 "contain a valid argument-value-pair: \"argument = value\"",
-                functionName = ".assertIsValitOutputFormatOptionValue", 
-		parameter ="optionKey", value = optionKey,
-                relatedParameter = "part", 
-		relatedValue = part
+                functionName = ".assertIsValitOutputFormatOptionValue",
+                parameter = "optionKey", value = optionKey,
+                relatedParameter = "part",
+                relatedValue = part
             )
         }
 
@@ -189,9 +190,9 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
         if (length(keyValuePair) != 2) {
             stopIllegalArgument(.pQuote(optionKey), " contains an invalid argument-value-pair: ", part,
                 functionName = ".assertIsValitOutputFormatOptionValue",
-                parameter = "optionKey", value = optionKey, 
-		relatedParameter ="part", 
-		relatedValue = part
+                parameter = "optionKey", value = optionKey,
+                relatedParameter = "part",
+                relatedValue = part
             )
         }
 
@@ -206,9 +207,9 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
         if (!(key %in% C_OUTPUT_FORMAT_ARGUMENTS)) {
             stopIllegalArgument(.pQuote(optionKey), " contains an invalid argument: ", key,
                 functionName = ".assertIsValitOutputFormatOptionValue",
-                parameter = "optionKey", value = optionKey, 
-		relatedParameter ="key", 
-		relatedValue = key
+                parameter = "optionKey", value = optionKey,
+                relatedParameter = "key",
+                relatedValue = key
             )
         }
 
@@ -224,9 +225,9 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
             if (grepl("\\D", value)) {
                 stopIllegalArgument("the value (", value, ") of ", .pQuote(optionKey), " must be an integer value",
                     functionName = ".assertIsValitOutputFormatOptionValue",
-                    parameter = "value", value = value, 
-		relatedParameter ="optionKey", 
-		relatedValue = optionKey
+                    parameter = "value", value = value,
+                    relatedParameter = "optionKey",
+                    relatedValue = optionKey
                 )
             }
         } else if (key %in% c("roundFunction")) {
@@ -234,18 +235,18 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
                 stopIllegalArgument("the value (", value, ") of ", .pQuote(optionKey), " must be one of these character values: ",
                     .arrayToString(C_ROUND_FUNCTIONS, encapsulate = TRUE),
                     functionName = ".assertIsValitOutputFormatOptionValue",
-                    parameter = "value", value = value, 
-		relatedParameter ="optionKey", 
-		relatedValue = optionKey
+                    parameter = "value", value = value,
+                    relatedParameter = "optionKey",
+                    relatedValue = optionKey
                 )
             }
         } else if (key %in% c("trimSingleZeros", "futilityProbabilityEnabled")) {
             if (!grepl("TRUE|FALSE", toupper(value))) {
                 stopIllegalArgument("the value (", value, ") of ", .pQuote(optionKey), " must be a logical value",
                     functionName = ".assertIsValitOutputFormatOptionValue",
-                    parameter = "value", value = value, 
-		relatedParameter ="optionKey", 
-		relatedValue = optionKey
+                    parameter = "value", value = value,
+                    relatedParameter = "optionKey",
+                    relatedValue = optionKey
                 )
             }
         }
@@ -804,16 +805,16 @@ C_OUTPUT_FORMAT_DEFAULT_VALUES <- pairlist(
     if (!is.character(name)) {
         stopIllegalArgument("'name' must be of type 'character' (is ", .getClassName(name, quote = TRUE), ")",
             functionName = ".getFormattedVariableName",
-            parameter = "name", value = name, 
-		relatedParameter ="character"
+            parameter = "name", value = name,
+            relatedParameter = "character"
         )
     }
 
     if (!is.numeric(n)) {
         stopIllegalArgument("'n' must be of type 'numeric' (is ", .getClassName(n, quote = TRUE), ")",
             functionName = ".getFormattedVariableName",
-            parameter = "n", value = n, 
-		relatedParameter ="numeric"
+            parameter = "n", value = n,
+            relatedParameter = "numeric"
         )
     }
 
@@ -928,8 +929,8 @@ setOutputFormat <- function(
     if (!is.na(file)) {
         if (!file.exists(file)) {
             stopIllegalArgument("'file' (", file, ") does not exist",
-                functionName = "setOutputFormat", 
-		parameter ="file",
+                functionName = "setOutputFormat",
+                parameter = "file",
                 value = file
             )
         }
@@ -1069,8 +1070,8 @@ setOutputFormat <- function(
     }
 
     stopIllegalArgument("output format key for 'parameterName' (", parameterName, ") could not be found",
-        functionName = ".getOutputFormatKey", 
-		parameter =parameterName
+        functionName = ".getOutputFormatKey",
+        parameter = parameterName
     )
 }
 

--- a/R/f_core_plot.R
+++ b/R/f_core_plot.R
@@ -156,9 +156,9 @@ NULL
     if (stopIfNotFound) {
         stopRuntimeIssue("could not find plot caption for ", .getClassName(obj), " and type ", type,
             functionName = ".getPlotCaption",
-            parameter = "obj", value = obj, 
-		relatedParameter ="type", 
-		relatedValue = type
+            parameter = "obj", value = obj,
+            relatedParameter = "type",
+            relatedValue = type
         )
     }
 
@@ -621,8 +621,8 @@ getAvailablePlotTypes <- function(
     .assertIsSingleCharacter(xParameterName, "xParameterName")
     if (length(yParameterNames) == 0 || !all(is.character(yParameterNames)) || all(is.na(yParameterNames))) {
         stopIllegalArgument("'yParameterNames' (", .arrayToString(yParameterNames), ") must be a valid character vector",
-            functionName = ".showPlotSourceInformation", 
-		parameter ="yParameterNames", value = yParameterNames
+            functionName = ".showPlotSourceInformation",
+            parameter = "yParameterNames", value = yParameterNames
         )
     }
     .assertIsSingleCharacter(hint, "hint", naAllowed = TRUE)
@@ -742,8 +742,9 @@ getAvailablePlotTypes <- function(
                 "(", .sQuote(as.character(e$call)), "): ", e$message
             )
             if (!silent) {
-                stopRuntimeIssue(msg[1], 
-		functionName = ".testPlotCommand")
+                stopRuntimeIssue(msg[1],
+                    functionName = ".testPlotCommand"
+                )
             }
             cat(.firstCharacterToUpperCase(msg), "\n")
         }
@@ -763,9 +764,9 @@ getAvailablePlotTypes <- function(
     if (.isTrialDesignSet(parameterSet) && parameterSet$getSize() > 1 &&
             (is.null(parameterSet$variedParameters) || length(parameterSet$variedParameters) == 0)) {
         stopRuntimeIssue("'variedParameters' must be not empty; ", "use 'DesignSet$addVariedParameters(character)' to add one or more varied parameters",
-            functionName = ".getParameterSetAsDataFrame", 
-		parameter ="variedParameters", 
-		relatedParameter ="DesignSet$addVariedParameters(character)"
+            functionName = ".getParameterSetAsDataFrame",
+            parameter = "variedParameters",
+            relatedParameter = "DesignSet$addVariedParameters(character)"
         )
     }
 
@@ -812,9 +813,9 @@ getAvailablePlotTypes <- function(
             if (length(column) <= 1) {
                 stopRuntimeIssue("varied parameter ", .pQuote(variedParameter), " has length ", length(column),
                     functionName = ".getParameterSetAsDataFrame",
-                    parameter = "variedParameter", value = variedParameter, 
-		relatedParameter ="column", 
-		relatedValue = length(column)
+                    parameter = "variedParameter", value = variedParameter,
+                    relatedParameter = "column",
+                    relatedValue = length(column)
                 )
             }
 
@@ -911,13 +912,13 @@ getAvailablePlotTypes <- function(
         }
         for (parameterName in parameterNames) {
             if (!is.na(parameterName) && !(parameterName %in% fieldNames)) {
-                stopIllegalArgument("", .getClassName(parameterSet, quote = TRUE), " and ", 
-                    .getClassName(designMaster, quote = TRUE), " ", 
-                    "do not contain a field with name ", .pQuote(parameterName), 
-                    functionName = ".plotParameterSet", 
-		parameter ="parameterName", value = parameterName,
-                    relatedParameter = "fieldNames", 
-		relatedValue = fieldNames
+                stopIllegalArgument("", .getClassName(parameterSet, quote = TRUE), " and ",
+                    .getClassName(designMaster, quote = TRUE), " ",
+                    "do not contain a field with name ", .pQuote(parameterName),
+                    functionName = ".plotParameterSet",
+                    parameter = "parameterName", value = parameterName,
+                    relatedParameter = "fieldNames",
+                    relatedValue = fieldNames
                 )
             }
         }
@@ -978,10 +979,10 @@ getAvailablePlotTypes <- function(
     } else {
         stopRuntimeIssue("'parameterSet' (", .getClassName(parameterSet), ") must be a data.frame, a 'TrialDesignSet' ",
             "or an object that inherits from 'ParameterSet'",
-            functionName = ".plotParameterSet", 
-		parameter ="parameterSet",
-            value = parameterSet, 
-		relatedParameter ="TrialDesignSet"
+            functionName = ".plotParameterSet",
+            parameter = "parameterSet",
+            value = parameterSet,
+            relatedParameter = "TrialDesignSet"
         )
     }
 
@@ -1319,14 +1320,14 @@ getAvailablePlotTypes <- function(
     m2 <- ifelse(length(.naAndNaNOmit(rightAxisValues)) == 0, 1, max(.naAndNaNOmit(rightAxisValues)))
     if (is.na(m1)) {
         stopRuntimeIssue("y-values, left (", .arrayToString(leftAxisValues), ") are not specified correctly",
-            functionName = ".getScalingFactors", 
-		parameter ="leftAxisValues", value = leftAxisValues
+            functionName = ".getScalingFactors",
+            parameter = "leftAxisValues", value = leftAxisValues
         )
     }
     if (is.na(m2)) {
         stopRuntimeIssue("y-values, right (", .arrayToString(rightAxisValues), ") are not specified correctly",
-            functionName = ".getScalingFactors", 
-		parameter ="rightAxisValues", value = rightAxisValues
+            functionName = ".getScalingFactors",
+            parameter = "rightAxisValues", value = rightAxisValues
         )
     }
 
@@ -1659,11 +1660,11 @@ getAvailablePlotTypes <- function(
     if (length(piecewiseSurvivalTime) != length(piecewiseLambda)) {
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", length(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
             length(piecewiseLambda), ") - 1",
-            functionName = ".getLambdaStepFunction", 
-		parameter ="piecewiseSurvivalTime",
-            value = length(piecewiseSurvivalTime), 
-		relatedParameter ="piecewiseLambda", 
-		relatedValue = length(piecewiseLambda)
+            functionName = ".getLambdaStepFunction",
+            parameter = "piecewiseSurvivalTime",
+            value = length(piecewiseSurvivalTime),
+            relatedParameter = "piecewiseLambda",
+            relatedValue = length(piecewiseLambda)
         )
     }
 
@@ -1751,8 +1752,8 @@ saveLastPlot <- function(filename, outputPath = .getRelativeFigureOutputPath()) 
     if (grepl("\\\\|/", filename)) {
         stopIllegalArgument("'filename' seems to be a path. ", "Please specify 'outputPath' separately",
             functionName = "saveLastPlot",
-            parameter = "filename", 
-		relatedParameter ="outputPath", value = filename
+            parameter = "filename",
+            relatedParameter = "outputPath", value = filename
         )
     }
 

--- a/R/f_core_plot.R
+++ b/R/f_core_plot.R
@@ -156,7 +156,9 @@ NULL
     if (stopIfNotFound) {
         stopRuntimeIssue("could not find plot caption for ", .getClassName(obj), " and type ", type,
             functionName = ".getPlotCaption",
-            parameter = "obj", value = obj, relatedParameter = "type", relatedValue = type
+            parameter = "obj", value = obj, 
+		relatedParameter ="type", 
+		relatedValue = type
         )
     }
 
@@ -274,7 +276,7 @@ NULL
                 return(eval(parse(text = plotCmd)))
             },
             error = function(e) {
-                warning("Failed to create grid plot using command '", plotCmd, "': ", e$message)
+                warning("Failed to create grid plot using command ", .sQuote(plotCmd), ": ", e$message)
             }
         )
     }
@@ -619,7 +621,8 @@ getAvailablePlotTypes <- function(
     .assertIsSingleCharacter(xParameterName, "xParameterName")
     if (length(yParameterNames) == 0 || !all(is.character(yParameterNames)) || all(is.na(yParameterNames))) {
         stopIllegalArgument("'yParameterNames' (", .arrayToString(yParameterNames), ") must be a valid character vector",
-            functionName = ".showPlotSourceInformation", parameter = "yParameterNames", value = yParameterNames
+            functionName = ".showPlotSourceInformation", 
+		parameter ="yParameterNames", value = yParameterNames
         )
     }
     .assertIsSingleCharacter(hint, "hint", naAllowed = TRUE)
@@ -736,10 +739,11 @@ getAvailablePlotTypes <- function(
         error = function(e) {
             msg <- paste0(
                 "failed to evaluate plot command \"", plotCmd, "\" ",
-                "('", as.character(e$call), "'): ", e$message
+                "(", .sQuote(as.character(e$call)), "): ", e$message
             )
             if (!silent) {
-                stopRuntimeIssue(msg[1], functionName = ".testPlotCommand")
+                stopRuntimeIssue(msg[1], 
+		functionName = ".testPlotCommand")
             }
             cat(.firstCharacterToUpperCase(msg), "\n")
         }
@@ -759,7 +763,9 @@ getAvailablePlotTypes <- function(
     if (.isTrialDesignSet(parameterSet) && parameterSet$getSize() > 1 &&
             (is.null(parameterSet$variedParameters) || length(parameterSet$variedParameters) == 0)) {
         stopRuntimeIssue("'variedParameters' must be not empty; ", "use 'DesignSet$addVariedParameters(character)' to add one or more varied parameters",
-            functionName = ".getParameterSetAsDataFrame", parameter = "variedParameters", relatedParameter = "DesignSet$addVariedParameters(character)"
+            functionName = ".getParameterSetAsDataFrame", 
+		parameter ="variedParameters", 
+		relatedParameter ="DesignSet$addVariedParameters(character)"
         )
     }
 
@@ -804,9 +810,11 @@ getAvailablePlotTypes <- function(
         for (variedParameter in variedParameters) {
             column <- data[[variedParameter]]
             if (length(column) <= 1) {
-                stopRuntimeIssue("varied parameter '", variedParameter, "' has length ", length(column),
+                stopRuntimeIssue("varied parameter ", .pQuote(variedParameter), " has length ", length(column),
                     functionName = ".getParameterSetAsDataFrame",
-                    parameter = "variedParameter", value = variedParameter, relatedParameter = "column", relatedValue = length(column)
+                    parameter = "variedParameter", value = variedParameter, 
+		relatedParameter ="column", 
+		relatedValue = length(column)
                 )
             }
 
@@ -903,10 +911,13 @@ getAvailablePlotTypes <- function(
         }
         for (parameterName in parameterNames) {
             if (!is.na(parameterName) && !(parameterName %in% fieldNames)) {
-                stopIllegalArgument("'", .getClassName(parameterSet), "' and '", .getClassName(designMaster), "' ", "do not contain a field with name '",
-                    parameterName, "'",
-                    functionName = ".plotParameterSet", parameter = "parameterName", value = parameterName,
-                    relatedParameter = "fieldNames", relatedValue = fieldNames
+                stopIllegalArgument("", .getClassName(parameterSet, quote = TRUE), " and ", 
+                    .getClassName(designMaster, quote = TRUE), " ", 
+                    "do not contain a field with name ", .pQuote(parameterName), 
+                    functionName = ".plotParameterSet", 
+		parameter ="parameterName", value = parameterName,
+                    relatedParameter = "fieldNames", 
+		relatedValue = fieldNames
                 )
             }
         }
@@ -967,8 +978,10 @@ getAvailablePlotTypes <- function(
     } else {
         stopRuntimeIssue("'parameterSet' (", .getClassName(parameterSet), ") must be a data.frame, a 'TrialDesignSet' ",
             "or an object that inherits from 'ParameterSet'",
-            functionName = ".plotParameterSet", parameter = "parameterSet",
-            value = parameterSet, relatedParameter = "TrialDesignSet"
+            functionName = ".plotParameterSet", 
+		parameter ="parameterSet",
+            value = parameterSet, 
+		relatedParameter ="TrialDesignSet"
         )
     }
 
@@ -1306,12 +1319,14 @@ getAvailablePlotTypes <- function(
     m2 <- ifelse(length(.naAndNaNOmit(rightAxisValues)) == 0, 1, max(.naAndNaNOmit(rightAxisValues)))
     if (is.na(m1)) {
         stopRuntimeIssue("y-values, left (", .arrayToString(leftAxisValues), ") are not specified correctly",
-            functionName = ".getScalingFactors", parameter = "leftAxisValues", value = leftAxisValues
+            functionName = ".getScalingFactors", 
+		parameter ="leftAxisValues", value = leftAxisValues
         )
     }
     if (is.na(m2)) {
         stopRuntimeIssue("y-values, right (", .arrayToString(rightAxisValues), ") are not specified correctly",
-            functionName = ".getScalingFactors", parameter = "rightAxisValues", value = rightAxisValues
+            functionName = ".getScalingFactors", 
+		parameter ="rightAxisValues", value = rightAxisValues
         )
     }
 
@@ -1644,8 +1659,11 @@ getAvailablePlotTypes <- function(
     if (length(piecewiseSurvivalTime) != length(piecewiseLambda)) {
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", length(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
             length(piecewiseLambda), ") - 1",
-            functionName = ".getLambdaStepFunction", parameter = "piecewiseSurvivalTime",
-            value = length(piecewiseSurvivalTime), relatedParameter = "piecewiseLambda", relatedValue = length(piecewiseLambda)
+            functionName = ".getLambdaStepFunction", 
+		parameter ="piecewiseSurvivalTime",
+            value = length(piecewiseSurvivalTime), 
+		relatedParameter ="piecewiseLambda", 
+		relatedValue = length(piecewiseLambda)
         )
     }
 
@@ -1733,7 +1751,8 @@ saveLastPlot <- function(filename, outputPath = .getRelativeFigureOutputPath()) 
     if (grepl("\\\\|/", filename)) {
         stopIllegalArgument("'filename' seems to be a path. ", "Please specify 'outputPath' separately",
             functionName = "saveLastPlot",
-            parameter = "filename", relatedParameter = "outputPath", value = filename
+            parameter = "filename", 
+		relatedParameter ="outputPath", value = filename
         )
     }
 
@@ -1748,7 +1767,7 @@ saveLastPlot <- function(filename, outputPath = .getRelativeFigureOutputPath()) 
         scale = 1.2, width = 16, height = 15, units = "cm", dpi = 600, limitsize = TRUE
     )
 
-    cat("Last plot was saved to '", path, "'\n")
+    cat("Last plot was saved to ", .pQuote(path), "\n")
 }
 
 .getGridPlotSettings <- function(x, typeNumbers, grid) {

--- a/R/f_core_utilities.R
+++ b/R/f_core_utilities.R
@@ -18,18 +18,22 @@
 #' @include f_logger.R
 NULL
 
+# single quote
 .sQuote <- function(x) {
     return(paste0("'", x, "'"))
 }
 
+# parameter quote
 .pQuote <- function(x) {
     return(paste0("'", x, "'"))
 }
 
+# value quote
 .vQuote <- function(x) {
     return(paste0("'", x, "'"))
 }
 
+# double quote
 .dQuote <- function(x) {
     return(paste0('"', x, '"'))
 }
@@ -60,7 +64,11 @@ NULL
     return(toupper(gsub("\\.", "_", optionKey)))
 }
 
-.getEnvironmentVariable <- function(envKey, optionKey = NULL, ..., type = c("unknown", "character", "integer", "numeric", "logical")) {
+.getEnvironmentVariable <- function(
+        envKey,
+        optionKey = NULL,
+        ...,
+        type = c("unknown", "character", "integer", "numeric", "logical")) {
     type <- match.arg(type)
 
     value <- Sys.getenv(envKey)
@@ -259,11 +267,11 @@ NULL
                 }
             },
             error = function(e) {
-                stopMissingArgument("the object ", .pQuote(paramName), " has not been defined anywhere. ", 
+                stopMissingArgument("the object ", .pQuote(paramName), " has not been defined anywhere. ",
                     "Please define it first, e.g., run '",
                     paramName, " <- 1'",
-                    functionName = ".isDefinedArgument", 
-		parameter =paramName
+                    functionName = ".isDefinedArgument",
+                    parameter = paramName
                 )
             }
         )
@@ -524,8 +532,8 @@ getTestLabel <- function(x) {
 .getInputForZeroOutputInsideTolerance <- function(input, output, tolerance = .Machine$double.eps^0.25) {
     if (is.null(tolerance) || is.na(tolerance)) {
         stopIllegalArgument("'tolerance' must be a valid double",
-            functionName = ".getInputForZeroOutputInsideTolerance", 
-		parameter ="tolerance",
+            functionName = ".getInputForZeroOutputInsideTolerance",
+            parameter = "tolerance",
             value = tolerance
         )
     }
@@ -539,8 +547,8 @@ getTestLabel <- function(x) {
 
     if (is.null(input)) {
         stopIllegalArgument("'input' must be a valid double or NA",
-            functionName = ".getInputForZeroOutputInsideTolerance", 
-		parameter ="input",
+            functionName = ".getInputForZeroOutputInsideTolerance",
+            parameter = "input",
             value = input
         )
     }
@@ -911,19 +919,19 @@ getTestLabel <- function(x) {
 
     if (is.null(parameterSet)) {
         stopIllegalArgument("'parameterSet' must be not null",
-            functionName = ".setValueAndParameterType", 
-		parameter ="parameterSet",
+            functionName = ".setValueAndParameterType",
+            parameter = "parameterSet",
             value = parameterSet
         )
     }
 
     if (!(parameterName %in% names(parameterSet))) {
-        stopIllegalArgument(.getClassName(parameterSet, quote = TRUE), 
-            " does not contain a field with name ", .pQuote(parameterName), 
-            functionName = ".setValueAndParameterType", 
-		parameter ="parameterName", value = parameterName,
-            relatedParameter = "parameterSet", 
-		relatedValue = names(parameterSet)
+        stopIllegalArgument(.getClassName(parameterSet, quote = TRUE),
+            " does not contain a field with name ", .pQuote(parameterName),
+            functionName = ".setValueAndParameterType",
+            parameter = "parameterName", value = parameterName,
+            relatedParameter = "parameterSet",
+            relatedValue = names(parameterSet)
         )
     }
 
@@ -999,14 +1007,14 @@ getTestLabel <- function(x) {
     minValue <- variedParameter[1]
     maxValue <- variedParameter[2]
     if (minValue == maxValue) {
-        stopIllegalArgument(.pQuote(variedParameterName), 
+        stopIllegalArgument(.pQuote(variedParameterName),
             " with length 2 must contain minimum != maximum (", minValue,
             " == ", maxValue, ")",
-            functionName = ".getVariedParameterVector", 
-		parameter ="variedParameterName",
-            value = variedParameterName, 
-		relatedParameter ="minValue", 
-		relatedValue = minValue
+            functionName = ".getVariedParameterVector",
+            parameter = "variedParameterName",
+            value = variedParameterName,
+            relatedParameter = "minValue",
+            relatedValue = minValue
         )
     }
     by <- .getVariedParameterVectorByValue(variedParameter)
@@ -1328,8 +1336,9 @@ getParameterName <- function(obj, parameterCaption) {
 
     dataDim <- dim(x)
     if (length(dataDim) != 3) {
-        stopRuntimeIssue("function .removeLastEntryFromArray() only works for 3-dimensional arrays", 
-		functionName = ".removeLastEntryFromArray")
+        stopRuntimeIssue("function .removeLastEntryFromArray() only works for 3-dimensional arrays",
+            functionName = ".removeLastEntryFromArray"
+        )
     }
     if (dataDim[3] < 2) {
         return(NA_real_)
@@ -1344,8 +1353,8 @@ getParameterName <- function(obj, parameterCaption) {
     if (!is.data.frame(data)) {
         stopIllegalArgument(sQuote("data"), " (", .getClassName(data), ") must be a data.frame",
             parameter = "data",
-            value = .getClassName(data), constraint = "data.frame", 
-		functionName = ".moveColumn"
+            value = .getClassName(data), constraint = "data.frame",
+            functionName = ".moveColumn"
         )
     }
     if (is.null(insertPositionColumnName) || length(insertPositionColumnName) != 1 ||
@@ -1353,32 +1362,38 @@ getParameterName <- function(obj, parameterCaption) {
         stopIllegalArgument(sQuote("insertPositionColumnName"), " (", .getClassName(insertPositionColumnName),
             ") must be a valid character value",
             parameter = "insertPositionColumnName", value = insertPositionColumnName,
-            constraint = "valid character value", 
-		functionName = ".moveColumn"
+            constraint = "valid character value",
+            functionName = ".moveColumn"
         )
     }
     if (is.null(columnName) || length(columnName) != 1 || is.na(columnName) || !is.character(columnName)) {
         stopIllegalArgument(sQuote("columnName"), " (", .getClassName(columnName), ") must be a valid character value",
-            parameter = "columnName", value = columnName, constraint = "valid character value", 
-		functionName = ".moveColumn"
+            parameter = "columnName", value = columnName, constraint = "valid character value",
+            functionName = ".moveColumn"
         )
     }
 
     colNames <- colnames(data)
     if (!(columnName %in% colNames)) {
-        stopIllegalArgument(sQuote("columnName"), " (", columnName, ") does not exist in the specified data.frame 'data'",
-            parameter = "columnName", value = columnName, constraint = "existing column in data", 
-		relatedParameter ="data",
-            relatedValue = colNames, 
-		functionName = ".moveColumn"
+        stopIllegalArgument(sQuote("columnName"),
+            " (", columnName, ") does not exist in the specified data.frame 'data'",
+            parameter = "columnName",
+            value = columnName,
+            constraint = "existing column in data",
+            relatedParameter = "data",
+            relatedValue = colNames,
+            functionName = ".moveColumn"
         )
     }
     if (!(insertPositionColumnName %in% colNames)) {
-        stopIllegalArgument(sQuote("insertPositionColumnName"), " (", insertPositionColumnName, ") does not exist in the specified data.frame 'data'",
-            parameter = "insertPositionColumnName", value = insertPositionColumnName, constraint = "existing column in data",
-            relatedParameter = "data", 
-		relatedValue = colNames, 
-		functionName = ".moveColumn"
+        stopIllegalArgument(sQuote("insertPositionColumnName"),
+            " (", insertPositionColumnName, ") does not exist in the specified data.frame 'data'",
+            parameter = "insertPositionColumnName",
+            value = insertPositionColumnName,
+            constraint = "existing column in data",
+            relatedParameter = "data",
+            relatedValue = colNames,
+            functionName = ".moveColumn"
         )
     }
     if (columnName == insertPositionColumnName) {
@@ -1391,7 +1406,10 @@ getParameterName <- function(obj, parameterCaption) {
         if (insertPositioIndex == length(colNames)) {
             data <- data[, c(colNames[1:insertPositioIndex], columnName)]
         } else {
-            data <- data[, c(colNames[1:insertPositioIndex], columnName, colNames[(insertPositioIndex + 1):length(colNames)])]
+            data <- data[, c(
+                colNames[1:insertPositioIndex], columnName,
+                colNames[(insertPositioIndex + 1):length(colNames)]
+            )]
         }
     }
     return(data)
@@ -1443,18 +1461,20 @@ getParameterName <- function(obj, parameterCaption) {
     if (is.list(x)) {
         listNames <- names(x)
         if (is.null(listNames) || anyNA(listNames) || any(trimws(listNames) == "")) {
-            stopRuntimeIssue("list (", .arrayToString(unlist(x)), ") must be named", 
-		functionName = ".isConditionTrue")
+            stopRuntimeIssue("list (", .arrayToString(unlist(x)), ") must be named",
+                functionName = ".isConditionTrue"
+            )
         }
 
         results <- logical(0)
         for (listName in listNames) {
             type <- gsub("\\d*", "", listName)
             if (!(type %in% c("and", "or"))) {
-                stopRuntimeIssue("all list names (", type, " / ", listName, ") must have the format 'and[number]' or 'or[number]', where [number] is an integer",
-                    functionName = ".isConditionTrue", 
-		parameter ="and[number]", 
-		relatedParameter ="or[number]"
+                stopRuntimeIssue("all list names (", type, " / ", listName, ") ",
+                    "must have the format 'and[number]' or 'or[number]', where [number] is an integer",
+                    functionName = ".isConditionTrue",
+                    parameter = "and[number]",
+                    relatedParameter = "or[number]"
                 )
             }
 
@@ -1500,7 +1520,13 @@ getParameterName <- function(obj, parameterCaption) {
     return(nzchar(try(system.file(package = packageName), silent = TRUE)))
 }
 
-.getQNorm <- function(p, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE, epsilon = C_QNORM_EPSILON) {
+.getQNorm <- function(
+        p,
+        mean = 0,
+        sd = 1,
+        lower.tail = TRUE,
+        log.p = FALSE,
+        epsilon = C_QNORM_EPSILON) {
     if (any(p < -1e-07 | p > 1 + 1e-07, na.rm = TRUE)) {
         warning("Tried to get qnorm() from ", .arrayToString(p), " which is out of interval (0, 1)")
     }
@@ -1516,7 +1542,14 @@ getParameterName <- function(obj, parameterCaption) {
     return(result)
 }
 
-.getOneMinusQNorm <- function(p, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE, ..., epsilon = C_QNORM_EPSILON) {
+.getOneMinusQNorm <- function(
+        p,
+        mean = 0,
+        sd = 1,
+        lower.tail = TRUE,
+        log.p = FALSE,
+        ...,
+        epsilon = C_QNORM_EPSILON) {
     if (all(is.na(p))) {
         return(p)
     }
@@ -1559,29 +1592,35 @@ getParameterName <- function(obj, parameterCaption) {
 
 .moveValue <- function(values, value, insertPositionValue) {
     if (is.null(insertPositionValue) || length(insertPositionValue) != 1 || is.na(insertPositionValue)) {
-        stopIllegalArgument("'insertPositionValue' (", class(insertPositionValue), ") must be a valid single value",
-            functionName = ".moveValue", 
-		parameter ="insertPositionValue", value = insertPositionValue
+        stopIllegalArgument("'insertPositionValue' (", class(insertPositionValue), ") ",
+            "must be a valid single value",
+            functionName = ".moveValue",
+            parameter = "insertPositionValue",
+            value = insertPositionValue
         )
     }
     if (is.null(value) || length(value) != 1 || is.na(value)) {
         stopIllegalArgument("'value' (", class(value), ") must be a valid single value",
             functionName = ".moveValue",
-            parameter = "value", value = value
+            parameter = "value",
+            value = value
         )
     }
     if (!(value %in% values)) {
         stopIllegalArgument("'value' (", value, ") does not exist in the specified vector 'values'",
             functionName = ".moveValue",
-            parameter = "value", value = value, 
-		relatedParameter ="values"
+            parameter = "value",
+            value = value,
+            relatedParameter = "values"
         )
     }
     if (!(insertPositionValue %in% values)) {
-        stopIllegalArgument("'insertPositionValue' (", insertPositionValue, ") does not exist in the specified vector 'values'",
-            functionName = ".moveValue", 
-		parameter ="insertPositionValue", value = insertPositionValue, 
-		relatedParameter ="values"
+        stopIllegalArgument("'insertPositionValue' (", insertPositionValue, ") ",
+            "does not exist in the specified vector 'values'",
+            functionName = ".moveValue",
+            parameter = "insertPositionValue",
+            value = insertPositionValue,
+            relatedParameter = "values"
         )
     }
     if (value == insertPositionValue) {
@@ -1595,7 +1634,10 @@ getParameterName <- function(obj, parameterCaption) {
         if (insertPositioIndex == length(values)) {
             values <- c(values[1:insertPositioIndex], value)
         } else {
-            values <- c(values[1:insertPositioIndex], value, values[(insertPositioIndex + 1):length(values)])
+            values <- c(
+                values[1:insertPositioIndex], value,
+                values[(insertPositioIndex + 1):length(values)]
+            )
         }
     }
     return(values)
@@ -1773,7 +1815,7 @@ getParameterName <- function(obj, parameterCaption) {
         deprecationDate = NULL) {
     if (!fieldName %in% names(parameterSet)) {
         stopRuntimeIssue("", .getClassName(parameterSet, quote = TRUE), " does not ",
-            "contain a field with name ", .pQuote(fieldName), 
+            "contain a field with name ", .pQuote(fieldName),
             functionName = ".addDeprecatedFieldValues",
             parameter = "fieldName",
             value = fieldName,

--- a/R/f_core_utilities.R
+++ b/R/f_core_utilities.R
@@ -18,6 +18,22 @@
 #' @include f_logger.R
 NULL
 
+.sQuote <- function(x) {
+    return(paste0("'", x, "'"))
+}
+
+.pQuote <- function(x) {
+    return(paste0("'", x, "'"))
+}
+
+.vQuote <- function(x) {
+    return(paste0("'", x, "'"))
+}
+
+.dQuote <- function(x) {
+    return(paste0('"', x, '"'))
+}
+
 .getLogicalEnvironmentVariable <- function(variableName) {
     result <- as.logical(Sys.getenv(variableName))
     return(ifelse(is.na(result), FALSE, result))
@@ -243,9 +259,11 @@ NULL
                 }
             },
             error = function(e) {
-                stopMissingArgument("the object '", paramName, "' has not been defined anywhere. ", "Please define it first, e.g., run '",
+                stopMissingArgument("the object ", .pQuote(paramName), " has not been defined anywhere. ", 
+                    "Please define it first, e.g., run '",
                     paramName, " <- 1'",
-                    functionName = ".isDefinedArgument", parameter = paramName
+                    functionName = ".isDefinedArgument", 
+		parameter =paramName
                 )
             }
         )
@@ -421,7 +439,7 @@ getTestLabel <- function(x) {
         for (i in 1:nrow(x)) {
             row <- x[i, ]
             if (encapsulate) {
-                row <- paste0("'", row, "'")
+                row <- .sQuote(row)
             }
             result <- c(result, paste0("(", paste(row, collapse = separator), ")"))
         }
@@ -429,7 +447,7 @@ getTestLabel <- function(x) {
     }
 
     if (encapsulate) {
-        x <- paste0("'", x, "'")
+        x <- .sQuote(x)
     }
 
     if (length(x) > maxLength) {
@@ -506,7 +524,8 @@ getTestLabel <- function(x) {
 .getInputForZeroOutputInsideTolerance <- function(input, output, tolerance = .Machine$double.eps^0.25) {
     if (is.null(tolerance) || is.na(tolerance)) {
         stopIllegalArgument("'tolerance' must be a valid double",
-            functionName = ".getInputForZeroOutputInsideTolerance", parameter = "tolerance",
+            functionName = ".getInputForZeroOutputInsideTolerance", 
+		parameter ="tolerance",
             value = tolerance
         )
     }
@@ -520,7 +539,8 @@ getTestLabel <- function(x) {
 
     if (is.null(input)) {
         stopIllegalArgument("'input' must be a valid double or NA",
-            functionName = ".getInputForZeroOutputInsideTolerance", parameter = "input",
+            functionName = ".getInputForZeroOutputInsideTolerance", 
+		parameter ="input",
             value = input
         )
     }
@@ -891,16 +911,19 @@ getTestLabel <- function(x) {
 
     if (is.null(parameterSet)) {
         stopIllegalArgument("'parameterSet' must be not null",
-            functionName = ".setValueAndParameterType", parameter = "parameterSet",
+            functionName = ".setValueAndParameterType", 
+		parameter ="parameterSet",
             value = parameterSet
         )
     }
 
     if (!(parameterName %in% names(parameterSet))) {
-        stopIllegalArgument("'", .getClassName(parameterSet), "' does not contain a field with name '", parameterName,
-            "'",
-            functionName = ".setValueAndParameterType", parameter = "parameterName", value = parameterName,
-            relatedParameter = "parameterSet", relatedValue = names(parameterSet)
+        stopIllegalArgument(.getClassName(parameterSet, quote = TRUE), 
+            " does not contain a field with name ", .pQuote(parameterName), 
+            functionName = ".setValueAndParameterType", 
+		parameter ="parameterName", value = parameterName,
+            relatedParameter = "parameterSet", 
+		relatedValue = names(parameterSet)
         )
     }
 
@@ -976,10 +999,14 @@ getTestLabel <- function(x) {
     minValue <- variedParameter[1]
     maxValue <- variedParameter[2]
     if (minValue == maxValue) {
-        stopIllegalArgument("'", variedParameterName, "' with length 2 must contain minimum != maximum (", minValue,
+        stopIllegalArgument(.pQuote(variedParameterName), 
+            " with length 2 must contain minimum != maximum (", minValue,
             " == ", maxValue, ")",
-            functionName = ".getVariedParameterVector", parameter = "variedParameterName",
-            value = variedParameterName, relatedParameter = "minValue", relatedValue = minValue
+            functionName = ".getVariedParameterVector", 
+		parameter ="variedParameterName",
+            value = variedParameterName, 
+		relatedParameter ="minValue", 
+		relatedValue = minValue
         )
     }
     by <- .getVariedParameterVectorByValue(variedParameter)
@@ -1301,7 +1328,8 @@ getParameterName <- function(obj, parameterCaption) {
 
     dataDim <- dim(x)
     if (length(dataDim) != 3) {
-        stopRuntimeIssue("function .removeLastEntryFromArray() only works for 3-dimensional arrays", functionName = ".removeLastEntryFromArray")
+        stopRuntimeIssue("function .removeLastEntryFromArray() only works for 3-dimensional arrays", 
+		functionName = ".removeLastEntryFromArray")
     }
     if (dataDim[3] < 2) {
         return(NA_real_)
@@ -1316,7 +1344,8 @@ getParameterName <- function(obj, parameterCaption) {
     if (!is.data.frame(data)) {
         stopIllegalArgument(sQuote("data"), " (", .getClassName(data), ") must be a data.frame",
             parameter = "data",
-            value = .getClassName(data), constraint = "data.frame", functionName = ".moveColumn"
+            value = .getClassName(data), constraint = "data.frame", 
+		functionName = ".moveColumn"
         )
     }
     if (is.null(insertPositionColumnName) || length(insertPositionColumnName) != 1 ||
@@ -1324,26 +1353,32 @@ getParameterName <- function(obj, parameterCaption) {
         stopIllegalArgument(sQuote("insertPositionColumnName"), " (", .getClassName(insertPositionColumnName),
             ") must be a valid character value",
             parameter = "insertPositionColumnName", value = insertPositionColumnName,
-            constraint = "valid character value", functionName = ".moveColumn"
+            constraint = "valid character value", 
+		functionName = ".moveColumn"
         )
     }
     if (is.null(columnName) || length(columnName) != 1 || is.na(columnName) || !is.character(columnName)) {
         stopIllegalArgument(sQuote("columnName"), " (", .getClassName(columnName), ") must be a valid character value",
-            parameter = "columnName", value = columnName, constraint = "valid character value", functionName = ".moveColumn"
+            parameter = "columnName", value = columnName, constraint = "valid character value", 
+		functionName = ".moveColumn"
         )
     }
 
     colNames <- colnames(data)
     if (!(columnName %in% colNames)) {
         stopIllegalArgument(sQuote("columnName"), " (", columnName, ") does not exist in the specified data.frame 'data'",
-            parameter = "columnName", value = columnName, constraint = "existing column in data", relatedParameter = "data",
-            relatedValue = colNames, functionName = ".moveColumn"
+            parameter = "columnName", value = columnName, constraint = "existing column in data", 
+		relatedParameter ="data",
+            relatedValue = colNames, 
+		functionName = ".moveColumn"
         )
     }
     if (!(insertPositionColumnName %in% colNames)) {
         stopIllegalArgument(sQuote("insertPositionColumnName"), " (", insertPositionColumnName, ") does not exist in the specified data.frame 'data'",
             parameter = "insertPositionColumnName", value = insertPositionColumnName, constraint = "existing column in data",
-            relatedParameter = "data", relatedValue = colNames, functionName = ".moveColumn"
+            relatedParameter = "data", 
+		relatedValue = colNames, 
+		functionName = ".moveColumn"
         )
     }
     if (columnName == insertPositionColumnName) {
@@ -1408,7 +1443,8 @@ getParameterName <- function(obj, parameterCaption) {
     if (is.list(x)) {
         listNames <- names(x)
         if (is.null(listNames) || anyNA(listNames) || any(trimws(listNames) == "")) {
-            stopRuntimeIssue("list (", .arrayToString(unlist(x)), ") must be named", functionName = ".isConditionTrue")
+            stopRuntimeIssue("list (", .arrayToString(unlist(x)), ") must be named", 
+		functionName = ".isConditionTrue")
         }
 
         results <- logical(0)
@@ -1416,7 +1452,9 @@ getParameterName <- function(obj, parameterCaption) {
             type <- gsub("\\d*", "", listName)
             if (!(type %in% c("and", "or"))) {
                 stopRuntimeIssue("all list names (", type, " / ", listName, ") must have the format 'and[number]' or 'or[number]', where [number] is an integer",
-                    functionName = ".isConditionTrue", parameter = "and[number]", relatedParameter = "or[number]"
+                    functionName = ".isConditionTrue", 
+		parameter ="and[number]", 
+		relatedParameter ="or[number]"
                 )
             }
 
@@ -1450,8 +1488,12 @@ getParameterName <- function(obj, parameterCaption) {
     )
 }
 
-.getClassName <- function(x) {
-    return(as.character(class(x))[1])
+.getClassName <- function(x, quote = FALSE) {
+    s <- as.character(class(x))[1]
+    if (quote) {
+        s <- .sQuote(s)
+    }
+    return(s)
 }
 
 .isPackageInstalled <- function(packageName) {
@@ -1518,7 +1560,8 @@ getParameterName <- function(obj, parameterCaption) {
 .moveValue <- function(values, value, insertPositionValue) {
     if (is.null(insertPositionValue) || length(insertPositionValue) != 1 || is.na(insertPositionValue)) {
         stopIllegalArgument("'insertPositionValue' (", class(insertPositionValue), ") must be a valid single value",
-            functionName = ".moveValue", parameter = "insertPositionValue", value = insertPositionValue
+            functionName = ".moveValue", 
+		parameter ="insertPositionValue", value = insertPositionValue
         )
     }
     if (is.null(value) || length(value) != 1 || is.na(value)) {
@@ -1530,12 +1573,15 @@ getParameterName <- function(obj, parameterCaption) {
     if (!(value %in% values)) {
         stopIllegalArgument("'value' (", value, ") does not exist in the specified vector 'values'",
             functionName = ".moveValue",
-            parameter = "value", value = value, relatedParameter = "values"
+            parameter = "value", value = value, 
+		relatedParameter ="values"
         )
     }
     if (!(insertPositionValue %in% values)) {
         stopIllegalArgument("'insertPositionValue' (", insertPositionValue, ") does not exist in the specified vector 'values'",
-            functionName = ".moveValue", parameter = "insertPositionValue", value = insertPositionValue, relatedParameter = "values"
+            functionName = ".moveValue", 
+		parameter ="insertPositionValue", value = insertPositionValue, 
+		relatedParameter ="values"
         )
     }
     if (value == insertPositionValue) {
@@ -1726,8 +1772,8 @@ getParameterName <- function(obj, parameterCaption) {
         fieldValues,
         deprecationDate = NULL) {
     if (!fieldName %in% names(parameterSet)) {
-        stopRuntimeIssue("'", .getClassName(parameterSet), "' does not ",
-            "contain a field with name '", fieldName, "'",
+        stopRuntimeIssue("", .getClassName(parameterSet, quote = TRUE), " does not ",
+            "contain a field with name ", .pQuote(fieldName), 
             functionName = ".addDeprecatedFieldValues",
             parameter = "fieldName",
             value = fieldName,

--- a/R/f_design_fisher_combination_test.R
+++ b/R/f_design_fisher_combination_test.R
@@ -221,7 +221,8 @@ getDesignFisher <- function(
     }
 
     if (sided != 1) {
-        stopIllegalArgument("Fisher's combination test only available for one-sided testing", functionName = ".getDesignFisher")
+        stopIllegalArgument("Fisher's combination test only available for one-sided testing", 
+		functionName = ".getDesignFisher")
     }
 
     if (is.na(bindingFutility)) {
@@ -294,8 +295,8 @@ getDesignFisher <- function(
     } else {
         design$.setParameterType("userAlphaSpending", C_PARAM_NOT_APPLICABLE)
         if (.isDefinedArgument(design$userAlphaSpending)) {
-            warning("'userAlphaSpending' will be ignored because 'method' is not '",
-                C_FISHER_METHOD_USER_DEFINED_ALPHA, "'",
+            warning("'userAlphaSpending' will be ignored because 'method' is not ", 
+                .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA), 
                 call. = FALSE
             )
         }
@@ -319,9 +320,11 @@ getDesignFisher <- function(
     .assertIsSingleInteger(design$kMax, "kMax")
     .assertIsValidKMax(design$kMax, kMaxUpperBound = C_KMAX_UPPER_BOUND_FISHER)
     if (design$method == C_FISHER_METHOD_NO_INTERACTION && design$kMax < 3) {
-        stopIllegalArgument("method '", C_FISHER_METHOD_NO_INTERACTION, "' is only allowed for kMax > 2 (kMax is ",
+        stopIllegalArgument("method ", .vQuote(C_FISHER_METHOD_NO_INTERACTION), 
+            " is only allowed for kMax > 2 (kMax is ",
             design$kMax, ")",
-            functionName = ".getDesignFisher", parameter = "C_FISHER_METHOD_NO_INTERACTION",
+            functionName = ".getDesignFisher", 
+		parameter ="C_FISHER_METHOD_NO_INTERACTION",
             value = C_FISHER_METHOD_NO_INTERACTION
         )
     }
@@ -346,7 +349,9 @@ getDesignFisher <- function(
         stopIllegalArgument("for specified 'method' (\"", C_FISHER_METHOD_NO_INTERACTION, "\") the 'alpha0Vec' must be unequal to ",
             .arrayToString(alpha0Vec, vectorLookAndFeelEnabled = TRUE), " and 'bindingFutility' must be TRUE",
             functionName = ".getDesignFisher",
-            parameter = "method", relatedParameter = "alpha0Vec", relatedValue = alpha0Vec, value = method
+            parameter = "method", 
+		relatedParameter ="alpha0Vec", 
+		relatedValue = alpha0Vec, value = method
         )
     }
 
@@ -419,12 +424,14 @@ getDesignFisher <- function(
 
     if (userFunctionCallEnabled) {
         if (design$method == C_FISHER_METHOD_NO_INTERACTION && abs(size - design$alpha) > 1e-03) {
-            stopRuntimeIssue("numerical overflow in computation routine", functionName = ".getDesignFisher")
+            stopRuntimeIssue("numerical overflow in computation routine", 
+		functionName = ".getDesignFisher")
         }
 
         if (design$method == C_FISHER_METHOD_EQUAL_ALPHA && !all(is.na(design$stageLevels)) &&
                 abs(mean(na.omit(design$stageLevels)) - design$stageLevels[1]) > 1e-03) {
-            stopRuntimeIssue("numerical overflow in computation routine", functionName = ".getDesignFisher")
+            stopRuntimeIssue("numerical overflow in computation routine", 
+		functionName = ".getDesignFisher")
         }
 
         if (design$kMax > 1) {
@@ -435,7 +442,8 @@ getDesignFisher <- function(
                     .arrayToString(design$criticalValues, vectorLookAndFeelEnabled = TRUE), ", ",
                     "i.e., differences are ", .arrayToString(diff, vectorLookAndFeelEnabled = TRUE)
                 )
-                stopRuntimeIssue("no calculation possible", functionName = ".getDesignFisher")
+                stopRuntimeIssue("no calculation possible", 
+		functionName = ".getDesignFisher")
             }
 
             if (!all(is.na(design$stageLevels)) && any(na.omit(design$stageLevels[1:(design$kMax - 1)]) > design$alpha)) {
@@ -450,8 +458,10 @@ getDesignFisher <- function(
             if (any(abs(design$alphaSpent - design$userAlphaSpending) > 1e-05)) {
                 stopIllegalArgument("'alpha' (", design$alpha, ") or 'userAlphaSpending' (", .arrayToString(design$userAlphaSpending),
                     ") not correctly specified",
-                    functionName = ".getDesignFisher", parameter = "alpha", value = design$alpha,
-                    relatedParameter = "userAlphaSpending", relatedValue = design$userAlphaSpending
+                    functionName = ".getDesignFisher", 
+		parameter ="alpha", value = design$alpha,
+                    relatedParameter = "userAlphaSpending", 
+		relatedValue = design$userAlphaSpending
                 )
             }
         }

--- a/R/f_design_fisher_combination_test.R
+++ b/R/f_design_fisher_combination_test.R
@@ -221,8 +221,9 @@ getDesignFisher <- function(
     }
 
     if (sided != 1) {
-        stopIllegalArgument("Fisher's combination test only available for one-sided testing", 
-		functionName = ".getDesignFisher")
+        stopIllegalArgument("Fisher's combination test only available for one-sided testing",
+            functionName = ".getDesignFisher"
+        )
     }
 
     if (is.na(bindingFutility)) {
@@ -295,8 +296,8 @@ getDesignFisher <- function(
     } else {
         design$.setParameterType("userAlphaSpending", C_PARAM_NOT_APPLICABLE)
         if (.isDefinedArgument(design$userAlphaSpending)) {
-            warning("'userAlphaSpending' will be ignored because 'method' is not ", 
-                .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA), 
+            warning("'userAlphaSpending' will be ignored because 'method' is not ",
+                .vQuote(C_FISHER_METHOD_USER_DEFINED_ALPHA),
                 call. = FALSE
             )
         }
@@ -320,11 +321,11 @@ getDesignFisher <- function(
     .assertIsSingleInteger(design$kMax, "kMax")
     .assertIsValidKMax(design$kMax, kMaxUpperBound = C_KMAX_UPPER_BOUND_FISHER)
     if (design$method == C_FISHER_METHOD_NO_INTERACTION && design$kMax < 3) {
-        stopIllegalArgument("method ", .vQuote(C_FISHER_METHOD_NO_INTERACTION), 
+        stopIllegalArgument("method ", .vQuote(C_FISHER_METHOD_NO_INTERACTION),
             " is only allowed for kMax > 2 (kMax is ",
             design$kMax, ")",
-            functionName = ".getDesignFisher", 
-		parameter ="C_FISHER_METHOD_NO_INTERACTION",
+            functionName = ".getDesignFisher",
+            parameter = "C_FISHER_METHOD_NO_INTERACTION",
             value = C_FISHER_METHOD_NO_INTERACTION
         )
     }
@@ -349,9 +350,9 @@ getDesignFisher <- function(
         stopIllegalArgument("for specified 'method' (\"", C_FISHER_METHOD_NO_INTERACTION, "\") the 'alpha0Vec' must be unequal to ",
             .arrayToString(alpha0Vec, vectorLookAndFeelEnabled = TRUE), " and 'bindingFutility' must be TRUE",
             functionName = ".getDesignFisher",
-            parameter = "method", 
-		relatedParameter ="alpha0Vec", 
-		relatedValue = alpha0Vec, value = method
+            parameter = "method",
+            relatedParameter = "alpha0Vec",
+            relatedValue = alpha0Vec, value = method
         )
     }
 
@@ -424,14 +425,16 @@ getDesignFisher <- function(
 
     if (userFunctionCallEnabled) {
         if (design$method == C_FISHER_METHOD_NO_INTERACTION && abs(size - design$alpha) > 1e-03) {
-            stopRuntimeIssue("numerical overflow in computation routine", 
-		functionName = ".getDesignFisher")
+            stopRuntimeIssue("numerical overflow in computation routine",
+                functionName = ".getDesignFisher"
+            )
         }
 
         if (design$method == C_FISHER_METHOD_EQUAL_ALPHA && !all(is.na(design$stageLevels)) &&
                 abs(mean(na.omit(design$stageLevels)) - design$stageLevels[1]) > 1e-03) {
-            stopRuntimeIssue("numerical overflow in computation routine", 
-		functionName = ".getDesignFisher")
+            stopRuntimeIssue("numerical overflow in computation routine",
+                functionName = ".getDesignFisher"
+            )
         }
 
         if (design$kMax > 1) {
@@ -442,8 +445,9 @@ getDesignFisher <- function(
                     .arrayToString(design$criticalValues, vectorLookAndFeelEnabled = TRUE), ", ",
                     "i.e., differences are ", .arrayToString(diff, vectorLookAndFeelEnabled = TRUE)
                 )
-                stopRuntimeIssue("no calculation possible", 
-		functionName = ".getDesignFisher")
+                stopRuntimeIssue("no calculation possible",
+                    functionName = ".getDesignFisher"
+                )
             }
 
             if (!all(is.na(design$stageLevels)) && any(na.omit(design$stageLevels[1:(design$kMax - 1)]) > design$alpha)) {
@@ -458,10 +462,10 @@ getDesignFisher <- function(
             if (any(abs(design$alphaSpent - design$userAlphaSpending) > 1e-05)) {
                 stopIllegalArgument("'alpha' (", design$alpha, ") or 'userAlphaSpending' (", .arrayToString(design$userAlphaSpending),
                     ") not correctly specified",
-                    functionName = ".getDesignFisher", 
-		parameter ="alpha", value = design$alpha,
-                    relatedParameter = "userAlphaSpending", 
-		relatedValue = design$userAlphaSpending
+                    functionName = ".getDesignFisher",
+                    parameter = "alpha", value = design$alpha,
+                    relatedParameter = "userAlphaSpending",
+                    relatedValue = design$userAlphaSpending
                 )
             }
         }

--- a/R/f_design_futility_bounds.R
+++ b/R/f_design_futility_bounds.R
@@ -35,8 +35,8 @@ NULL
                 if (isTRUE(showWarnings)) {
                     warning(
                         "'information[1]' (", information1, ") will be ignored ",
-                        "because it is not required for the conversion from ", 
-                        .vQuote(sourceScale), " to ", .vQuote(targetScale), 
+                        "because it is not required for the conversion from ",
+                        .vQuote(sourceScale), " to ", .vQuote(targetScale),
                         call. = FALSE
                     )
                 }
@@ -46,8 +46,8 @@ NULL
                 if (isTRUE(showWarnings)) {
                     warning(
                         "'information[2]' (", information2, ") will be ignored ",
-                        "because it is not required for the conversion from ", 
-                        .vQuote(sourceScale), " to ", .vQuote(targetScale), 
+                        "because it is not required for the conversion from ",
+                        .vQuote(sourceScale), " to ", .vQuote(targetScale),
                         call. = FALSE
                     )
                 }
@@ -289,11 +289,11 @@ summary.FutilityBounds <- function(object, ...) {
     if (!all(is.na(futilityBoundsFromArgs))) {
         if (is(futilityBoundsFromArgs, "FutilityBounds") &&
                 !identical(attr(futilityBoundsFromArgs, "targetScale")$value, targetScale)) {
-            stopIllegalArgument(.pQuote(futilityBoundsName), " (", .arrayToString(futilityBoundsFromArgs), ") ", 
+            stopIllegalArgument(.pQuote(futilityBoundsName), " (", .arrayToString(futilityBoundsFromArgs), ") ",
                 "must be on ", .vQuote(targetScale), " scale or converted to ", .vQuote(targetScale), " scale",
                 functionName = ".getFutilityBoundsFromArgs",
-                parameter = futilityBoundsName, value = futilityBoundsFromArgs, 
-		relatedParameter =futilityBoundsScaleName,
+                parameter = futilityBoundsName, value = futilityBoundsFromArgs,
+                relatedParameter = futilityBoundsScaleName,
                 relatedValue = targetScale
             )
         }
@@ -660,12 +660,12 @@ getFutilityBounds <- function(
         return(.addFutilityBoundParameterTypes(result, args))
     }
 
-    stopIllegalArgument("conversion from ", .vQuote(sourceScale), " to ", 
+    stopIllegalArgument("conversion from ", .vQuote(sourceScale), " to ",
         .vQuote(targetScale), " not implemented",
         functionName = "getFutilityBounds",
-        parameter = "sourceScale", value = sourceScale, 
-		relatedParameter ="targetScale", 
-		relatedValue = targetScale
+        parameter = "sourceScale", value = sourceScale,
+        relatedParameter = "targetScale",
+        relatedValue = targetScale
     )
 }
 
@@ -720,12 +720,16 @@ getFutilityBounds <- function(
             }
         },
         warning = function(w) {
-            warning("Failed to calculate ", sQuote(sourceScale), " source value from ", 
-                sourceValue, ": ", w$message, call. = FALSE)
+            warning("Failed to calculate ", sQuote(sourceScale), " source value from ",
+                sourceValue, ": ", w$message,
+                call. = FALSE
+            )
         },
         error = function(e) {
-            warning("Failed to calculate ", sQuote(sourceScale), " source value from ", 
-                sourceValue, ": ", e$message, call. = FALSE)
+            warning("Failed to calculate ", sQuote(sourceScale), " source value from ",
+                sourceValue, ": ", e$message,
+                call. = FALSE
+            )
         }
     )
 

--- a/R/f_design_futility_bounds.R
+++ b/R/f_design_futility_bounds.R
@@ -839,23 +839,26 @@ getFutilityBounds <- function(
 
 #'
 #' @title
-#' Get Fisher Information From a Design Plan
+#' Get Fisher Information From a Design Plan or Simulation Results
 #'
 #' @description
 #' Calculates the Fisher information at the first planned analysis stage for
-#' a design plan for means, rates, or survival endpoints.
+#' a design plan or simulation results object for means, rates, or survival endpoints.
 #'
-#' @param designPlan A trial design plan object as returned by functions such as
+#' @param designPlan A trial design plan or simulation results object as returned by functions such as
 #' \code{\link[=getSampleSizeMeans]{getSampleSizeMeans()}},
 #' \code{\link[=getPowerMeans]{getPowerMeans()}},
 #' \code{\link[=getSampleSizeRates]{getSampleSizeRates()}},
 #' \code{\link[=getPowerRates]{getPowerRates()}},
-#' \code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}}, or
-#' \code{\link[=getPowerSurvival]{getPowerSurvival()}}.
+#' \code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}},
+#' \code{\link[=getPowerSurvival]{getPowerSurvival()}},
+#' \code{\link[=getSimulationMeans]{getSimulationMeans()}},
+#' \code{\link[=getSimulationRates]{getSimulationRates()}}, or
+#' \code{\link[=getSimulationSurvival]{getSimulationSurvival()}}.
 #'
 #' @details
 #' The returned information is the information used at the first stage of the
-#' design plan. For group sequential designs, information at later stages can be
+#' design plan or simulation setup. For group sequential designs, information at later stages can be
 #' obtained by multiplying this value by the ratio of the corresponding
 #' information rate to the first information rate.
 #'
@@ -867,7 +870,7 @@ getFutilityBounds <- function(
 #'
 #' @return
 #' A numeric value or numeric vector containing the first-stage Fisher
-#' information. A vector is returned if the design plan contains several
+#' information. A vector is returned if the object contains several
 #' planning alternatives or sample size values. \code{NA_real_} is returned if
 #' the endpoint type is not supported by this helper.
 #'
@@ -881,6 +884,12 @@ getFutilityBounds <- function(
 #'     alternative = c(0.3, 0.4), maxNumberOfSubjects = 100
 #' )
 #' getFisherInformation(designPlan)
+#'
+#' simulationResults <- getSimulationMeans(design,
+#'     plannedSubjects = c(20, 40, 60), alternative = 0.4,
+#'     maxNumberOfIterations = 10
+#' )
+#' getFisherInformation(simulationResults)
 #' }
 #'
 #' @seealso \code{\link[=getFutilityBounds]{getFutilityBounds()}}
@@ -935,6 +944,41 @@ getFisherInformation <- function(designPlan) {
         } else {
             cumulativeEvents <- designPlan$maxNumberOfEvents * designPlan$.design$informationRates[1]
         }
+        allocationRatio <- designPlan$allocationRatioPlanned[1]
+        fisherInformation <- allocationRatio / (1 + allocationRatio)^2 * cumulativeEvents
+    } else if (is(designPlan, "SimulationResultsMeans")) {
+        numberOfSubjects <- designPlan$plannedSubjects[1]
+        stDev <- designPlan$stDev
+        if (length(stDev) == 1 && designPlan$groups == 2) {
+            stDev <- rep(stDev, 2)
+        }
+        if (designPlan$groups == 1) {
+            fisherInformation <- numberOfSubjects / stDev[1]^2
+        } else {
+            allocationRatio <- designPlan$allocationRatioPlanned[1]
+            if (designPlan$meanRatio) {
+                fisherInformation <- allocationRatio * numberOfSubjects /
+                    ((1 + allocationRatio) *
+                        (stDev[1]^2 + designPlan$thetaH0^2 * allocationRatio * stDev[2]^2))
+            } else {
+                fisherInformation <- allocationRatio * numberOfSubjects /
+                    ((1 + allocationRatio) *
+                        (stDev[1]^2 + allocationRatio * stDev[2]^2))
+            }
+        }
+    } else if (is(designPlan, "SimulationResultsRates")) {
+        n1 <- designPlan$plannedSubjects[1]
+        if (designPlan$groups == 1) {
+            pi0 <- designPlan$thetaH0
+            fisherInformation <- n1 / (pi0 * (1 - pi0))
+        } else if (designPlan$groups == 2) {
+            pi1 <- designPlan$pi1
+            pi2 <- designPlan$pi2
+            allocationRatio <- designPlan$allocationRatioPlanned[1]
+            fisherInformation <- allocationRatio / (pi1 * (1 - pi1) + allocationRatio * pi2 * (1 - pi2)) * n1 / (1 + allocationRatio)
+        }
+    } else if (is(designPlan, "SimulationResultsSurvival")) {
+        cumulativeEvents <- designPlan$plannedEvents[1]
         allocationRatio <- designPlan$allocationRatioPlanned[1]
         fisherInformation <- allocationRatio / (1 + allocationRatio)^2 * cumulativeEvents
     }

--- a/R/f_design_futility_bounds.R
+++ b/R/f_design_futility_bounds.R
@@ -35,8 +35,8 @@ NULL
                 if (isTRUE(showWarnings)) {
                     warning(
                         "'information[1]' (", information1, ") will be ignored ",
-                        "because it is not required for the conversion from '",
-                        sourceScale, "' to '", targetScale, "'",
+                        "because it is not required for the conversion from ", 
+                        .vQuote(sourceScale), " to ", .vQuote(targetScale), 
                         call. = FALSE
                     )
                 }
@@ -46,8 +46,8 @@ NULL
                 if (isTRUE(showWarnings)) {
                     warning(
                         "'information[2]' (", information2, ") will be ignored ",
-                        "because it is not required for the conversion from '",
-                        sourceScale, "' to '", targetScale, "'",
+                        "because it is not required for the conversion from ", 
+                        .vQuote(sourceScale), " to ", .vQuote(targetScale), 
                         call. = FALSE
                     )
                 }
@@ -289,10 +289,11 @@ summary.FutilityBounds <- function(object, ...) {
     if (!all(is.na(futilityBoundsFromArgs))) {
         if (is(futilityBoundsFromArgs, "FutilityBounds") &&
                 !identical(attr(futilityBoundsFromArgs, "targetScale")$value, targetScale)) {
-            stopIllegalArgument("'", futilityBoundsName, "' (", .arrayToString(futilityBoundsFromArgs), ") ", "must be on '",
-                targetScale, "' scale or converted to '", targetScale, "' scale",
+            stopIllegalArgument(.pQuote(futilityBoundsName), " (", .arrayToString(futilityBoundsFromArgs), ") ", 
+                "must be on ", .vQuote(targetScale), " scale or converted to ", .vQuote(targetScale), " scale",
                 functionName = ".getFutilityBoundsFromArgs",
-                parameter = futilityBoundsName, value = futilityBoundsFromArgs, relatedParameter = futilityBoundsScaleName,
+                parameter = futilityBoundsName, value = futilityBoundsFromArgs, 
+		relatedParameter =futilityBoundsScaleName,
                 relatedValue = targetScale
             )
         }
@@ -659,9 +660,12 @@ getFutilityBounds <- function(
         return(.addFutilityBoundParameterTypes(result, args))
     }
 
-    stopIllegalArgument("conversion from '", sourceScale, "' to '", targetScale, "' not implemented",
+    stopIllegalArgument("conversion from ", .vQuote(sourceScale), " to ", 
+        .vQuote(targetScale), " not implemented",
         functionName = "getFutilityBounds",
-        parameter = "sourceScale", value = sourceScale, relatedParameter = "targetScale", relatedValue = targetScale
+        parameter = "sourceScale", value = sourceScale, 
+		relatedParameter ="targetScale", 
+		relatedValue = targetScale
     )
 }
 
@@ -709,17 +713,19 @@ getFutilityBounds <- function(
                 )$root)
             } else {
                 warning(
-                    "Source scale '", sourceScale, "' not implemented for Fisher's combination test design",
+                    "Source scale ", .vQuote(sourceScale), " not implemented for Fisher's combination test design",
                     call. = FALSE
                 )
                 return(NA_real_)
             }
         },
         warning = function(w) {
-            warning("Failed to calculate ", sQuote(sourceScale), " source value from ", sourceValue, ": ", w$message, call. = FALSE)
+            warning("Failed to calculate ", sQuote(sourceScale), " source value from ", 
+                sourceValue, ": ", w$message, call. = FALSE)
         },
         error = function(e) {
-            warning("Failed to calculate ", sQuote(sourceScale), " source value from ", sourceValue, ": ", e$message, call. = FALSE)
+            warning("Failed to calculate ", sQuote(sourceScale), " source value from ", 
+                sourceValue, ": ", e$message, call. = FALSE)
         }
     )
 

--- a/R/f_design_general_utilities.R
+++ b/R/f_design_general_utilities.R
@@ -169,7 +169,7 @@ NULL
             ) &&
             (twoSidedWarningForDefaultValues && !all(is.na(parameterValues)) ||
                 (!twoSidedWarningForDefaultValues && any(na.omit(parameterValues) != defaultValue)))) {
-        warning("'", parameterName, "' (", .arrayToString(parameterValues),
+        warning(.pQuote(parameterName), " (", .arrayToString(parameterValues),
             ") will be ignored because the design is two-sided",
             call. = FALSE
         )
@@ -265,7 +265,7 @@ NULL
     }
 
     if (design$isUserDefinedParameter(parameterName)) {
-        warning("'", parameterName, "' (", .arrayToString(design[[parameterName]]),
+        warning(.pQuote(parameterName), " (", .arrayToString(design[[parameterName]]),
             ") will be ignored because it will be calculated",
             call. = FALSE
         )
@@ -373,7 +373,8 @@ NULL
 .validateUserAlphaSpending <- function(design) {
     .assertIsTrialDesign(design)
     .assertDesignParameterExists(design, "userAlphaSpending", NA_real_,
-        relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+        relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
     )
 
     if ((design$isUserDefinedParameter("informationRates") ||
@@ -386,7 +387,9 @@ NULL
             ),
             parameter = "userAlphaSpending",
             value = length(design$userAlphaSpending), constraint = "length must equal length of informationRates",
-            relatedParameter = "informationRates", relatedValue = length(design$informationRates), functionName = ".validateUserAlphaSpending"
+            relatedParameter = "informationRates", 
+		relatedValue = length(design$informationRates), 
+		functionName = ".validateUserAlphaSpending"
         )
     }
 
@@ -397,7 +400,9 @@ NULL
                 design$kMax
             ),
             parameter = "userAlphaSpending", value = length(design$userAlphaSpending), constraint = "length must equal kMax",
-            relatedParameter = "kMax", relatedValue = design$kMax, functionName = ".validateUserAlphaSpending"
+            relatedParameter = "kMax", 
+		relatedValue = design$kMax, 
+		functionName = ".validateUserAlphaSpending"
         )
     }
 
@@ -423,7 +428,8 @@ NULL
                 design$kMax, design$alpha
             ),
             parameter = "userAlphaSpending", value = design$userAlphaSpending, constraint = "0 <= alpha_1 <= .. <= alpha_kMax <= alpha",
-            relatedParameter = c("kMax", "alpha"), relatedValue = list(kMax = design$kMax, alpha = design$alpha),
+            relatedParameter = c("kMax", "alpha"), 
+		relatedValue = list(kMax = design$kMax, alpha = design$alpha),
             functionName = ".validateUserAlphaSpending"
         )
     }
@@ -439,7 +445,8 @@ NULL
 .validateUserBetaSpending <- function(design) {
     .assertIsTrialDesign(design)
     .assertDesignParameterExists(design, "userBetaSpending", NA_real_,
-        relatedParameter = "typeBetaSpending", relatedValue = design$typeBetaSpending
+        relatedParameter = "typeBetaSpending", 
+		relatedValue = design$typeBetaSpending
     )
 
     if ((design$isUserDefinedParameter("informationRates") ||
@@ -452,7 +459,9 @@ NULL
             ),
             parameter = "userBetaSpending",
             value = length(design$userBetaSpending), constraint = "length must equal length of informationRates",
-            relatedParameter = "informationRates", relatedValue = length(design$informationRates), functionName = ".validateUserBetaSpending"
+            relatedParameter = "informationRates", 
+		relatedValue = length(design$informationRates), 
+		functionName = ".validateUserBetaSpending"
         )
     }
 
@@ -463,7 +472,9 @@ NULL
                 design$kMax
             ),
             parameter = "userBetaSpending", value = length(design$userBetaSpending), constraint = "length must equal kMax",
-            relatedParameter = "kMax", relatedValue = design$kMax, functionName = ".validateUserBetaSpending"
+            relatedParameter = "kMax", 
+		relatedValue = design$kMax, 
+		functionName = ".validateUserBetaSpending"
         )
     }
 
@@ -471,10 +482,12 @@ NULL
         stopArgumentLengthOutOfBounds(sprintf(
             "length of 'userBetaSpending' (%s) is out of bounds [2; %s]", length(design$userBetaSpending),
             C_KMAX_UPPER_BOUND
-        ), parameter = "userBetaSpending", value = length(design$userBetaSpending), constraint = paste0(
+        ), 
+		parameter ="userBetaSpending", value = length(design$userBetaSpending), constraint = paste0(
             "length must be in [2; ",
             C_KMAX_UPPER_BOUND, "]"
-        ), lowerBound = 2, upperBound = C_KMAX_UPPER_BOUND, functionName = ".validateUserBetaSpending")
+        ), lowerBound = 2, upperBound = C_KMAX_UPPER_BOUND, 
+		functionName = ".validateUserBetaSpending")
     }
 
     if (.isUndefinedArgument(design$beta)) {
@@ -497,7 +510,8 @@ NULL
                 design$kMax, design$beta
             ),
             parameter = "userBetaSpending", value = design$userBetaSpending, constraint = "0 <= beta_1 <= .. <= beta_kMax <= beta",
-            relatedParameter = c("kMax", "beta"), relatedValue = list(kMax = design$kMax, beta = design$beta),
+            relatedParameter = c("kMax", "beta"), 
+		relatedValue = list(kMax = design$kMax, beta = design$beta),
             functionName = ".validateUserBetaSpending"
         )
     }
@@ -579,7 +593,8 @@ NULL
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
             .arrayToString(piecewiseLambda), ")",
             functionName = ".getPiecewiseExponentialDistributionSingleTime",
-            parameter = "piecewiseSurvivalTime", value = piecewiseSurvivalTime, relatedParameter = "piecewiseLambda",
+            parameter = "piecewiseSurvivalTime", value = piecewiseSurvivalTime, 
+		relatedParameter ="piecewiseLambda",
             relatedValue = piecewiseLambda
         )
     }
@@ -587,7 +602,8 @@ NULL
     piecewiseSurvivalTime <- .getPiecewiseExpStartTimesWithoutLeadingZero(piecewiseSurvivalTime)
 
     if (kappa != 1) {
-        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition", functionName = ".getPiecewiseExponentialDistributionSingleTime")
+        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition", 
+		functionName = ".getPiecewiseExponentialDistributionSingleTime")
     }
 
     len <- length(piecewiseSurvivalTime)
@@ -620,7 +636,8 @@ NULL
 .getPiecewiseExponentialSingleQuantile <- function(quantile, piecewiseLambda, piecewiseSurvivalTime, kappa) {
     if (length(piecewiseLambda) == 1) {
         if (kappa <= 0) {
-            stopIllegalArgument("kappa needs to a positive number", functionName = ".getPiecewiseExponentialSingleQuantile")
+            stopIllegalArgument("kappa needs to a positive number", 
+		functionName = ".getPiecewiseExponentialSingleQuantile")
         }
 
         # kappa is required here because quantiles depend on the Weibull shape parameter
@@ -696,8 +713,10 @@ NULL
     if (!all(is.na(piecewiseLambda)) && is.list(piecewiseSurvivalTime)) {
         stopConflictingArguments("'piecewiseSurvivalTime' needs to be a numeric vector and not a list ", "because 'piecewiseLambda' (",
             piecewiseLambda, ") is defined separately",
-            functionName = ".getPiecewiseExponentialSettings", parameter = "piecewiseSurvivalTime",
-            relatedParameter = "piecewiseLambda", relatedValue = piecewiseLambda, value = piecewiseSurvivalTime
+            functionName = ".getPiecewiseExponentialSettings", 
+		parameter ="piecewiseSurvivalTime",
+            relatedParameter = "piecewiseLambda", 
+		relatedValue = piecewiseLambda, value = piecewiseSurvivalTime
         )
     }
 
@@ -801,7 +820,8 @@ getPiecewiseExponentialDistribution <- function(
     .warnInCaseOfUnknownArguments(functionName = "getPiecewiseExponentialDistribution", ...)
     time <- .assertIsNumericVector(time, "time")
     if (any(time < 0)) {
-        stopIllegalArgument("time needs to be a non-negative number", functionName = "getPiecewiseExponentialDistribution")
+        stopIllegalArgument("time needs to be a non-negative number", 
+		functionName = "getPiecewiseExponentialDistribution")
     }
 
     settings <- .getPiecewiseExponentialSettings(
@@ -838,7 +858,8 @@ getPiecewiseExponentialQuantile <- function(
     .warnInCaseOfUnknownArguments(functionName = "getPiecewiseExponentialQuantile", ...)
     quantile <- .assertIsNumericVector(quantile, "quantile")
     if (any(quantile < 0) || any(quantile > 1)) {
-        stopIllegalArgument("quantile needs to be within [0; 1]", functionName = "getPiecewiseExponentialQuantile")
+        stopIllegalArgument("quantile needs to be within [0; 1]", 
+		functionName = "getPiecewiseExponentialQuantile")
     }
 
     settings <- .getPiecewiseExponentialSettings(
@@ -955,7 +976,9 @@ getLambdaByPi <- function(
     .assertIsInOpenInterval(eventTime, "eventTime", lower = 0, upper = NULL)
     for (value in piValue) {
         if (!is.na(value) && value > 1 - 1e-16 && value < 1 + 1e-16) {
-            stopIllegalArgument("'pi' must be != 1", functionName = "getLambdaByPi", parameter = "pi")
+            stopIllegalArgument("'pi' must be != 1", 
+		functionName = "getLambdaByPi", 
+		parameter ="pi")
         }
     }
 
@@ -988,7 +1011,8 @@ getLambdaByMedian <- function(median, kappa = 1) {
     stopIllegalArgument("invalid length of ", sQuote(paramName2), ". ", "Expected length 1 or the same length as ",
         sQuote(paramName1), " (", length(paramValue1), "), but got length ", length(paramValue2), ".",
         functionName = ".assertHasCompatibleLength",
-        parameter = paramName2, relatedParameter = paramName1
+        parameter = paramName2, 
+		relatedParameter =paramName1
     )
 }
 
@@ -1157,7 +1181,9 @@ getMedianByPi <- function(
 .getDesignParametersToShow <- function(parameterSet) {
     if (is.null(parameterSet[[".design"]])) {
         stopRuntimeIssue("'parameterSet' (", .getClassName(parameterSet), ") does not contain '.design' field",
-            functionName = ".getDesignParametersToShow", parameter = "parameterSet", value = parameterSet, relatedParameter = ".design"
+            functionName = ".getDesignParametersToShow", 
+		parameter ="parameterSet", value = parameterSet, 
+		relatedParameter =".design"
         )
     }
 

--- a/R/f_design_general_utilities.R
+++ b/R/f_design_general_utilities.R
@@ -373,8 +373,8 @@ NULL
 .validateUserAlphaSpending <- function(design) {
     .assertIsTrialDesign(design)
     .assertDesignParameterExists(design, "userAlphaSpending", NA_real_,
-        relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+        relatedParameter = "typeOfDesign",
+        relatedValue = design$typeOfDesign
     )
 
     if ((design$isUserDefinedParameter("informationRates") ||
@@ -387,9 +387,9 @@ NULL
             ),
             parameter = "userAlphaSpending",
             value = length(design$userAlphaSpending), constraint = "length must equal length of informationRates",
-            relatedParameter = "informationRates", 
-		relatedValue = length(design$informationRates), 
-		functionName = ".validateUserAlphaSpending"
+            relatedParameter = "informationRates",
+            relatedValue = length(design$informationRates),
+            functionName = ".validateUserAlphaSpending"
         )
     }
 
@@ -400,9 +400,9 @@ NULL
                 design$kMax
             ),
             parameter = "userAlphaSpending", value = length(design$userAlphaSpending), constraint = "length must equal kMax",
-            relatedParameter = "kMax", 
-		relatedValue = design$kMax, 
-		functionName = ".validateUserAlphaSpending"
+            relatedParameter = "kMax",
+            relatedValue = design$kMax,
+            functionName = ".validateUserAlphaSpending"
         )
     }
 
@@ -428,8 +428,8 @@ NULL
                 design$kMax, design$alpha
             ),
             parameter = "userAlphaSpending", value = design$userAlphaSpending, constraint = "0 <= alpha_1 <= .. <= alpha_kMax <= alpha",
-            relatedParameter = c("kMax", "alpha"), 
-		relatedValue = list(kMax = design$kMax, alpha = design$alpha),
+            relatedParameter = c("kMax", "alpha"),
+            relatedValue = list(kMax = design$kMax, alpha = design$alpha),
             functionName = ".validateUserAlphaSpending"
         )
     }
@@ -445,8 +445,8 @@ NULL
 .validateUserBetaSpending <- function(design) {
     .assertIsTrialDesign(design)
     .assertDesignParameterExists(design, "userBetaSpending", NA_real_,
-        relatedParameter = "typeBetaSpending", 
-		relatedValue = design$typeBetaSpending
+        relatedParameter = "typeBetaSpending",
+        relatedValue = design$typeBetaSpending
     )
 
     if ((design$isUserDefinedParameter("informationRates") ||
@@ -459,9 +459,9 @@ NULL
             ),
             parameter = "userBetaSpending",
             value = length(design$userBetaSpending), constraint = "length must equal length of informationRates",
-            relatedParameter = "informationRates", 
-		relatedValue = length(design$informationRates), 
-		functionName = ".validateUserBetaSpending"
+            relatedParameter = "informationRates",
+            relatedValue = length(design$informationRates),
+            functionName = ".validateUserBetaSpending"
         )
     }
 
@@ -472,22 +472,24 @@ NULL
                 design$kMax
             ),
             parameter = "userBetaSpending", value = length(design$userBetaSpending), constraint = "length must equal kMax",
-            relatedParameter = "kMax", 
-		relatedValue = design$kMax, 
-		functionName = ".validateUserBetaSpending"
+            relatedParameter = "kMax",
+            relatedValue = design$kMax,
+            functionName = ".validateUserBetaSpending"
         )
     }
 
     if (length(design$userBetaSpending) < 2 || length(design$userBetaSpending) > C_KMAX_UPPER_BOUND) {
-        stopArgumentLengthOutOfBounds(sprintf(
-            "length of 'userBetaSpending' (%s) is out of bounds [2; %s]", length(design$userBetaSpending),
-            C_KMAX_UPPER_BOUND
-        ), 
-		parameter ="userBetaSpending", value = length(design$userBetaSpending), constraint = paste0(
-            "length must be in [2; ",
-            C_KMAX_UPPER_BOUND, "]"
-        ), lowerBound = 2, upperBound = C_KMAX_UPPER_BOUND, 
-		functionName = ".validateUserBetaSpending")
+        stopArgumentLengthOutOfBounds(
+            sprintf(
+                "length of 'userBetaSpending' (%s) is out of bounds [2; %s]", length(design$userBetaSpending),
+                C_KMAX_UPPER_BOUND
+            ),
+            parameter = "userBetaSpending", value = length(design$userBetaSpending), constraint = paste0(
+                "length must be in [2; ",
+                C_KMAX_UPPER_BOUND, "]"
+            ), lowerBound = 2, upperBound = C_KMAX_UPPER_BOUND,
+            functionName = ".validateUserBetaSpending"
+        )
     }
 
     if (.isUndefinedArgument(design$beta)) {
@@ -510,8 +512,8 @@ NULL
                 design$kMax, design$beta
             ),
             parameter = "userBetaSpending", value = design$userBetaSpending, constraint = "0 <= beta_1 <= .. <= beta_kMax <= beta",
-            relatedParameter = c("kMax", "beta"), 
-		relatedValue = list(kMax = design$kMax, beta = design$beta),
+            relatedParameter = c("kMax", "beta"),
+            relatedValue = list(kMax = design$kMax, beta = design$beta),
             functionName = ".validateUserBetaSpending"
         )
     }
@@ -593,8 +595,8 @@ NULL
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
             .arrayToString(piecewiseLambda), ")",
             functionName = ".getPiecewiseExponentialDistributionSingleTime",
-            parameter = "piecewiseSurvivalTime", value = piecewiseSurvivalTime, 
-		relatedParameter ="piecewiseLambda",
+            parameter = "piecewiseSurvivalTime", value = piecewiseSurvivalTime,
+            relatedParameter = "piecewiseLambda",
             relatedValue = piecewiseLambda
         )
     }
@@ -602,8 +604,9 @@ NULL
     piecewiseSurvivalTime <- .getPiecewiseExpStartTimesWithoutLeadingZero(piecewiseSurvivalTime)
 
     if (kappa != 1) {
-        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition", 
-		functionName = ".getPiecewiseExponentialDistributionSingleTime")
+        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition",
+            functionName = ".getPiecewiseExponentialDistributionSingleTime"
+        )
     }
 
     len <- length(piecewiseSurvivalTime)
@@ -636,8 +639,9 @@ NULL
 .getPiecewiseExponentialSingleQuantile <- function(quantile, piecewiseLambda, piecewiseSurvivalTime, kappa) {
     if (length(piecewiseLambda) == 1) {
         if (kappa <= 0) {
-            stopIllegalArgument("kappa needs to a positive number", 
-		functionName = ".getPiecewiseExponentialSingleQuantile")
+            stopIllegalArgument("kappa needs to a positive number",
+                functionName = ".getPiecewiseExponentialSingleQuantile"
+            )
         }
 
         # kappa is required here because quantiles depend on the Weibull shape parameter
@@ -713,10 +717,10 @@ NULL
     if (!all(is.na(piecewiseLambda)) && is.list(piecewiseSurvivalTime)) {
         stopConflictingArguments("'piecewiseSurvivalTime' needs to be a numeric vector and not a list ", "because 'piecewiseLambda' (",
             piecewiseLambda, ") is defined separately",
-            functionName = ".getPiecewiseExponentialSettings", 
-		parameter ="piecewiseSurvivalTime",
-            relatedParameter = "piecewiseLambda", 
-		relatedValue = piecewiseLambda, value = piecewiseSurvivalTime
+            functionName = ".getPiecewiseExponentialSettings",
+            parameter = "piecewiseSurvivalTime",
+            relatedParameter = "piecewiseLambda",
+            relatedValue = piecewiseLambda, value = piecewiseSurvivalTime
         )
     }
 
@@ -820,8 +824,9 @@ getPiecewiseExponentialDistribution <- function(
     .warnInCaseOfUnknownArguments(functionName = "getPiecewiseExponentialDistribution", ...)
     time <- .assertIsNumericVector(time, "time")
     if (any(time < 0)) {
-        stopIllegalArgument("time needs to be a non-negative number", 
-		functionName = "getPiecewiseExponentialDistribution")
+        stopIllegalArgument("time needs to be a non-negative number",
+            functionName = "getPiecewiseExponentialDistribution"
+        )
     }
 
     settings <- .getPiecewiseExponentialSettings(
@@ -858,8 +863,9 @@ getPiecewiseExponentialQuantile <- function(
     .warnInCaseOfUnknownArguments(functionName = "getPiecewiseExponentialQuantile", ...)
     quantile <- .assertIsNumericVector(quantile, "quantile")
     if (any(quantile < 0) || any(quantile > 1)) {
-        stopIllegalArgument("quantile needs to be within [0; 1]", 
-		functionName = "getPiecewiseExponentialQuantile")
+        stopIllegalArgument("quantile needs to be within [0; 1]",
+            functionName = "getPiecewiseExponentialQuantile"
+        )
     }
 
     settings <- .getPiecewiseExponentialSettings(
@@ -976,9 +982,10 @@ getLambdaByPi <- function(
     .assertIsInOpenInterval(eventTime, "eventTime", lower = 0, upper = NULL)
     for (value in piValue) {
         if (!is.na(value) && value > 1 - 1e-16 && value < 1 + 1e-16) {
-            stopIllegalArgument("'pi' must be != 1", 
-		functionName = "getLambdaByPi", 
-		parameter ="pi")
+            stopIllegalArgument("'pi' must be != 1",
+                functionName = "getLambdaByPi",
+                parameter = "pi"
+            )
         }
     }
 
@@ -1011,8 +1018,8 @@ getLambdaByMedian <- function(median, kappa = 1) {
     stopIllegalArgument("invalid length of ", sQuote(paramName2), ". ", "Expected length 1 or the same length as ",
         sQuote(paramName1), " (", length(paramValue1), "), but got length ", length(paramValue2), ".",
         functionName = ".assertHasCompatibleLength",
-        parameter = paramName2, 
-		relatedParameter =paramName1
+        parameter = paramName2,
+        relatedParameter = paramName1
     )
 }
 
@@ -1181,9 +1188,9 @@ getMedianByPi <- function(
 .getDesignParametersToShow <- function(parameterSet) {
     if (is.null(parameterSet[[".design"]])) {
         stopRuntimeIssue("'parameterSet' (", .getClassName(parameterSet), ") does not contain '.design' field",
-            functionName = ".getDesignParametersToShow", 
-		parameter ="parameterSet", value = parameterSet, 
-		relatedParameter =".design"
+            functionName = ".getDesignParametersToShow",
+            parameter = "parameterSet", value = parameterSet,
+            relatedParameter = ".design"
         )
     }
 

--- a/R/f_design_group_sequential.R
+++ b/R/f_design_group_sequential.R
@@ -109,28 +109,28 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
     if (design$typeOfDesign == C_TYPE_OF_DESIGN_WT) {
         .assertDesignParameterExists(design, "deltaWT", NA_real_,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$deltaWT, "deltaWT", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$deltaWT, "deltaWT", lowerBound = -0.5, upperBound = 1)
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_PT) {
         .assertDesignParameterExists(design, "deltaPT1", NA_real_,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$deltaPT1, "deltaPT1", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$deltaPT1, "deltaPT1", lowerBound = -0.5, upperBound = 1)
         .assertDesignParameterExists(design, "deltaPT0", NA_real_,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$deltaPT0, "deltaPT0", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$deltaPT0, "deltaPT0", lowerBound = -0.5, upperBound = 1)
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_WT_OPTIMUM) {
         .assertDesignParameterExists(design, "optimizationCriterion", C_OPTIMIZATION_CRITERION_DEFAULT,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         if (!.isOptimizationCriterion(design$optimizationCriterion)) {
             stopIllegalArgument("optimization criterion must be one of the following: ", .printOptimizationCriterion(),
@@ -139,15 +139,15 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
         }
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_HP) {
         .assertDesignParameterExists(design, "constantBoundsHP", C_CONST_BOUND_HP_DEFAULT,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$constantBoundsHP, "constantBoundsHP")
         .showParameterOutOfValidatedBoundsMessage(design$constantBoundsHP, "constantBoundsHP", lowerBound = 2)
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_AS_KD) {
         .assertDesignParameterExists(design, "gammaA", NA_real_,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$gammaA, "gammaA", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$gammaA, "gammaA",
@@ -156,8 +156,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
         )
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_AS_HSD) {
         .assertDesignParameterExists(design, "gammaA", NA_real_,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$gammaA, "gammaA", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$gammaA, "gammaA",
@@ -186,14 +186,15 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
     if ((.isBetaSpendingDesignType(design$typeBetaSpending) || !.isAlphaSpendingDesignType(design$typeOfDesign)) &&
             (design$informationRates[length(design$informationRates)] != 1)) {
-        stopIllegalArgument("For specified design, last information rate should be equal 1", 
-		functionName = ".validateTypeOfDesign")
+        stopIllegalArgument("For specified design, last information rate should be equal 1",
+            functionName = ".validateTypeOfDesign"
+        )
     }
 
     if (.isAlphaSpendingDesignType(design$typeOfDesign)) {
         .assertDesignParameterExists(design, "typeBetaSpending", C_TYPE_OF_DESIGN_BS_NONE,
-            relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign",
+            relatedValue = design$typeOfDesign
         )
 
         if (!.isBetaSpendingDesignType(design$typeBetaSpending, noneIncluded = TRUE)) {
@@ -204,8 +205,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
         if (design$typeBetaSpending == C_TYPE_OF_DESIGN_BS_KD) {
             .assertDesignParameterExists(design, "gammaB", NA_real_,
-                relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+                relatedParameter = "typeOfDesign",
+                relatedValue = design$typeOfDesign
             )
             .assertIsSingleNumber(design$gammaB, "gammaB", naAllowed = FALSE)
             .showParameterOutOfValidatedBoundsMessage(design$gammaB, "gammaB",
@@ -216,8 +217,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
         if (design$typeBetaSpending == C_TYPE_OF_DESIGN_BS_HSD) {
             .assertDesignParameterExists(design, "gammaB", NA_real_,
-                relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+                relatedParameter = "typeOfDesign",
+                relatedValue = design$typeOfDesign
             )
             .assertIsSingleNumber(design$gammaB, "gammaB", naAllowed = FALSE)
             .showParameterOutOfValidatedBoundsMessage(design$gammaB, "gammaB",
@@ -339,9 +340,9 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
                     kMax
                 ),
                 parameter = "userAlphaSpending", value = length(userAlphaSpending), constraint = "length must equal kMax",
-                relatedParameter = "kMax", 
-		relatedValue = kMax, 
-		functionName = ".createDesign"
+                relatedParameter = "kMax",
+                relatedValue = kMax,
+                functionName = ".createDesign"
             )
         }
         kMax <- length(userAlphaSpending)
@@ -371,13 +372,13 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
             delayedInformation = delayedInformation
         )
     } else {
-        stopIllegalArgument("'designClass' (", .pQuote(designClass), ") must be ", 
-            .vQuote(C_CLASS_NAME_TRIAL_DESIGN_INVERSE_NORMAL), " or ", 
-            .vQuote(C_CLASS_NAME_TRIAL_DESIGN_GROUP_SEQUENTIAL), 
-            functionName = ".createDesign", 
-		parameter ="designClass",
-            value = designClass, 
-		relatedParameter =") must be "
+        stopIllegalArgument("'designClass' (", .pQuote(designClass), ") must be ",
+            .vQuote(C_CLASS_NAME_TRIAL_DESIGN_INVERSE_NORMAL), " or ",
+            .vQuote(C_CLASS_NAME_TRIAL_DESIGN_GROUP_SEQUENTIAL),
+            functionName = ".createDesign",
+            parameter = "designClass",
+            value = designClass,
+            relatedParameter = ") must be "
         )
     }
 
@@ -724,8 +725,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 .getDesignGroupSequentialWangAndTsiatisOptimum <- function(design) {
     .assertDesignParameterExists(design, "optimizationCriterion",
         C_OPTIMIZATION_CRITERION_DEFAULT,
-        relatedParameter = "typeOfDesign", 
-		relatedValue = design$typeOfDesign
+        relatedParameter = "typeOfDesign",
+        relatedValue = design$typeOfDesign
     )
     .assertIsOptimizationCriterion(design$optimizationCriterion)
 
@@ -893,11 +894,11 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 .getDesignGroupSequentialUserDefinedBetaSpending <- function(design) {
     if (design$typeBetaSpending != C_TYPE_OF_DESIGN_BS_USER) {
         stopIllegalArgument("'typeBetaSpending' (", .vQuote(design$typeBetaSpending), ") ",
-            "must be ", .vQuote(C_TYPE_OF_DESIGN_BS_USER), 
-            functionName = ".getDesignGroupSequentialUserDefinedBetaSpending", 
-		parameter ="typeBetaSpending",
-            value = design$typeBetaSpending, 
-		relatedParameter =") must be "
+            "must be ", .vQuote(C_TYPE_OF_DESIGN_BS_USER),
+            functionName = ".getDesignGroupSequentialUserDefinedBetaSpending",
+            parameter = "typeBetaSpending",
+            value = design$typeBetaSpending,
+            relatedParameter = ") must be "
         )
     }
 
@@ -1389,8 +1390,8 @@ getDesignInverseNormal <- function(
         stopRuntimeIssue(".getDesignGroupSequentialDefaultValues() does return the arguments ", .arrayToString(missingArgNames,
             encapsulate = TRUE
         ),
-        functionName = ".assertAllArgumentsHaveDefaultValues", 
-		parameter ="missingArgNames",
+        functionName = ".assertAllArgumentsHaveDefaultValues",
+        parameter = "missingArgNames",
         value = missingArgNames
         )
     }
@@ -1461,17 +1462,17 @@ getDesignInverseNormal <- function(
     if (!(typeOfDesign %in% validTypesOfDesign)) {
         stopConflictingArguments("'typeOfDesign' (", dQuote(typeOfDesign), ") must be one of the following ",
             "when 'efficacyStops' or 'futilityStops' are specified: ", .arrayToString(validTypesOfDesign, encapsulate = TRUE),
-            functionName = ".getDesignWithInterimStops", 
-		parameter ="typeOfDesign", 
-		relatedParameter ="efficacyStops",
+            functionName = ".getDesignWithInterimStops",
+            parameter = "typeOfDesign",
+            relatedParameter = "efficacyStops",
             value = typeOfDesign
         )
     }
     if (identical(typeBetaSpending, C_TYPE_OF_DESIGN_BS_USER)) {
         stopConflictingArguments("'typeBetaSpending' cannot be ", dQuote(C_TYPE_OF_DESIGN_BS_USER), " ", "when 'efficacyStops' or 'futilityStops' are specified",
-            functionName = ".getDesignWithInterimStops", 
-		parameter ="typeBetaSpending", 
-		relatedParameter =C_TYPE_OF_DESIGN_BS_USER,
+            functionName = ".getDesignWithInterimStops",
+            parameter = "typeBetaSpending",
+            relatedParameter = C_TYPE_OF_DESIGN_BS_USER,
             value = typeBetaSpending
         )
     }
@@ -1506,8 +1507,8 @@ getDesignInverseNormal <- function(
     if (length(efficacyStops) != kMax - 1) {
         stopIllegalArgument("'efficacyStops' (", .arrayToString(efficacyStops, vectorLookAndFeelEnabled = FALSE),
             ") must have length kMax - 1 (", kMax - 1, ")",
-            functionName = ".getDesignWithInterimStops", 
-		parameter ="efficacyStops",
+            functionName = ".getDesignWithInterimStops",
+            parameter = "efficacyStops",
             value = efficacyStops
         )
     }
@@ -1519,8 +1520,8 @@ getDesignInverseNormal <- function(
     if (betaSpendingEnabled && length(futilityStops) != kMax - 1) {
         stopIllegalArgument("'futilityStops' (", .arrayToString(futilityStops, vectorLookAndFeelEnabled = FALSE),
             ") must have length kMax - 1 (", kMax - 1, ")",
-            functionName = ".getDesignWithInterimStops", 
-		parameter ="futilityStops",
+            functionName = ".getDesignWithInterimStops",
+            parameter = "futilityStops",
             value = futilityStops
         )
     }
@@ -1830,8 +1831,9 @@ getDesignInverseNormal <- function(
         else if (design$typeOfDesign %in% c(C_TYPE_OF_DESIGN_AS_USER, C_TYPE_OF_DESIGN_NO_EARLY_EFFICACY)) {
             .getDesignGroupSequentialUserDefinedAlphaSpending(design, userFunctionCallEnabled)
         } else {
-            stopRuntimeIssue("no calculation routine defined for ", design$typeOfDesign, 
-		functionName = ".getDesignGroupSequential")
+            stopRuntimeIssue("no calculation routine defined for ", design$typeOfDesign,
+                functionName = ".getDesignGroupSequential"
+            )
         }
     }
 
@@ -1851,8 +1853,8 @@ getDesignInverseNormal <- function(
         } else if (userFunctionCallEnabled &&
                 any(.getFutilityBounds(design) > .getCriticalValues(design, 1:(design$kMax - 1)) - 0.01, na.rm = TRUE)) {
             stopIllegalArgument("'futilityBounds' (", .arrayToString(design$futilityBounds), ") ", "too extreme for this situation",
-                functionName = ".getDesignGroupSequential", 
-		parameter ="futilityBounds", value = design$futilityBounds
+                functionName = ".getDesignGroupSequential",
+                parameter = "futilityBounds", value = design$futilityBounds
             )
         }
     }
@@ -1936,8 +1938,8 @@ getDesignInverseNormal <- function(
     if (length(delayedInformation) != kMax - 1) {
         stopIllegalArgument("'delayedInformation' (", .arrayToString(delayedInformation), ") must have length ",
             (kMax - 1), " (kMax - 1)",
-            functionName = ".getDesignGroupSequential", 
-		parameter ="delayedInformation",
+            functionName = ".getDesignGroupSequential",
+            parameter = "delayedInformation",
             value = delayedInformation
         )
     }
@@ -1962,9 +1964,9 @@ getDesignInverseNormal <- function(
             " too large (>= 1). Recruitment stop analysis information + pipeline data ", "information cannot exceed overall trial information. Instead, the ",
             "recruitment stop analysis would be skipped, directly proceeding to the ", "final analysis",
             functionName = ".getDesignGroupSequential",
-            parameter = "delayedInformation", value = delayedInformation, 
-		relatedParameter ="informationRates", 
-		relatedValue = informationRates
+            parameter = "delayedInformation", value = delayedInformation,
+            relatedParameter = "informationRates",
+            relatedValue = informationRates
         )
     }
 
@@ -2106,8 +2108,9 @@ getDesignInverseNormal <- function(
     }
 
     if (iteration < 0) {
-        stopRuntimeIssue("critical values cannot be calculated", 
-		functionName = ".assertIsValidBetaSpent")
+        stopRuntimeIssue("critical values cannot be calculated",
+            functionName = ".assertIsValidBetaSpent"
+        )
     }
 
     if (is.na(design$betaSpent[design$kMax]) || abs(design$betaSpent[design$kMax] - design$beta) > 1e-05) {
@@ -2726,8 +2729,9 @@ getDesignCharacteristics <- function(design = NULL, ...) {
 
     if (is.na(designCharacteristics$inflationFactor) ||
             designCharacteristics$inflationFactor > 4 || designCharacteristics$inflationFactor < 1 - 1e-05) {
-        stopRuntimeIssue("inflation factor cannot be calculated", 
-		functionName = ".getDesignCharacteristics")
+        stopRuntimeIssue("inflation factor cannot be calculated",
+            functionName = ".getDesignCharacteristics"
+        )
     }
 
     return(designCharacteristics)
@@ -2861,8 +2865,8 @@ getSimulatedRejectionsDelayedResponse <- function(design, ..., delta = 0, iterat
     if (!design$.isDelayedResponseDesign()) {
         stopIllegalArgument("'design' must be a delayed ", "response design with specified 'delayedInformation'",
             functionName = "getSimulatedRejectionsDelayedResponse",
-            parameter = "design", 
-		relatedParameter ="delayedInformation", value = design
+            parameter = "design",
+            relatedParameter = "delayedInformation", value = design
         )
     }
     startTime <- Sys.time()

--- a/R/f_design_group_sequential.R
+++ b/R/f_design_group_sequential.R
@@ -109,24 +109,28 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
     if (design$typeOfDesign == C_TYPE_OF_DESIGN_WT) {
         .assertDesignParameterExists(design, "deltaWT", NA_real_,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$deltaWT, "deltaWT", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$deltaWT, "deltaWT", lowerBound = -0.5, upperBound = 1)
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_PT) {
         .assertDesignParameterExists(design, "deltaPT1", NA_real_,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$deltaPT1, "deltaPT1", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$deltaPT1, "deltaPT1", lowerBound = -0.5, upperBound = 1)
         .assertDesignParameterExists(design, "deltaPT0", NA_real_,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$deltaPT0, "deltaPT0", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$deltaPT0, "deltaPT0", lowerBound = -0.5, upperBound = 1)
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_WT_OPTIMUM) {
         .assertDesignParameterExists(design, "optimizationCriterion", C_OPTIMIZATION_CRITERION_DEFAULT,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         if (!.isOptimizationCriterion(design$optimizationCriterion)) {
             stopIllegalArgument("optimization criterion must be one of the following: ", .printOptimizationCriterion(),
@@ -135,13 +139,15 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
         }
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_HP) {
         .assertDesignParameterExists(design, "constantBoundsHP", C_CONST_BOUND_HP_DEFAULT,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$constantBoundsHP, "constantBoundsHP")
         .showParameterOutOfValidatedBoundsMessage(design$constantBoundsHP, "constantBoundsHP", lowerBound = 2)
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_AS_KD) {
         .assertDesignParameterExists(design, "gammaA", NA_real_,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$gammaA, "gammaA", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$gammaA, "gammaA",
@@ -150,7 +156,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
         )
     } else if (design$typeOfDesign == C_TYPE_OF_DESIGN_AS_HSD) {
         .assertDesignParameterExists(design, "gammaA", NA_real_,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
         .assertIsSingleNumber(design$gammaA, "gammaA", naAllowed = FALSE)
         .showParameterOutOfValidatedBoundsMessage(design$gammaA, "gammaA",
@@ -179,12 +186,14 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
     if ((.isBetaSpendingDesignType(design$typeBetaSpending) || !.isAlphaSpendingDesignType(design$typeOfDesign)) &&
             (design$informationRates[length(design$informationRates)] != 1)) {
-        stopIllegalArgument("For specified design, last information rate should be equal 1", functionName = ".validateTypeOfDesign")
+        stopIllegalArgument("For specified design, last information rate should be equal 1", 
+		functionName = ".validateTypeOfDesign")
     }
 
     if (.isAlphaSpendingDesignType(design$typeOfDesign)) {
         .assertDesignParameterExists(design, "typeBetaSpending", C_TYPE_OF_DESIGN_BS_NONE,
-            relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+            relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
         )
 
         if (!.isBetaSpendingDesignType(design$typeBetaSpending, noneIncluded = TRUE)) {
@@ -195,7 +204,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
         if (design$typeBetaSpending == C_TYPE_OF_DESIGN_BS_KD) {
             .assertDesignParameterExists(design, "gammaB", NA_real_,
-                relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+                relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
             )
             .assertIsSingleNumber(design$gammaB, "gammaB", naAllowed = FALSE)
             .showParameterOutOfValidatedBoundsMessage(design$gammaB, "gammaB",
@@ -206,7 +216,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 
         if (design$typeBetaSpending == C_TYPE_OF_DESIGN_BS_HSD) {
             .assertDesignParameterExists(design, "gammaB", NA_real_,
-                relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+                relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
             )
             .assertIsSingleNumber(design$gammaB, "gammaB", naAllowed = FALSE)
             .showParameterOutOfValidatedBoundsMessage(design$gammaB, "gammaB",
@@ -328,7 +339,9 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
                     kMax
                 ),
                 parameter = "userAlphaSpending", value = length(userAlphaSpending), constraint = "length must equal kMax",
-                relatedParameter = "kMax", relatedValue = kMax, functionName = ".createDesign"
+                relatedParameter = "kMax", 
+		relatedValue = kMax, 
+		functionName = ".createDesign"
             )
         }
         kMax <- length(userAlphaSpending)
@@ -358,10 +371,13 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
             delayedInformation = delayedInformation
         )
     } else {
-        stopIllegalArgument("'designClass' ('", designClass, "') must be '", C_CLASS_NAME_TRIAL_DESIGN_INVERSE_NORMAL,
-            "' or ", "'", C_CLASS_NAME_TRIAL_DESIGN_GROUP_SEQUENTIAL, "'",
-            functionName = ".createDesign", parameter = "designClass",
-            value = designClass, relatedParameter = ") must be "
+        stopIllegalArgument("'designClass' (", .pQuote(designClass), ") must be ", 
+            .vQuote(C_CLASS_NAME_TRIAL_DESIGN_INVERSE_NORMAL), " or ", 
+            .vQuote(C_CLASS_NAME_TRIAL_DESIGN_GROUP_SEQUENTIAL), 
+            functionName = ".createDesign", 
+		parameter ="designClass",
+            value = designClass, 
+		relatedParameter =") must be "
         )
     }
 
@@ -708,7 +724,8 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 .getDesignGroupSequentialWangAndTsiatisOptimum <- function(design) {
     .assertDesignParameterExists(design, "optimizationCriterion",
         C_OPTIMIZATION_CRITERION_DEFAULT,
-        relatedParameter = "typeOfDesign", relatedValue = design$typeOfDesign
+        relatedParameter = "typeOfDesign", 
+		relatedValue = design$typeOfDesign
     )
     .assertIsOptimizationCriterion(design$optimizationCriterion)
 
@@ -875,10 +892,12 @@ getGroupSequentialProbabilities <- function(decisionMatrix, informationRates) {
 #'
 .getDesignGroupSequentialUserDefinedBetaSpending <- function(design) {
     if (design$typeBetaSpending != C_TYPE_OF_DESIGN_BS_USER) {
-        stopIllegalArgument("'typeBetaSpending' ('", design$typeBetaSpending, "') must be '", C_TYPE_OF_DESIGN_BS_USER,
-            "'",
-            functionName = ".getDesignGroupSequentialUserDefinedBetaSpending", parameter = "typeBetaSpending",
-            value = design$typeBetaSpending, relatedParameter = ") must be "
+        stopIllegalArgument("'typeBetaSpending' (", .vQuote(design$typeBetaSpending), ") ",
+            "must be ", .vQuote(C_TYPE_OF_DESIGN_BS_USER), 
+            functionName = ".getDesignGroupSequentialUserDefinedBetaSpending", 
+		parameter ="typeBetaSpending",
+            value = design$typeBetaSpending, 
+		relatedParameter =") must be "
         )
     }
 
@@ -1370,7 +1389,8 @@ getDesignInverseNormal <- function(
         stopRuntimeIssue(".getDesignGroupSequentialDefaultValues() does return the arguments ", .arrayToString(missingArgNames,
             encapsulate = TRUE
         ),
-        functionName = ".assertAllArgumentsHaveDefaultValues", parameter = "missingArgNames",
+        functionName = ".assertAllArgumentsHaveDefaultValues", 
+		parameter ="missingArgNames",
         value = missingArgNames
         )
     }
@@ -1441,13 +1461,17 @@ getDesignInverseNormal <- function(
     if (!(typeOfDesign %in% validTypesOfDesign)) {
         stopConflictingArguments("'typeOfDesign' (", dQuote(typeOfDesign), ") must be one of the following ",
             "when 'efficacyStops' or 'futilityStops' are specified: ", .arrayToString(validTypesOfDesign, encapsulate = TRUE),
-            functionName = ".getDesignWithInterimStops", parameter = "typeOfDesign", relatedParameter = "efficacyStops",
+            functionName = ".getDesignWithInterimStops", 
+		parameter ="typeOfDesign", 
+		relatedParameter ="efficacyStops",
             value = typeOfDesign
         )
     }
     if (identical(typeBetaSpending, C_TYPE_OF_DESIGN_BS_USER)) {
         stopConflictingArguments("'typeBetaSpending' cannot be ", dQuote(C_TYPE_OF_DESIGN_BS_USER), " ", "when 'efficacyStops' or 'futilityStops' are specified",
-            functionName = ".getDesignWithInterimStops", parameter = "typeBetaSpending", relatedParameter = C_TYPE_OF_DESIGN_BS_USER,
+            functionName = ".getDesignWithInterimStops", 
+		parameter ="typeBetaSpending", 
+		relatedParameter =C_TYPE_OF_DESIGN_BS_USER,
             value = typeBetaSpending
         )
     }
@@ -1482,7 +1506,8 @@ getDesignInverseNormal <- function(
     if (length(efficacyStops) != kMax - 1) {
         stopIllegalArgument("'efficacyStops' (", .arrayToString(efficacyStops, vectorLookAndFeelEnabled = FALSE),
             ") must have length kMax - 1 (", kMax - 1, ")",
-            functionName = ".getDesignWithInterimStops", parameter = "efficacyStops",
+            functionName = ".getDesignWithInterimStops", 
+		parameter ="efficacyStops",
             value = efficacyStops
         )
     }
@@ -1494,7 +1519,8 @@ getDesignInverseNormal <- function(
     if (betaSpendingEnabled && length(futilityStops) != kMax - 1) {
         stopIllegalArgument("'futilityStops' (", .arrayToString(futilityStops, vectorLookAndFeelEnabled = FALSE),
             ") must have length kMax - 1 (", kMax - 1, ")",
-            functionName = ".getDesignWithInterimStops", parameter = "futilityStops",
+            functionName = ".getDesignWithInterimStops", 
+		parameter ="futilityStops",
             value = futilityStops
         )
     }
@@ -1804,7 +1830,8 @@ getDesignInverseNormal <- function(
         else if (design$typeOfDesign %in% c(C_TYPE_OF_DESIGN_AS_USER, C_TYPE_OF_DESIGN_NO_EARLY_EFFICACY)) {
             .getDesignGroupSequentialUserDefinedAlphaSpending(design, userFunctionCallEnabled)
         } else {
-            stopRuntimeIssue("no calculation routine defined for ", design$typeOfDesign, functionName = ".getDesignGroupSequential")
+            stopRuntimeIssue("no calculation routine defined for ", design$typeOfDesign, 
+		functionName = ".getDesignGroupSequential")
         }
     }
 
@@ -1824,7 +1851,8 @@ getDesignInverseNormal <- function(
         } else if (userFunctionCallEnabled &&
                 any(.getFutilityBounds(design) > .getCriticalValues(design, 1:(design$kMax - 1)) - 0.01, na.rm = TRUE)) {
             stopIllegalArgument("'futilityBounds' (", .arrayToString(design$futilityBounds), ") ", "too extreme for this situation",
-                functionName = ".getDesignGroupSequential", parameter = "futilityBounds", value = design$futilityBounds
+                functionName = ".getDesignGroupSequential", 
+		parameter ="futilityBounds", value = design$futilityBounds
             )
         }
     }
@@ -1908,7 +1936,8 @@ getDesignInverseNormal <- function(
     if (length(delayedInformation) != kMax - 1) {
         stopIllegalArgument("'delayedInformation' (", .arrayToString(delayedInformation), ") must have length ",
             (kMax - 1), " (kMax - 1)",
-            functionName = ".getDesignGroupSequential", parameter = "delayedInformation",
+            functionName = ".getDesignGroupSequential", 
+		parameter ="delayedInformation",
             value = delayedInformation
         )
     }
@@ -1933,7 +1962,9 @@ getDesignInverseNormal <- function(
             " too large (>= 1). Recruitment stop analysis information + pipeline data ", "information cannot exceed overall trial information. Instead, the ",
             "recruitment stop analysis would be skipped, directly proceeding to the ", "final analysis",
             functionName = ".getDesignGroupSequential",
-            parameter = "delayedInformation", value = delayedInformation, relatedParameter = "informationRates", relatedValue = informationRates
+            parameter = "delayedInformation", value = delayedInformation, 
+		relatedParameter ="informationRates", 
+		relatedValue = informationRates
         )
     }
 
@@ -2075,7 +2106,8 @@ getDesignInverseNormal <- function(
     }
 
     if (iteration < 0) {
-        stopRuntimeIssue("critical values cannot be calculated", functionName = ".assertIsValidBetaSpent")
+        stopRuntimeIssue("critical values cannot be calculated", 
+		functionName = ".assertIsValidBetaSpent")
     }
 
     if (is.na(design$betaSpent[design$kMax]) || abs(design$betaSpent[design$kMax] - design$beta) > 1e-05) {
@@ -2694,7 +2726,8 @@ getDesignCharacteristics <- function(design = NULL, ...) {
 
     if (is.na(designCharacteristics$inflationFactor) ||
             designCharacteristics$inflationFactor > 4 || designCharacteristics$inflationFactor < 1 - 1e-05) {
-        stopRuntimeIssue("inflation factor cannot be calculated", functionName = ".getDesignCharacteristics")
+        stopRuntimeIssue("inflation factor cannot be calculated", 
+		functionName = ".getDesignCharacteristics")
     }
 
     return(designCharacteristics)
@@ -2828,7 +2861,8 @@ getSimulatedRejectionsDelayedResponse <- function(design, ..., delta = 0, iterat
     if (!design$.isDelayedResponseDesign()) {
         stopIllegalArgument("'design' must be a delayed ", "response design with specified 'delayedInformation'",
             functionName = "getSimulatedRejectionsDelayedResponse",
-            parameter = "design", relatedParameter = "delayedInformation", value = design
+            parameter = "design", 
+		relatedParameter ="delayedInformation", value = design
         )
     }
     startTime <- Sys.time()

--- a/R/f_design_group_sequential.R
+++ b/R/f_design_group_sequential.R
@@ -1387,12 +1387,14 @@ getDesignInverseNormal <- function(
     argNames <- argNames[argNames != "..."]
     missingArgNames <- argNames[!(argNames %in% names(defaultValues))]
     if (length(missingArgNames) > 0) {
-        stopRuntimeIssue(".getDesignGroupSequentialDefaultValues() does return the arguments ", .arrayToString(missingArgNames,
-            encapsulate = TRUE
-        ),
-        functionName = ".assertAllArgumentsHaveDefaultValues",
-        parameter = "missingArgNames",
-        value = missingArgNames
+        stopRuntimeIssue(
+            ".getDesignGroupSequentialDefaultValues() does return the arguments ",
+            .arrayToString(missingArgNames,
+                encapsulate = TRUE
+            ),
+            functionName = ".assertAllArgumentsHaveDefaultValues",
+            parameter = "missingArgNames",
+            value = missingArgNames
         )
     }
 }
@@ -1460,8 +1462,10 @@ getDesignInverseNormal <- function(
         tolerance = 1e-08) {
     validTypesOfDesign <- c("asOF", "asP", "asKD", "asHSD")
     if (!(typeOfDesign %in% validTypesOfDesign)) {
-        stopConflictingArguments("'typeOfDesign' (", dQuote(typeOfDesign), ") must be one of the following ",
-            "when 'efficacyStops' or 'futilityStops' are specified: ", .arrayToString(validTypesOfDesign, encapsulate = TRUE),
+        stopConflictingArguments(
+            "'typeOfDesign' (", dQuote(typeOfDesign), ") must be one of the following ",
+            "when 'efficacyStops' or 'futilityStops' are specified: ",
+            .arrayToString(validTypesOfDesign, encapsulate = TRUE),
             functionName = ".getDesignWithInterimStops",
             parameter = "typeOfDesign",
             relatedParameter = "efficacyStops",
@@ -1469,7 +1473,8 @@ getDesignInverseNormal <- function(
         )
     }
     if (identical(typeBetaSpending, C_TYPE_OF_DESIGN_BS_USER)) {
-        stopConflictingArguments("'typeBetaSpending' cannot be ", dQuote(C_TYPE_OF_DESIGN_BS_USER), " ", "when 'efficacyStops' or 'futilityStops' are specified",
+        stopConflictingArguments("'typeBetaSpending' cannot be ", dQuote(C_TYPE_OF_DESIGN_BS_USER),
+            " when 'efficacyStops' or 'futilityStops' are specified",
             functionName = ".getDesignWithInterimStops",
             parameter = "typeBetaSpending",
             relatedParameter = C_TYPE_OF_DESIGN_BS_USER,
@@ -1852,7 +1857,9 @@ getDesignInverseNormal <- function(
             design$.setParameterType("futilityBounds", C_PARAM_NOT_APPLICABLE)
         } else if (userFunctionCallEnabled &&
                 any(.getFutilityBounds(design) > .getCriticalValues(design, 1:(design$kMax - 1)) - 0.01, na.rm = TRUE)) {
-            stopIllegalArgument("'futilityBounds' (", .arrayToString(design$futilityBounds), ") ", "too extreme for this situation",
+            stopIllegalArgument(
+                "'futilityBounds' (", .arrayToString(design$futilityBounds), ") ",
+                "too extreme for this situation",
                 functionName = ".getDesignGroupSequential",
                 parameter = "futilityBounds", value = design$futilityBounds
             )
@@ -1913,7 +1920,8 @@ getDesignInverseNormal <- function(
     # proceed with delayed response design
     .assertIsInClosedInterval(delayedInformation, "delayedInformation", lower = 0, upper = NULL)
     if (design$sided != 1) {
-        stopIllegalArgument("decision critical values for delayed response design ", "are only available for one-sided designs",
+        stopIllegalArgument("decision critical values for delayed response design ",
+            "are only available for one-sided designs",
             functionName = ".getDesignGroupSequential"
         )
     }
@@ -1927,7 +1935,8 @@ getDesignInverseNormal <- function(
     reversalProbabilities <- numeric(kMax - 1)
 
     if (all(contRegionLower <= C_FUTILITY_BOUNDS_DEFAULT + 1e-06)) {
-        stopIllegalArgument("decision critical values for delayed response design are ", "only available for designs with valid futility bounds",
+        stopIllegalArgument("decision critical values for delayed response design are ",
+            "only available for designs with valid futility bounds",
             functionName = ".getDesignGroupSequential"
         )
     }
@@ -1936,7 +1945,8 @@ getDesignInverseNormal <- function(
         delayedInformation <- rep(delayedInformation, kMax - 1)
     }
     if (length(delayedInformation) != kMax - 1) {
-        stopIllegalArgument("'delayedInformation' (", .arrayToString(delayedInformation), ") must have length ",
+        stopIllegalArgument(
+            "'delayedInformation' (", .arrayToString(delayedInformation), ") must have length ",
             (kMax - 1), " (kMax - 1)",
             functionName = ".getDesignGroupSequential",
             parameter = "delayedInformation",
@@ -1947,7 +1957,8 @@ getDesignInverseNormal <- function(
     indices <- which(delayedInformation > 0 & delayedInformation < 1e-03)
     n <- length(indices)
     if (n > 0) {
-        warning("The", ifelse(n == 1, "", paste0(" ", n)), " delayed information value", ifelse(n == 1, "", "s"), " ",
+        warning("The", ifelse(n == 1, "", paste0(" ", n)),
+            " delayed information value", ifelse(n == 1, "", "s"), " ",
             .arrayToString(delayedInformation[indices], mode = "and"),
             " will be replaced by 1e-03 to achieve reasonable results",
             call. = FALSE
@@ -1960,11 +1971,15 @@ getDesignInverseNormal <- function(
     if (!anyNA(eps) && any(eps >= 1)) {
         stages <- which(eps >= 1)
         stagesInfo <- ifelse(length(stages) == 1, paste0(" ", stages), paste0("s ", .arrayToString(stages, mode = "and")))
-        stopIllegalArgument("'delayedInformation[stage] + informationRates[stage]' for ", "stage", stagesInfo,
-            " too large (>= 1). Recruitment stop analysis information + pipeline data ", "information cannot exceed overall trial information. Instead, the ",
-            "recruitment stop analysis would be skipped, directly proceeding to the ", "final analysis",
+        stopIllegalArgument(
+            "'delayedInformation[stage] + informationRates[stage]' for ",
+            "stage", stagesInfo, " too large (>= 1). Recruitment stop analysis information + pipeline data ",
+            "information cannot exceed overall trial information. Instead, the ",
+            "recruitment stop analysis would be skipped, directly proceeding to the ",
+            "final analysis",
             functionName = ".getDesignGroupSequential",
-            parameter = "delayedInformation", value = delayedInformation,
+            parameter = "delayedInformation",
+            value = delayedInformation,
             relatedParameter = "informationRates",
             relatedValue = informationRates
         )
@@ -2091,7 +2106,9 @@ getDesignInverseNormal <- function(
     }
 
     if (is.na(design$alphaSpent[design$kMax]) || abs(design$alphaSpent[design$kMax] - design$alpha) > 1e-05) {
-        stopRuntimeIssue("critical values cannot be calculated ", "(alpha: ", design$alpha, "; alpha spent at maximum stage: ",
+        stopRuntimeIssue(
+            "critical values cannot be calculated ",
+            "(alpha: ", design$alpha, "; alpha spent at maximum stage: ",
             design$alphaSpent[design$kMax], ")",
             functionName = ".assertIsValidAlphaSpent"
         )
@@ -2114,8 +2131,9 @@ getDesignInverseNormal <- function(
     }
 
     if (is.na(design$betaSpent[design$kMax]) || abs(design$betaSpent[design$kMax] - design$beta) > 1e-05) {
-        stopRuntimeIssue("critical values cannot be calculated ", "(beta spent at maximum stage: ", design$betaSpent[design$kMax],
-            ")",
+        stopRuntimeIssue(
+            "critical values cannot be calculated ",
+            "(beta spent at maximum stage: ", design$betaSpent[design$kMax], ")",
             functionName = ".assertIsValidBetaSpent"
         )
     }
@@ -2369,7 +2387,8 @@ getDesignGroupSequential <- function(
 #'   \item \code{\link[=print.FieldSet]{print()}} to print the object,
 #'   \item \code{\link[=summary.ParameterSet]{summary()}} to display a summary of the object,
 #'   \item \code{\link[=plot.ParameterSet]{plot()}} to plot the object,
-#'   \item \code{\link[=as.data.frame.TrialDesignCharacteristics]{as.data.frame()}} to coerce the object to a \code{\link[base]{data.frame}},
+#'   \item \code{\link[=as.data.frame.TrialDesignCharacteristics]{as.data.frame()}}
+#'         to coerce the object to a \code{\link[base]{data.frame}},
 #'   \item \code{\link[=as.matrix.FieldSet]{as.matrix()}} to coerce the object to a \code{\link[base]{matrix}}.
 #' }
 #' @template how_to_get_help_for_generics
@@ -2863,10 +2882,13 @@ getSimulatedRejectionsDelayedResponse <- function(design, ..., delta = 0, iterat
     .assertIsSingleNumber(delta, "delta")
     .assertIsValidIterationsAndSeed(iterations, seed, zeroIterationsAllowed = FALSE)
     if (!design$.isDelayedResponseDesign()) {
-        stopIllegalArgument("'design' must be a delayed ", "response design with specified 'delayedInformation'",
+        stopIllegalArgument(
+            "'design' must be a delayed ",
+            "response design with specified 'delayedInformation'",
             functionName = "getSimulatedRejectionsDelayedResponse",
             parameter = "design",
-            relatedParameter = "delayedInformation", value = design
+            relatedParameter = "delayedInformation",
+            value = design
         )
     }
     startTime <- Sys.time()

--- a/R/f_design_plan_boundary_data.R
+++ b/R/f_design_plan_boundary_data.R
@@ -729,7 +729,7 @@
         }
     } else {
         stopRuntimeIssue("Cannot determine the direction of the test. ",
-            "The trial design plan type ", sQuote(.getClassName(designPlan)), 
+            "The trial design plan type ", sQuote(.getClassName(designPlan)),
             " is not supported for this operation.",
             functionName = ".getDirectionUpperCalculated"
         )
@@ -766,8 +766,8 @@
         } else {
             stopIllegalArgument("The specified 'directionUpper' (", directionUpperDefined, ") ", "is not consistent with the calculated 'directionUpper' (",
                 .arrayToString(directionUpperCalculated), "). ",
-                functionName = ".setDirectionUpper", 
-		parameter ="directionUpper"
+                functionName = ".setDirectionUpper",
+                parameter = "directionUpper"
             )
         }
     }

--- a/R/f_design_plan_boundary_data.R
+++ b/R/f_design_plan_boundary_data.R
@@ -490,7 +490,8 @@
                         )
 
                         if (is.null(vHat) || length(vHat) == 0 || is.na(vHat) || is.nan(vHat)) {
-                            stopRuntimeIssue("Cannot find theta. ", "The calculated variance estimate is invalid: ", vHat,
+                            stopRuntimeIssue("Cannot find theta. ", 
+                                "The calculated variance estimate is invalid: ", vHat,
                                 functionName = ".getEffectScaleBoundaryCountDataTheta",
                                 parameter = "vHat", value = vHat
                             )
@@ -523,7 +524,8 @@
                     )
 
                     if (is.null(vHat) || length(vHat) == 0 || is.na(vHat) || is.nan(vHat)) {
-                        stopRuntimeIssue("cannot find theta. ", "The calculated variance estimate is invalid: ", vHat,
+                        stopRuntimeIssue("cannot find theta. ", 
+                            "The calculated variance estimate is invalid: ", vHat,
                             functionName = ".getEffectScaleBoundaryCountDataTheta",
                             parameter = "vHat", value = vHat
                         )
@@ -764,7 +766,8 @@
                 call. = FALSE
             )
         } else {
-            stopIllegalArgument("The specified 'directionUpper' (", directionUpperDefined, ") ", "is not consistent with the calculated 'directionUpper' (",
+            stopIllegalArgument("The specified 'directionUpper' (", directionUpperDefined, ") ", 
+                "is not consistent with the calculated 'directionUpper' (",
                 .arrayToString(directionUpperCalculated), "). ",
                 functionName = ".setDirectionUpper",
                 parameter = "directionUpper"

--- a/R/f_design_plan_boundary_data.R
+++ b/R/f_design_plan_boundary_data.R
@@ -766,7 +766,8 @@
         } else {
             stopIllegalArgument("The specified 'directionUpper' (", directionUpperDefined, ") ", "is not consistent with the calculated 'directionUpper' (",
                 .arrayToString(directionUpperCalculated), "). ",
-                functionName = ".setDirectionUpper", parameter = "directionUpper"
+                functionName = ".setDirectionUpper", 
+		parameter ="directionUpper"
             )
         }
     }

--- a/R/f_design_plan_counts.R
+++ b/R/f_design_plan_counts.R
@@ -152,8 +152,10 @@
     if (length(accrualTime) != length(accrualIntensity)) {
         stopRuntimeIssue("length of accrualTime (", length(accrualTime), ") and ", "accrualIntensity (", length(accrualIntensity),
             ") must be identical",
-            functionName = ".generateRecruitmentTimes", parameter = "accrualTime", value = length(accrualTime),
-            relatedParameter = "accrualIntensity", relatedValue = length(accrualIntensity)
+            functionName = ".generateRecruitmentTimes", 
+		parameter ="accrualTime", value = length(accrualTime),
+            relatedParameter = "accrualIntensity", 
+		relatedValue = length(accrualIntensity)
         )
     }
 
@@ -260,7 +262,8 @@
             (1 / fixedExposureTime * (1 / lambda2 + 1 / (lambda1 * allocation)) + overdispersion * (1 + 1 / allocation))
     } else {
         if (is.na(followUpTime)) {
-            stopRuntimeIssue("Cannot calculated variance estimate because follow-up time is NA", functionName = ".getVarianceEstimate")
+            stopRuntimeIssue("Cannot calculated variance estimate because follow-up time is NA", 
+		functionName = ".getVarianceEstimate")
         }
         timeUnderObservation1 <-
             pmax(accrualTime[length(accrualTime)] + followUpTime - recruit1, 0)

--- a/R/f_design_plan_counts.R
+++ b/R/f_design_plan_counts.R
@@ -150,10 +150,11 @@
     accrualIntensity <- .assertIsNumericVector(accrualIntensity, "accrualIntensity")
 
     if (length(accrualTime) != length(accrualIntensity)) {
-        stopRuntimeIssue("length of accrualTime (", length(accrualTime), ") and ", "accrualIntensity (", length(accrualIntensity),
-            ") must be identical",
+        stopRuntimeIssue("length of accrualTime (", length(accrualTime), ") and ", 
+            "accrualIntensity (", length(accrualIntensity), ") must be identical",
             functionName = ".generateRecruitmentTimes",
-            parameter = "accrualTime", value = length(accrualTime),
+            parameter = "accrualTime", 
+            value = length(accrualTime),
             relatedParameter = "accrualIntensity",
             relatedValue = length(accrualIntensity)
         )

--- a/R/f_design_plan_counts.R
+++ b/R/f_design_plan_counts.R
@@ -152,10 +152,10 @@
     if (length(accrualTime) != length(accrualIntensity)) {
         stopRuntimeIssue("length of accrualTime (", length(accrualTime), ") and ", "accrualIntensity (", length(accrualIntensity),
             ") must be identical",
-            functionName = ".generateRecruitmentTimes", 
-		parameter ="accrualTime", value = length(accrualTime),
-            relatedParameter = "accrualIntensity", 
-		relatedValue = length(accrualIntensity)
+            functionName = ".generateRecruitmentTimes",
+            parameter = "accrualTime", value = length(accrualTime),
+            relatedParameter = "accrualIntensity",
+            relatedValue = length(accrualIntensity)
         )
     }
 
@@ -262,8 +262,9 @@
             (1 / fixedExposureTime * (1 / lambda2 + 1 / (lambda1 * allocation)) + overdispersion * (1 + 1 / allocation))
     } else {
         if (is.na(followUpTime)) {
-            stopRuntimeIssue("Cannot calculated variance estimate because follow-up time is NA", 
-		functionName = ".getVarianceEstimate")
+            stopRuntimeIssue("Cannot calculated variance estimate because follow-up time is NA",
+                functionName = ".getVarianceEstimate"
+            )
         }
         timeUnderObservation1 <-
             pmax(accrualTime[length(accrualTime)] + followUpTime - recruit1, 0)

--- a/R/f_design_plan_means.R
+++ b/R/f_design_plan_means.R
@@ -445,12 +445,12 @@ NULL
             )
             if (design$sided == 1 && any(effect <= 0)) {
                 stopIllegalArgument(
-                    "any 'alternative' (", .arrayToString(alternative), ") must be ", 
+                    "any 'alternative' (", .arrayToString(alternative), ") must be ",
                     ifelse(isFALSE(directionUpper), "<", ">"), " 'thetaH0' (", thetaH0, ")",
-                    functionName = ".createDesignPlanMeans", 
+                    functionName = ".createDesignPlanMeans",
                     parameter = "alternative",
-                    value = alternative, 
-                    relatedParameter = "thetaH0", 
+                    value = alternative,
+                    relatedParameter = "thetaH0",
                     relatedValue = thetaH0
                 )
             }
@@ -459,9 +459,9 @@ NULL
         if (any(alternative - thetaH0 == 0)) {
             stopIllegalArgument("any 'alternative' (", .arrayToString(alternative), ") ",
                 "must be != 'thetaH0' (", thetaH0, ")",
-                functionName = ".createDesignPlanMeans", 
-                parameter = "alternative", 
-                value = alternative, 
+                functionName = ".createDesignPlanMeans",
+                parameter = "alternative",
+                value = alternative,
                 relatedParameter = "thetaH0",
                 relatedValue = thetaH0
             )
@@ -485,7 +485,7 @@ NULL
     if (groups == 2) {
         if (design$sided == 2 && ((thetaH0 != 0 && !meanRatio) ||
                 (thetaH0 != 1 && meanRatio))) {
-            stopIllegalArgument("two-sided case is implemented only for superiority testing ", 
+            stopIllegalArgument("two-sided case is implemented only for superiority testing ",
                 "(i.e., thetaH0 = ", ifelse(meanRatio, 1, 0), ")",
                 functionName = ".createDesignPlanMeans"
             )
@@ -508,11 +508,11 @@ NULL
         )
 
         if (meanRatio && thetaH0 <= 0) {
-            stopIllegalArgument("null hypothesis mean ratio is not allowed be negative or zero, ", 
+            stopIllegalArgument("null hypothesis mean ratio is not allowed be negative or zero, ",
                 "i.e., 'thetaH0' must be > 0 if 'meanRatio' = TRUE",
-                functionName = ".createDesignPlanMeans", 
-                parameter = "thetaH0", 
-                relatedParameter = "meanRatio", 
+                functionName = ".createDesignPlanMeans",
+                parameter = "thetaH0",
+                relatedParameter = "meanRatio",
                 value = thetaH0
             )
         }
@@ -536,8 +536,10 @@ NULL
         )
     }
     .setValueAndParameterType(designPlan, "stDev", stDev, C_STDEV_DEFAULT)
-    .setValueAndParameterType(designPlan, "directionUpper", 
-        directionUpper, C_DIRECTION_UPPER_DEFAULT)
+    .setValueAndParameterType(
+        designPlan, "directionUpper",
+        directionUpper, C_DIRECTION_UPPER_DEFAULT
+    )
     if (objectType == "power") {
         .assertIsValidMaxNumberOfSubjects(maxNumberOfSubjects)
         .setValueAndParameterType(

--- a/R/f_design_plan_plot.R
+++ b/R/f_design_plan_plot.R
@@ -132,21 +132,24 @@
         if (is.null(designPlan$alternative) || anyNA(designPlan$alternative) ||
                 length(designPlan$alternative) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'alternative' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForPlotting", parameter = "alternative"
+                functionName = ".assertIsValidVariedParameterVectorForPlotting", 
+		parameter ="alternative"
             )
         }
     } else if (.isTrialDesignPlanRates(designPlan)) {
         if (is.null(designPlan$pi1) || anyNA(designPlan$pi1) ||
                 length(designPlan$pi1) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'pi1' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForPlotting", parameter = "pi1"
+                functionName = ".assertIsValidVariedParameterVectorForPlotting", 
+		parameter ="pi1"
             )
         }
     } else if (.isTrialDesignPlanSurvival(designPlan)) {
         if (is.null(designPlan$hazardRatio) || anyNA(designPlan$hazardRatio) ||
                 length(designPlan$hazardRatio) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'hazardRatio' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForPlotting", parameter = "hazardRatio"
+                functionName = ".assertIsValidVariedParameterVectorForPlotting", 
+		parameter ="hazardRatio"
             )
         }
     }
@@ -727,7 +730,10 @@
             } else {
                 stopRuntimeIssue("Plot type 5 is not implemented for class ", sQuote(.getClassName(designPlan)),
                     parameter = "type",
-                    value = 5L, relatedParameter = "designPlan", relatedValue = .getClassName(designPlan), functionName = ".plotTrialDesignPlan"
+                    value = 5L, 
+		relatedParameter ="designPlan", 
+		relatedValue = .getClassName(designPlan), 
+		functionName = ".plotTrialDesignPlan"
                 )
             }
 
@@ -1190,21 +1196,29 @@
 
     type <- type[1]
     if (!(type %in% c(13, 14))) {
-        stopIllegalArgument("'type' must be 13 or 14", functionName = ".plotSurvivalFunction", parameter = "type", value = type)
+        stopIllegalArgument("'type' must be 13 or 14", 
+		functionName = ".plotSurvivalFunction", 
+		parameter ="type", value = type)
     }
 
     lambda1 <- designPlan[["lambda1"]]
     lambda2 <- designPlan[["lambda2"]]
     if (is.null(lambda2) || length(lambda2) == 0) {
-        stopMissingArgument("'lambda2' must be specified", functionName = ".plotSurvivalFunction", parameter = "lambda2")
+        stopMissingArgument("'lambda2' must be specified", 
+		functionName = ".plotSurvivalFunction", 
+		parameter ="lambda2")
     }
 
     if (is.null(designPlan$kappa) || length(designPlan$kappa) == 0) {
-        stopMissingArgument("'kappa' must be specified", functionName = ".plotSurvivalFunction", parameter = "kappa")
+        stopMissingArgument("'kappa' must be specified", 
+		functionName = ".plotSurvivalFunction", 
+		parameter ="kappa")
     }
 
     if (is.null(designPlan$hazardRatio) || length(designPlan$hazardRatio) == 0) {
-        stopMissingArgument("'hazardRatio' must be specified", functionName = ".plotSurvivalFunction", parameter = "hazardRatio")
+        stopMissingArgument("'hazardRatio' must be specified", 
+		functionName = ".plotSurvivalFunction", 
+		parameter ="hazardRatio")
     }
 
     piecewiseSurvivalEnabled <- designPlan$.piecewiseSurvivalTime$piecewiseSurvivalEnabled

--- a/R/f_design_plan_plot.R
+++ b/R/f_design_plan_plot.R
@@ -132,24 +132,24 @@
         if (is.null(designPlan$alternative) || anyNA(designPlan$alternative) ||
                 length(designPlan$alternative) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'alternative' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForPlotting", 
-		parameter ="alternative"
+                functionName = ".assertIsValidVariedParameterVectorForPlotting",
+                parameter = "alternative"
             )
         }
     } else if (.isTrialDesignPlanRates(designPlan)) {
         if (is.null(designPlan$pi1) || anyNA(designPlan$pi1) ||
                 length(designPlan$pi1) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'pi1' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForPlotting", 
-		parameter ="pi1"
+                functionName = ".assertIsValidVariedParameterVectorForPlotting",
+                parameter = "pi1"
             )
         }
     } else if (.isTrialDesignPlanSurvival(designPlan)) {
         if (is.null(designPlan$hazardRatio) || anyNA(designPlan$hazardRatio) ||
                 length(designPlan$hazardRatio) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'hazardRatio' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForPlotting", 
-		parameter ="hazardRatio"
+                functionName = ".assertIsValidVariedParameterVectorForPlotting",
+                parameter = "hazardRatio"
             )
         }
     }
@@ -730,10 +730,10 @@
             } else {
                 stopRuntimeIssue("Plot type 5 is not implemented for class ", sQuote(.getClassName(designPlan)),
                     parameter = "type",
-                    value = 5L, 
-		relatedParameter ="designPlan", 
-		relatedValue = .getClassName(designPlan), 
-		functionName = ".plotTrialDesignPlan"
+                    value = 5L,
+                    relatedParameter = "designPlan",
+                    relatedValue = .getClassName(designPlan),
+                    functionName = ".plotTrialDesignPlan"
                 )
             }
 
@@ -1196,29 +1196,33 @@
 
     type <- type[1]
     if (!(type %in% c(13, 14))) {
-        stopIllegalArgument("'type' must be 13 or 14", 
-		functionName = ".plotSurvivalFunction", 
-		parameter ="type", value = type)
+        stopIllegalArgument("'type' must be 13 or 14",
+            functionName = ".plotSurvivalFunction",
+            parameter = "type", value = type
+        )
     }
 
     lambda1 <- designPlan[["lambda1"]]
     lambda2 <- designPlan[["lambda2"]]
     if (is.null(lambda2) || length(lambda2) == 0) {
-        stopMissingArgument("'lambda2' must be specified", 
-		functionName = ".plotSurvivalFunction", 
-		parameter ="lambda2")
+        stopMissingArgument("'lambda2' must be specified",
+            functionName = ".plotSurvivalFunction",
+            parameter = "lambda2"
+        )
     }
 
     if (is.null(designPlan$kappa) || length(designPlan$kappa) == 0) {
-        stopMissingArgument("'kappa' must be specified", 
-		functionName = ".plotSurvivalFunction", 
-		parameter ="kappa")
+        stopMissingArgument("'kappa' must be specified",
+            functionName = ".plotSurvivalFunction",
+            parameter = "kappa"
+        )
     }
 
     if (is.null(designPlan$hazardRatio) || length(designPlan$hazardRatio) == 0) {
-        stopMissingArgument("'hazardRatio' must be specified", 
-		functionName = ".plotSurvivalFunction", 
-		parameter ="hazardRatio")
+        stopMissingArgument("'hazardRatio' must be specified",
+            functionName = ".plotSurvivalFunction",
+            parameter = "hazardRatio"
+        )
     }
 
     piecewiseSurvivalEnabled <- designPlan$.piecewiseSurvivalTime$piecewiseSurvivalEnabled

--- a/R/f_design_plan_rates.R
+++ b/R/f_design_plan_rates.R
@@ -382,7 +382,9 @@ NULL
         if (!anyNA(pi1) && any(pi1 == thetaH0) && (objectType == "sampleSize")) {
             stopIllegalArgument("any 'pi1' (", .arrayToString(pi1), ") must be != 'thetaH0' (", thetaH0, ")",
                 functionName = ".createDesignPlanRates",
-                parameter = "pi1", value = pi1, relatedParameter = "thetaH0", relatedValue = thetaH0
+                parameter = "pi1", value = pi1, 
+		relatedParameter ="thetaH0", 
+		relatedValue = thetaH0
             )
         }
 
@@ -401,7 +403,8 @@ NULL
         }
 
         if (!normalApproximation && design$sided == 2 && (objectType == "sampleSize")) {
-            stopIllegalArgument("exact sample size calculation not available for two-sided testing", functionName = ".createDesignPlanRates")
+            stopIllegalArgument("exact sample size calculation not available for two-sided testing", 
+		functionName = ".createDesignPlanRates")
         }
 
         if (normalApproximation && !conservative && (objectType == "sampleSize")) {
@@ -419,7 +422,9 @@ NULL
             ) {
             stopIllegalArgument("any 'pi1 - pi2' (", .arrayToString(pi1 - pi2), ") ", "must be != 'thetaH0' (", thetaH0,
                 ")",
-                functionName = ".createDesignPlanRates", parameter = "pi1 - pi2", value = pi1 - pi2, relatedParameter = "thetaH0",
+                functionName = ".createDesignPlanRates", 
+		parameter ="pi1 - pi2", value = pi1 - pi2, 
+		relatedParameter ="thetaH0",
                 relatedValue = thetaH0
             )
         }
@@ -432,20 +437,24 @@ NULL
             ) {
             stopIllegalArgument("any 'pi1 / pi2' (", .arrayToString(pi1 / pi2), ") ", "must be != 'thetaH0' (", thetaH0,
                 ")",
-                functionName = ".createDesignPlanRates", parameter = "pi1 / pi2", value = pi1 / pi2,
-                relatedParameter = "thetaH0", relatedValue = thetaH0
+                functionName = ".createDesignPlanRates", 
+		parameter ="pi1 / pi2", value = pi1 / pi2,
+                relatedParameter = "thetaH0", 
+		relatedValue = thetaH0
             )
         }
 
         if (anyNA(pi1) || any(pi1 <= 0) || any(pi1 >= 1)) {
             stopArgumentOutOfBounds("probability 'pi1' (", .arrayToString(pi1), ") ", "is out of bounds (0; 1)",
-                functionName = ".createDesignPlanRates", parameter = "pi1", value = pi1
+                functionName = ".createDesignPlanRates", 
+		parameter ="pi1", value = pi1
             )
         }
 
         if (anyNA(pi2) || any(pi2 <= 0) || any(pi2 >= 1)) {
             stopArgumentOutOfBounds("probability 'pi2' (", .arrayToString(pi2), ") ", "is out of bounds (0; 1)",
-                functionName = ".createDesignPlanRates", parameter = "pi2", value = pi2
+                functionName = ".createDesignPlanRates", 
+		parameter ="pi2", value = pi2
             )
         }
 
@@ -454,16 +463,19 @@ NULL
                 ((thetaH0 != 0 && !riskRatio) ||
                     (thetaH0 != 1 && riskRatio))
             ) {
-            stopIllegalArgument("two-sided case ", "is implemented only for superiority testing", functionName = ".createDesignPlanRates")
+            stopIllegalArgument("two-sided case ", "is implemented only for superiority testing", 
+		functionName = ".createDesignPlanRates")
         }
 
         if (!normalApproximation) {
-            stopIllegalArgument("only normal approximation case is implemented for two groups", functionName = ".createDesignPlanRates")
+            stopIllegalArgument("only normal approximation case is implemented for two groups", 
+		functionName = ".createDesignPlanRates")
         }
 
         if (!conservative) {
             stopIllegalArgument("'conservative' (", conservative, ") has no effect on sample size calculation for two groups",
-                functionName = ".createDesignPlanRates", parameter = "conservative", value = conservative
+                functionName = ".createDesignPlanRates", 
+		parameter ="conservative", value = conservative
             )
         }
 
@@ -480,7 +492,9 @@ NULL
 
         if (riskRatio && thetaH0 <= 0) {
             stopIllegalArgument("null hypothesis risk ratio is not allowed be negative or zero, ", "i.e., 'thetaH0' must be > 0 if 'riskRatio' = TRUE",
-                functionName = ".createDesignPlanRates", parameter = "thetaH0", relatedParameter = "riskRatio", value = thetaH0
+                functionName = ".createDesignPlanRates", 
+		parameter ="thetaH0", 
+		relatedParameter ="riskRatio", value = thetaH0
             )
         }
     }
@@ -654,7 +668,8 @@ getPowerRates <- function(
     )
 
     if (!is.na(allocationRatioPlanned) && allocationRatioPlanned <= 0) {
-        stopIllegalArgument("allocation ratio must be > 0", functionName = "getPowerRates")
+        stopIllegalArgument("allocation ratio must be > 0", 
+		functionName = "getPowerRates")
     }
 
     allocationRatioPlanned <- designPlan$allocationRatioPlanned

--- a/R/f_design_plan_rates.R
+++ b/R/f_design_plan_rates.R
@@ -382,9 +382,9 @@ NULL
         if (!anyNA(pi1) && any(pi1 == thetaH0) && (objectType == "sampleSize")) {
             stopIllegalArgument("any 'pi1' (", .arrayToString(pi1), ") must be != 'thetaH0' (", thetaH0, ")",
                 functionName = ".createDesignPlanRates",
-                parameter = "pi1", value = pi1, 
-		relatedParameter ="thetaH0", 
-		relatedValue = thetaH0
+                parameter = "pi1", value = pi1,
+                relatedParameter = "thetaH0",
+                relatedValue = thetaH0
             )
         }
 
@@ -403,8 +403,9 @@ NULL
         }
 
         if (!normalApproximation && design$sided == 2 && (objectType == "sampleSize")) {
-            stopIllegalArgument("exact sample size calculation not available for two-sided testing", 
-		functionName = ".createDesignPlanRates")
+            stopIllegalArgument("exact sample size calculation not available for two-sided testing",
+                functionName = ".createDesignPlanRates"
+            )
         }
 
         if (normalApproximation && !conservative && (objectType == "sampleSize")) {
@@ -422,9 +423,9 @@ NULL
             ) {
             stopIllegalArgument("any 'pi1 - pi2' (", .arrayToString(pi1 - pi2), ") ", "must be != 'thetaH0' (", thetaH0,
                 ")",
-                functionName = ".createDesignPlanRates", 
-		parameter ="pi1 - pi2", value = pi1 - pi2, 
-		relatedParameter ="thetaH0",
+                functionName = ".createDesignPlanRates",
+                parameter = "pi1 - pi2", value = pi1 - pi2,
+                relatedParameter = "thetaH0",
                 relatedValue = thetaH0
             )
         }
@@ -437,24 +438,24 @@ NULL
             ) {
             stopIllegalArgument("any 'pi1 / pi2' (", .arrayToString(pi1 / pi2), ") ", "must be != 'thetaH0' (", thetaH0,
                 ")",
-                functionName = ".createDesignPlanRates", 
-		parameter ="pi1 / pi2", value = pi1 / pi2,
-                relatedParameter = "thetaH0", 
-		relatedValue = thetaH0
+                functionName = ".createDesignPlanRates",
+                parameter = "pi1 / pi2", value = pi1 / pi2,
+                relatedParameter = "thetaH0",
+                relatedValue = thetaH0
             )
         }
 
         if (anyNA(pi1) || any(pi1 <= 0) || any(pi1 >= 1)) {
             stopArgumentOutOfBounds("probability 'pi1' (", .arrayToString(pi1), ") ", "is out of bounds (0; 1)",
-                functionName = ".createDesignPlanRates", 
-		parameter ="pi1", value = pi1
+                functionName = ".createDesignPlanRates",
+                parameter = "pi1", value = pi1
             )
         }
 
         if (anyNA(pi2) || any(pi2 <= 0) || any(pi2 >= 1)) {
             stopArgumentOutOfBounds("probability 'pi2' (", .arrayToString(pi2), ") ", "is out of bounds (0; 1)",
-                functionName = ".createDesignPlanRates", 
-		parameter ="pi2", value = pi2
+                functionName = ".createDesignPlanRates",
+                parameter = "pi2", value = pi2
             )
         }
 
@@ -463,19 +464,21 @@ NULL
                 ((thetaH0 != 0 && !riskRatio) ||
                     (thetaH0 != 1 && riskRatio))
             ) {
-            stopIllegalArgument("two-sided case ", "is implemented only for superiority testing", 
-		functionName = ".createDesignPlanRates")
+            stopIllegalArgument("two-sided case ", "is implemented only for superiority testing",
+                functionName = ".createDesignPlanRates"
+            )
         }
 
         if (!normalApproximation) {
-            stopIllegalArgument("only normal approximation case is implemented for two groups", 
-		functionName = ".createDesignPlanRates")
+            stopIllegalArgument("only normal approximation case is implemented for two groups",
+                functionName = ".createDesignPlanRates"
+            )
         }
 
         if (!conservative) {
             stopIllegalArgument("'conservative' (", conservative, ") has no effect on sample size calculation for two groups",
-                functionName = ".createDesignPlanRates", 
-		parameter ="conservative", value = conservative
+                functionName = ".createDesignPlanRates",
+                parameter = "conservative", value = conservative
             )
         }
 
@@ -492,9 +495,9 @@ NULL
 
         if (riskRatio && thetaH0 <= 0) {
             stopIllegalArgument("null hypothesis risk ratio is not allowed be negative or zero, ", "i.e., 'thetaH0' must be > 0 if 'riskRatio' = TRUE",
-                functionName = ".createDesignPlanRates", 
-		parameter ="thetaH0", 
-		relatedParameter ="riskRatio", value = thetaH0
+                functionName = ".createDesignPlanRates",
+                parameter = "thetaH0",
+                relatedParameter = "riskRatio", value = thetaH0
             )
         }
     }
@@ -668,8 +671,9 @@ getPowerRates <- function(
     )
 
     if (!is.na(allocationRatioPlanned) && allocationRatioPlanned <= 0) {
-        stopIllegalArgument("allocation ratio must be > 0", 
-		functionName = "getPowerRates")
+        stopIllegalArgument("allocation ratio must be > 0",
+            functionName = "getPowerRates"
+        )
     }
 
     allocationRatioPlanned <- designPlan$allocationRatioPlanned

--- a/R/f_design_plan_rates.R
+++ b/R/f_design_plan_rates.R
@@ -421,8 +421,8 @@ NULL
                 (objectType == "sampleSize") &&
                 !riskRatio
             ) {
-            stopIllegalArgument("any 'pi1 - pi2' (", .arrayToString(pi1 - pi2), ") ", "must be != 'thetaH0' (", thetaH0,
-                ")",
+            stopIllegalArgument("any 'pi1 - pi2' (", .arrayToString(pi1 - pi2), ") ",
+                "must be != 'thetaH0' (", thetaH0, ")",
                 functionName = ".createDesignPlanRates",
                 parameter = "pi1 - pi2", value = pi1 - pi2,
                 relatedParameter = "thetaH0",
@@ -436,8 +436,8 @@ NULL
                 (objectType == "sampleSize") &&
                 riskRatio
             ) {
-            stopIllegalArgument("any 'pi1 / pi2' (", .arrayToString(pi1 / pi2), ") ", "must be != 'thetaH0' (", thetaH0,
-                ")",
+            stopIllegalArgument("any 'pi1 / pi2' (", .arrayToString(pi1 / pi2), ") ",
+                "must be != 'thetaH0' (", thetaH0, ")",
                 functionName = ".createDesignPlanRates",
                 parameter = "pi1 / pi2", value = pi1 / pi2,
                 relatedParameter = "thetaH0",
@@ -446,14 +446,16 @@ NULL
         }
 
         if (anyNA(pi1) || any(pi1 <= 0) || any(pi1 >= 1)) {
-            stopArgumentOutOfBounds("probability 'pi1' (", .arrayToString(pi1), ") ", "is out of bounds (0; 1)",
+            stopArgumentOutOfBounds("probability 'pi1' (", .arrayToString(pi1), ") ",
+                "is out of bounds (0; 1)",
                 functionName = ".createDesignPlanRates",
                 parameter = "pi1", value = pi1
             )
         }
 
         if (anyNA(pi2) || any(pi2 <= 0) || any(pi2 >= 1)) {
-            stopArgumentOutOfBounds("probability 'pi2' (", .arrayToString(pi2), ") ", "is out of bounds (0; 1)",
+            stopArgumentOutOfBounds("probability 'pi2' (", .arrayToString(pi2), ") ",
+                "is out of bounds (0; 1)",
                 functionName = ".createDesignPlanRates",
                 parameter = "pi2", value = pi2
             )
@@ -464,7 +466,8 @@ NULL
                 ((thetaH0 != 0 && !riskRatio) ||
                     (thetaH0 != 1 && riskRatio))
             ) {
-            stopIllegalArgument("two-sided case ", "is implemented only for superiority testing",
+            stopIllegalArgument("two-sided case ",
+                "is implemented only for superiority testing",
                 functionName = ".createDesignPlanRates"
             )
         }
@@ -476,7 +479,8 @@ NULL
         }
 
         if (!conservative) {
-            stopIllegalArgument("'conservative' (", conservative, ") has no effect on sample size calculation for two groups",
+            stopIllegalArgument("'conservative' (", conservative, ") ",
+                "has no effect on sample size calculation for two groups",
                 functionName = ".createDesignPlanRates",
                 parameter = "conservative", value = conservative
             )
@@ -494,7 +498,8 @@ NULL
         }
 
         if (riskRatio && thetaH0 <= 0) {
-            stopIllegalArgument("null hypothesis risk ratio is not allowed be negative or zero, ", "i.e., 'thetaH0' must be > 0 if 'riskRatio' = TRUE",
+            stopIllegalArgument("null hypothesis risk ratio is not allowed be negative ",
+                "or zero, ", "i.e., 'thetaH0' must be > 0 if 'riskRatio' = TRUE",
                 functionName = ".createDesignPlanRates",
                 parameter = "thetaH0",
                 relatedParameter = "riskRatio", value = thetaH0

--- a/R/f_design_plan_survival.R
+++ b/R/f_design_plan_survival.R
@@ -48,7 +48,8 @@ NULL
 .getEventProbabilityFunction <- function(..., time, piecewiseLambda, piecewiseSurvivalTime, phi, kappa) {
     if (length(piecewiseLambda) == 1) {
         if (kappa != 1 && phi > 0) {
-            stopIllegalArgument("Weibull distribution cannot ", "be used together with specified dropout rate (use simulation instead)",
+            stopIllegalArgument("Weibull distribution cannot ",
+                "be used together with specified dropout rate (use simulation instead)",
                 functionName = ".getEventProbabilityFunction"
             )
         }
@@ -58,7 +59,9 @@ NULL
     }
 
     if (length(piecewiseSurvivalTime) != length(piecewiseLambda)) {
-        stopIllegalArgument("length of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
+        stopIllegalArgument(
+            "length of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime),
+            ") must be equal to length of 'piecewiseLambda' (",
             .arrayToString(piecewiseLambda), ")",
             functionName = ".getEventProbabilityFunction",
             parameter = "piecewiseSurvivalTime",
@@ -471,9 +474,10 @@ NULL
             if (!is.null(paramName)) {
                 paramValue <- designPlan[[paramName]]
                 if (!is.null(paramValue) && length(paramValue) > 1) {
-                    stopIllegalArgument("the definition of relative accrual intensities ", "(all 'accrualIntensity' values < 1) ",
-                        "is only available for a single value ", "(", paramName, " = ", .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE),
-                        ")",
+                    stopIllegalArgument("the definition of relative accrual intensities ",
+                        "(all 'accrualIntensity' values < 1) ",
+                        "is only available for a single value ", "(", paramName, " = ",
+                        .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE), ")",
                         functionName = ".calculateSampleSizeSurvival",
                         parameter = "accrualIntensity"
                     )
@@ -1143,7 +1147,10 @@ NULL
                 if (length(hazardRatio) > 1) {
                     stopIllegalArgument(
                         sprintf(
-                            paste0("'maxNumberOfSubjects' (%s) is smaller than the number ", "of events (%.3f) at index %s (hazard ratio = %.3f)"),
+                            paste0(
+                                "'maxNumberOfSubjects' (%s) is smaller than the number ",
+                                "of events (%.3f) at index %s (hazard ratio = %.3f)"
+                            ),
                             maxNumberOfSubjects, designPlan$eventsFixed[i], i, hazardRatio[i]
                         ),
                         functionName = ".getSampleSizeFixedSurvival",
@@ -1152,7 +1159,10 @@ NULL
                 } else {
                     stopIllegalArgument(
                         sprintf(
-                            paste0("'maxNumberOfSubjects' (%s) is smaller than the number ", "of events (%.3f)"),
+                            paste0(
+                                "'maxNumberOfSubjects' (%s) is smaller than the number ",
+                                "of events (%.3f)"
+                            ),
                             maxNumberOfSubjects, designPlan$eventsFixed[i]
                         ),
                         functionName = ".getSampleSizeFixedSurvival",
@@ -1174,7 +1184,9 @@ NULL
                 up <- 2 * up
                 iterate <- iterate + 1
                 if (iterate > 50) {
-                    stopIllegalArgument("the number of subjects is too small to reach maximum number of events ", "(presumably due to drop-out rates), search algorithm failed",
+                    stopIllegalArgument(
+                        "the number of subjects is too small to reach maximum number of events ",
+                        "(presumably due to drop-out rates), search algorithm failed",
                         functionName = ".getSampleSizeFixedSurvival"
                     )
                 }
@@ -1303,7 +1315,10 @@ NULL
                 if (designPlan$cumulativeEventsPerStage[kMax, i] > designPlan$maxNumberOfSubjects[i]) {
                     stopIllegalArgument(
                         sprintf(
-                            paste0("the number of subjects (%s) is smaller than the number ", "of events (%s) at stage %s"),
+                            paste0(
+                                "the number of subjects (%s) is smaller than the number ",
+                                "of events (%s) at stage %s"
+                            ),
                             designPlan$maxNumberOfSubjects[i], designPlan$cumulativeEventsPerStage[kMax, i], i
                         ),
                         functionName = ".getSampleSizeSequentialSurvival"
@@ -1326,7 +1341,9 @@ NULL
                     up <- 2 * up
                     iterate <- iterate + 1
                     if (iterate > 50) {
-                        stopIllegalArgument("the number of subjects is too small to reach maximum number of events ", "(presumably due to drop-out rates)",
+                        stopIllegalArgument(
+                            "the number of subjects is too small to reach maximum number of events ",
+                            "(presumably due to drop-out rates)",
                             functionName = ".getSampleSizeSequentialSurvival"
                         )
                     }
@@ -2416,7 +2433,9 @@ getSampleSizeSurvival <- function(
         )
 
         if (is.na(maxNumberOfSubjectsTarget)) {
-            stopRuntimeIssue("failed to calculate 'maxNumberOfSubjects' by given 'followUpTime' ", "(lower = ", maxNumberOfSubjectsLower,
+            stopRuntimeIssue(
+                "failed to calculate 'maxNumberOfSubjects' by given 'followUpTime' ",
+                "(lower = ", maxNumberOfSubjectsLower,
                 ", upper = ", maxNumberOfSubjectsUpper, ")",
                 functionName = "getSampleSizeSurvival",
                 parameter = "maxNumberOfSubjects",
@@ -2704,7 +2723,8 @@ getPowerSurvival <- function(
             up <- 2 * up
             iterate <- iterate + 1
             if (iterate > 50) {
-                stopIllegalArgument("'maxNumberOfSubjects' (", designPlan$maxNumberOfSubjects, ") ", "is too small to reach maximum number of events ",
+                stopIllegalArgument("'maxNumberOfSubjects' (", designPlan$maxNumberOfSubjects, ") ",
+                    "is too small to reach maximum number of events ",
                     "(presumably due to drop-out rates)",
                     functionName = "getPowerSurvival",
                     parameter = "maxNumberOfSubjects",

--- a/R/f_design_plan_survival.R
+++ b/R/f_design_plan_survival.R
@@ -60,19 +60,20 @@ NULL
     if (length(piecewiseSurvivalTime) != length(piecewiseLambda)) {
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
             .arrayToString(piecewiseLambda), ")",
-            functionName = ".getEventProbabilityFunction", 
-		parameter ="piecewiseSurvivalTime",
-            value = piecewiseSurvivalTime, 
-		relatedParameter ="piecewiseLambda", 
-		relatedValue = piecewiseLambda
+            functionName = ".getEventProbabilityFunction",
+            parameter = "piecewiseSurvivalTime",
+            value = piecewiseSurvivalTime,
+            relatedParameter = "piecewiseLambda",
+            relatedValue = piecewiseLambda
         )
     }
 
     piecewiseSurvivalTime <- .getPiecewiseExpStartTimesWithoutLeadingZero(piecewiseSurvivalTime)
 
     if (kappa != 1) {
-        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition", 
-		functionName = ".getEventProbabilityFunction")
+        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition",
+            functionName = ".getEventProbabilityFunction"
+        )
     }
     len <- length(piecewiseSurvivalTime)
     for (i in 1:len) {
@@ -193,8 +194,8 @@ NULL
         stopIllegalArgument("'densityIntervals' (", .arrayToString(densityIntervals), ") and 'accrualIntensity' (",
             .arrayToString(accrualIntensity), ") must have same length",
             functionName = ".getEventProbabilitiesGroupwise",
-            parameter = "densityIntervals", value = densityIntervals, 
-		relatedParameter ="accrualIntensity",
+            parameter = "densityIntervals", value = densityIntervals,
+            relatedParameter = "accrualIntensity",
             relatedValue = accrualIntensity
         )
     }
@@ -473,8 +474,8 @@ NULL
                     stopIllegalArgument("the definition of relative accrual intensities ", "(all 'accrualIntensity' values < 1) ",
                         "is only available for a single value ", "(", paramName, " = ", .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE),
                         ")",
-                        functionName = ".calculateSampleSizeSurvival", 
-		parameter ="accrualIntensity"
+                        functionName = ".calculateSampleSizeSurvival",
+                        parameter = "accrualIntensity"
                     )
                 }
             }
@@ -649,17 +650,18 @@ NULL
         }
 
         if (thetaH0 <= 0) {
-            stopIllegalArgument("null hypothesis hazard ratio is not allowed be negative or zero", 
-		functionName = ".createDesignPlanSurvival")
+            stopIllegalArgument("null hypothesis hazard ratio is not allowed be negative or zero",
+                functionName = ".createDesignPlanSurvival"
+            )
         }
 
         if (!(typeOfComputation %in% c("Schoenfeld", "Freedman", "HsiehFreedman"))) {
             stopIllegalArgument("computation type (", .vQuote(typeOfComputation), ") ",
-                "must be one of the following: ", 
+                "must be one of the following: ",
                 "'Schoenfeld', 'Freedman', or 'HsiehFreedman' ",
-                functionName = ".createDesignPlanSurvival", 
-		parameter ="Schoenfeld", 
-		relatedParameter ="Freedman"
+                functionName = ".createDesignPlanSurvival",
+                parameter = "Schoenfeld",
+                relatedParameter = "Freedman"
             )
         }
 
@@ -793,15 +795,15 @@ NULL
         pi1Default <- C_PI_1_SAMPLE_SIZE_DEFAULT
     }
     designPlan$.piecewiseSurvivalTime <- getPiecewiseSurvivalTime(
-        piecewiseSurvivalTime = piecewiseSurvivalTime, 
-        lambda2 = lambda2, 
+        piecewiseSurvivalTime = piecewiseSurvivalTime,
+        lambda2 = lambda2,
         lambda1 = lambda1,
-        median1 = median1, 
+        median1 = median1,
         median2 = median2,
-        hazardRatio = hazardRatio, 
-        pi1 = pi1, 
-        pi2 = pi2, 
-        eventTime = eventTime, 
+        hazardRatio = hazardRatio,
+        pi1 = pi1,
+        pi2 = pi2,
+        eventTime = eventTime,
         kappa = kappa,
         .pi1Default = pi1Default,
         .silent = TRUE
@@ -971,9 +973,9 @@ NULL
                     !is.na(designPlan$accountForObservationTimes) &&
                     !designPlan$accountForObservationTimes) {
                 stopIllegalArgument("'accountForObservationTimes' must be TRUE because 'maxNumberOfSubjects' is > 0",
-                    functionName = ".initDesignPlanSurvival", 
-		parameter ="accountForObservationTimes", 
-		relatedParameter ="maxNumberOfSubjects"
+                    functionName = ".initDesignPlanSurvival",
+                    parameter = "accountForObservationTimes",
+                    relatedParameter = "maxNumberOfSubjects"
                 )
             }
 
@@ -1045,9 +1047,9 @@ NULL
         stopConflictingArguments("determination of optimum allocation ('allocationRatioPlanned' = 0) not possible ",
             "for given 'maxNumberOfSubjects' (", designPlan$maxNumberOfSubjects, ")",
             functionName = ".getSampleSizeFixedSurvival",
-            parameter = "allocationRatioPlanned", 
-		relatedParameter ="maxNumberOfSubjects", 
-		relatedValue = designPlan$maxNumberOfSubjects
+            parameter = "allocationRatioPlanned",
+            relatedParameter = "maxNumberOfSubjects",
+            relatedValue = designPlan$maxNumberOfSubjects
         )
     }
 
@@ -1123,8 +1125,8 @@ NULL
             if (length(maxNumberOfSubjects) > 1) {
                 stopIllegalArgument("length of user defined 'maxNumberOfSubjects' (", .arrayToString(maxNumberOfSubjects),
                     ") must be 1",
-                    functionName = ".getSampleSizeFixedSurvival", 
-		parameter ="maxNumberOfSubjects", value = maxNumberOfSubjects
+                    functionName = ".getSampleSizeFixedSurvival",
+                    parameter = "maxNumberOfSubjects", value = maxNumberOfSubjects
                 )
             }
 
@@ -1153,8 +1155,8 @@ NULL
                             paste0("'maxNumberOfSubjects' (%s) is smaller than the number ", "of events (%.3f)"),
                             maxNumberOfSubjects, designPlan$eventsFixed[i]
                         ),
-                        functionName = ".getSampleSizeFixedSurvival", 
-		parameter ="maxNumberOfSubjects",
+                        functionName = ".getSampleSizeFixedSurvival",
+                        parameter = "maxNumberOfSubjects",
                         value = maxNumberOfSubjects
                     )
                 }
@@ -1299,11 +1301,13 @@ NULL
 
             if (designPlan$.calculateFollowUpTime) {
                 if (designPlan$cumulativeEventsPerStage[kMax, i] > designPlan$maxNumberOfSubjects[i]) {
-                    stopIllegalArgument(sprintf(
-                        paste0("the number of subjects (%s) is smaller than the number ", "of events (%s) at stage %s"),
-                        designPlan$maxNumberOfSubjects[i], designPlan$cumulativeEventsPerStage[kMax, i], i
-                    ), 
-		functionName = ".getSampleSizeSequentialSurvival")
+                    stopIllegalArgument(
+                        sprintf(
+                            paste0("the number of subjects (%s) is smaller than the number ", "of events (%s) at stage %s"),
+                            designPlan$maxNumberOfSubjects[i], designPlan$cumulativeEventsPerStage[kMax, i], i
+                        ),
+                        functionName = ".getSampleSizeSequentialSurvival"
+                    )
                 }
 
                 up <- 2
@@ -1386,9 +1390,9 @@ NULL
 
                 if (is.na(designPlan$followUpTime)) {
                     stopIllegalArgument("'followUpTime' must be defined because 'designPlan$.calculateFollowUpTime' = FALSE",
-                        functionName = ".getSampleSizeSequentialSurvival", 
-		parameter ="followUpTime", 
-		relatedParameter ="designPlan$.calculateFollowUpTime",
+                        functionName = ".getSampleSizeSequentialSurvival",
+                        parameter = "followUpTime",
+                        relatedParameter = "designPlan$.calculateFollowUpTime",
                         relatedValue = designPlan$.calculateFollowUpTime
                     )
                 }
@@ -1711,25 +1715,25 @@ getEventProbabilities <- function(
     if (length(accrualTime) != length(accrualIntensity)) {
         stopIllegalArgument("length of 'accrualTime' (", (length(accrualTime) + 1), ") must be equal to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
-            functionName = "getEventProbabilities", 
-		parameter ="accrualTime",
-            relatedParameter = "accrualIntensity", 
-		relatedValue = length(accrualIntensity), value = length(accrualTime)
+            functionName = "getEventProbabilities",
+            parameter = "accrualTime",
+            relatedParameter = "accrualIntensity",
+            relatedValue = length(accrualIntensity), value = length(accrualTime)
         )
     }
 
     if (any(accrualIntensity <= 0)) {
         stopIllegalArgument("all values of 'accrualIntensity' must be > 0",
-            functionName = "getEventProbabilities", 
-		parameter ="accrualIntensity",
+            functionName = "getEventProbabilities",
+            parameter = "accrualIntensity",
             value = accrualIntensity
         )
     }
 
     if (any(accrualTime <= 0)) {
         stopIllegalArgument("all values of 'accrualTime' must be > 0",
-            functionName = "getEventProbabilities", 
-		parameter ="accrualTime",
+            functionName = "getEventProbabilities",
+            parameter = "accrualTime",
             value = accrualTime
         )
     }
@@ -1741,14 +1745,16 @@ getEventProbabilities <- function(
     }
 
     if (any(phi < 0)) {
-        stopIllegalArgument("all drop-out rates (phi) must be >= 0", 
-		functionName = "getEventProbabilities")
+        stopIllegalArgument("all drop-out rates (phi) must be >= 0",
+            functionName = "getEventProbabilities"
+        )
     }
 
     lambda2 <- .assertIsNumericVector(lambda2, "lambda2")
     if (any(lambda2 <= 0)) {
-        stopIllegalArgument("all rates (lambda2) must be > 0", 
-		functionName = "getEventProbabilities")
+        stopIllegalArgument("all rates (lambda2) must be > 0",
+            functionName = "getEventProbabilities"
+        )
     }
 
     eventProbabilities <- EventProbabilities$new(
@@ -1896,33 +1902,33 @@ getNumberOfSubjects <- function(
     if (length(accrualTime) != length(accrualIntensity)) {
         stopIllegalArgument("length of 'accrualTime' (", length(accrualTime), ") must be equal to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
-            functionName = "getNumberOfSubjects", 
-		parameter ="accrualTime", value = length(accrualTime),
-            relatedParameter = "accrualIntensity", 
-		relatedValue = length(accrualIntensity)
+            functionName = "getNumberOfSubjects",
+            parameter = "accrualTime", value = length(accrualTime),
+            relatedParameter = "accrualIntensity",
+            relatedValue = length(accrualIntensity)
         )
     }
 
     if (any(accrualIntensity < 0)) {
         stopIllegalArgument("all values of 'accrualIntensity' must be >= 0",
-            functionName = "getNumberOfSubjects", 
-		parameter ="accrualIntensity",
+            functionName = "getNumberOfSubjects",
+            parameter = "accrualIntensity",
             value = accrualIntensity
         )
     }
 
     if (all(accrualIntensity < 1)) {
         stopIllegalArgument("at least one value of 'accrualIntensity' must be >= 1",
-            functionName = "getNumberOfSubjects", 
-		parameter ="accrualIntensity",
+            functionName = "getNumberOfSubjects",
+            parameter = "accrualIntensity",
             value = accrualIntensity
         )
     }
 
     if (any(accrualTime <= 0)) {
         stopIllegalArgument("all values of 'accrualTime' must be > 0",
-            functionName = "getNumberOfSubjects", 
-		parameter ="accrualTime",
+            functionName = "getNumberOfSubjects",
+            parameter = "accrualTime",
             value = accrualTime
         )
     }
@@ -2042,8 +2048,10 @@ getSampleSizeSurvival <- function(
         dropoutRate2 = 0,
         dropoutTime = 12) {
     if (is.null(design)) {
-        design <- .getDefaultDesign(directionUpper = directionUpper, type = "sampleSize", ..., 
-            ignore = c("accountForObservationTimes"))
+        design <- .getDefaultDesign(
+            directionUpper = directionUpper, type = "sampleSize", ...,
+            ignore = c("accountForObservationTimes")
+        )
         .warnInCaseOfUnknownArguments(
             functionName = "getSampleSizeSurvival",
             ignore = c(.getDesignArgumentsToIgnoreAtUnknownArgumentCheck(
@@ -2097,14 +2105,14 @@ getSampleSizeSurvival <- function(
                 }
                 stopMissingArgument("'followUpTime', 'maxNumberOfSubjects' or end of accrual must be defined",
                     functionName = "getSampleSizeSurvival",
-                    parameter = "followUpTime", 
-		relatedParameter ="maxNumberOfSubjects", value = followUpTime
+                    parameter = "followUpTime",
+                    relatedParameter = "maxNumberOfSubjects", value = followUpTime
                 )
             }
 
             stopMissingArgument("'followUpTime' or 'maxNumberOfSubjects' must be defined",
-                functionName = "getSampleSizeSurvival", 
-		parameter ="followUpTime",
+                functionName = "getSampleSizeSurvival",
+                parameter = "followUpTime",
                 relatedParameter = "maxNumberOfSubjects", value = followUpTime
             )
         }
@@ -2151,12 +2159,12 @@ getSampleSizeSurvival <- function(
         if (!is.null(paramName)) {
             paramValue <- pwst[[paramName]]
             if (!is.null(paramValue) && length(paramValue) > 1) {
-                stopIllegalArgument("the calculation of 'maxNumberOfSubjects' for given 'followUpTime' ", 
-                    "is only available for a single ", .pQuote(paramName), "; ", 
+                stopIllegalArgument("the calculation of 'maxNumberOfSubjects' for given 'followUpTime' ",
+                    "is only available for a single ", .pQuote(paramName), "; ",
                     paramName, " = ", .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE),
-                    functionName = "getSampleSizeSurvival", 
-		parameter =paramName, value = paramValue, 
-		relatedParameter ="followUpTime"
+                    functionName = "getSampleSizeSurvival",
+                    parameter = paramName, value = paramValue,
+                    relatedParameter = "followUpTime"
                 )
             }
         }
@@ -2236,8 +2244,8 @@ getSampleSizeSurvival <- function(
                 if (is.null(sampleSize) || is.na(sampleSize$followUpTime)) {
                     if (!is.na(expectionMessage) && grepl("'allocationRatioPlanned' > 0", expectionMessage)) {
                         stopIllegalArgument(expectionMessage,
-                            parameter = "allocationRatioPlanned", constraint = "must be > 0", 
-		functionName = "getSampleSizeSurvival",
+                            parameter = "allocationRatioPlanned", constraint = "must be > 0",
+                            functionName = "getSampleSizeSurvival",
                             value = allocationRatioPlanned
                         )
                     }
@@ -2289,23 +2297,23 @@ getSampleSizeSurvival <- function(
                     fut <- .getSampleSizeSurvival(
                         design = design,
                         typeOfComputation = typeOfComputation,
-                        thetaH0 = thetaH0, 
+                        thetaH0 = thetaH0,
                         directionUpper = directionUpper,
-                        pi2 = pi2, 
+                        pi2 = pi2,
                         pi1 = pi1,
                         allocationRatioPlanned = allocationRatioPlanned,
                         accountForObservationTimes = accountForObservationTimes,
                         eventTime = eventTime, accrualTime = accrualSetup$accrualTime,
                         accrualIntensity = accrualSetup$accrualIntensity, kappa = kappa,
                         piecewiseSurvivalTime = piecewiseSurvivalTime,
-                        lambda2 = lambda2, 
-                        lambda1 = lambda1, 
-                        median1 = median1, 
+                        lambda2 = lambda2,
+                        lambda1 = lambda1,
+                        median1 = median1,
                         median2 = median2,
-                        followUpTime = NA_real_, 
+                        followUpTime = NA_real_,
                         maxNumberOfSubjects = maxNumberOfSubjectsUpper,
-                        dropoutRate1 = dropoutRate1, 
-                        dropoutRate2 = dropoutRate2, 
+                        dropoutRate1 = dropoutRate1,
+                        dropoutRate2 = dropoutRate2,
                         dropoutTime = dropoutTime,
                         hazardRatio = hazardRatio
                     )$followUpTime
@@ -2342,9 +2350,9 @@ getSampleSizeSurvival <- function(
                         fut <- .getSampleSizeSurvival(
                             design = design,
                             typeOfComputation = typeOfComputation,
-                            thetaH0 = thetaH0, 
+                            thetaH0 = thetaH0,
                             directionUpper = directionUpper,
-                            pi2 = pi2, 
+                            pi2 = pi2,
                             pi1 = pi1,
                             allocationRatioPlanned = allocationRatioPlanned,
                             accountForObservationTimes = accountForObservationTimes,
@@ -2372,9 +2380,9 @@ getSampleSizeSurvival <- function(
                             fut <- .getSampleSizeSurvival(
                                 design = design,
                                 typeOfComputation = typeOfComputation,
-                                thetaH0 = thetaH0, 
+                                thetaH0 = thetaH0,
                                 directionUpper = directionUpper,
-                                pi2 = pi2, 
+                                pi2 = pi2,
                                 pi1 = pi1,
                                 allocationRatioPlanned = allocationRatioPlanned,
                                 accountForObservationTimes = accountForObservationTimes,
@@ -2410,8 +2418,8 @@ getSampleSizeSurvival <- function(
         if (is.na(maxNumberOfSubjectsTarget)) {
             stopRuntimeIssue("failed to calculate 'maxNumberOfSubjects' by given 'followUpTime' ", "(lower = ", maxNumberOfSubjectsLower,
                 ", upper = ", maxNumberOfSubjectsUpper, ")",
-                functionName = "getSampleSizeSurvival", 
-		parameter ="maxNumberOfSubjects",
+                functionName = "getSampleSizeSurvival",
+                parameter = "maxNumberOfSubjects",
                 relatedParameter = "followUpTime", value = maxNumberOfSubjects
             )
         }
@@ -2419,24 +2427,24 @@ getSampleSizeSurvival <- function(
         sampleSizeSurvival <- .getSampleSizeSurvival(
             design = design,
             typeOfComputation = typeOfComputation,
-            thetaH0 = thetaH0, 
+            thetaH0 = thetaH0,
             directionUpper = directionUpper,
-            pi2 = pi2, 
+            pi2 = pi2,
             pi1 = pi1,
             allocationRatioPlanned = allocationRatioPlanned,
             accountForObservationTimes = accountForObservationTimes,
-            eventTime = eventTime, 
+            eventTime = eventTime,
             accrualTime = accrualSetup$accrualTime,
-            accrualIntensity = accrualSetup$accrualIntensity, 
+            accrualIntensity = accrualSetup$accrualIntensity,
             kappa = kappa,
-            piecewiseSurvivalTime = piecewiseSurvivalTime, 
-            lambda2 = lambda2, 
+            piecewiseSurvivalTime = piecewiseSurvivalTime,
+            lambda2 = lambda2,
             lambda1 = lambda1,
-            median1 = median1, 
+            median1 = median1,
             median2 = median2,
-            followUpTime = NA_real_, 
+            followUpTime = NA_real_,
             maxNumberOfSubjects = maxNumberOfSubjectsTarget,
-            dropoutRate1 = dropoutRate1, 
+            dropoutRate1 = dropoutRate1,
             dropoutRate2 = dropoutRate2,
             dropoutTime = dropoutTime,
             hazardRatio = hazardRatio,
@@ -2473,25 +2481,25 @@ getSampleSizeSurvival <- function(
     return(.getSampleSizeSurvival(
         design = design,
         typeOfComputation = typeOfComputation,
-        thetaH0 = thetaH0, 
+        thetaH0 = thetaH0,
         directionUpper = directionUpper,
-        pi2 = pi2, 
+        pi2 = pi2,
         pi1 = pi1,
         allocationRatioPlanned = allocationRatioPlanned,
         accountForObservationTimes = accountForObservationTimes,
-        eventTime = eventTime, 
+        eventTime = eventTime,
         accrualTime = accrualTime,
-        accrualIntensity = accrualIntensity, 
+        accrualIntensity = accrualIntensity,
         accrualIntensityType = accrualIntensityType,
-        kappa = kappa, 
+        kappa = kappa,
         piecewiseSurvivalTime = piecewiseSurvivalTime,
-        lambda2 = lambda2, 
+        lambda2 = lambda2,
         lambda1 = lambda1,
-        median1 = median1, 
+        median1 = median1,
         median2 = median2,
-        followUpTime = followUpTime, 
+        followUpTime = followUpTime,
         maxNumberOfSubjects = maxNumberOfSubjects,
-        dropoutRate1 = dropoutRate1, 
+        dropoutRate1 = dropoutRate1,
         dropoutRate2 = dropoutRate2,
         dropoutTime = dropoutTime,
         hazardRatio = hazardRatio
@@ -2698,8 +2706,8 @@ getPowerSurvival <- function(
             if (iterate > 50) {
                 stopIllegalArgument("'maxNumberOfSubjects' (", designPlan$maxNumberOfSubjects, ") ", "is too small to reach maximum number of events ",
                     "(presumably due to drop-out rates)",
-                    functionName = "getPowerSurvival", 
-		parameter ="maxNumberOfSubjects",
+                    functionName = "getPowerSurvival",
+                    parameter = "maxNumberOfSubjects",
                     value = designPlan$maxNumberOfSubjects
                 )
             }

--- a/R/f_design_plan_survival.R
+++ b/R/f_design_plan_survival.R
@@ -60,15 +60,19 @@ NULL
     if (length(piecewiseSurvivalTime) != length(piecewiseLambda)) {
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime), ") must be equal to length of 'piecewiseLambda' (",
             .arrayToString(piecewiseLambda), ")",
-            functionName = ".getEventProbabilityFunction", parameter = "piecewiseSurvivalTime",
-            value = piecewiseSurvivalTime, relatedParameter = "piecewiseLambda", relatedValue = piecewiseLambda
+            functionName = ".getEventProbabilityFunction", 
+		parameter ="piecewiseSurvivalTime",
+            value = piecewiseSurvivalTime, 
+		relatedParameter ="piecewiseLambda", 
+		relatedValue = piecewiseLambda
         )
     }
 
     piecewiseSurvivalTime <- .getPiecewiseExpStartTimesWithoutLeadingZero(piecewiseSurvivalTime)
 
     if (kappa != 1) {
-        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition", functionName = ".getEventProbabilityFunction")
+        stopIllegalArgument("Weibull distribution cannot be used for piecewise survival definition", 
+		functionName = ".getEventProbabilityFunction")
     }
     len <- length(piecewiseSurvivalTime)
     for (i in 1:len) {
@@ -189,7 +193,8 @@ NULL
         stopIllegalArgument("'densityIntervals' (", .arrayToString(densityIntervals), ") and 'accrualIntensity' (",
             .arrayToString(accrualIntensity), ") must have same length",
             functionName = ".getEventProbabilitiesGroupwise",
-            parameter = "densityIntervals", value = densityIntervals, relatedParameter = "accrualIntensity",
+            parameter = "densityIntervals", value = densityIntervals, 
+		relatedParameter ="accrualIntensity",
             relatedValue = accrualIntensity
         )
     }
@@ -468,7 +473,8 @@ NULL
                     stopIllegalArgument("the definition of relative accrual intensities ", "(all 'accrualIntensity' values < 1) ",
                         "is only available for a single value ", "(", paramName, " = ", .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE),
                         ")",
-                        functionName = ".calculateSampleSizeSurvival", parameter = "accrualIntensity"
+                        functionName = ".calculateSampleSizeSurvival", 
+		parameter ="accrualIntensity"
                     )
                 }
             }
@@ -643,12 +649,17 @@ NULL
         }
 
         if (thetaH0 <= 0) {
-            stopIllegalArgument("null hypothesis hazard ratio is not allowed be negative or zero", functionName = ".createDesignPlanSurvival")
+            stopIllegalArgument("null hypothesis hazard ratio is not allowed be negative or zero", 
+		functionName = ".createDesignPlanSurvival")
         }
 
         if (!(typeOfComputation %in% c("Schoenfeld", "Freedman", "HsiehFreedman"))) {
-            stopIllegalArgument("computation type ('", typeOfComputation, "') must be one of the following: ", "'Schoenfeld', 'Freedman', or 'HsiehFreedman' ",
-                functionName = ".createDesignPlanSurvival", parameter = "Schoenfeld", relatedParameter = "Freedman"
+            stopIllegalArgument("computation type (", .vQuote(typeOfComputation), ") ",
+                "must be one of the following: ", 
+                "'Schoenfeld', 'Freedman', or 'HsiehFreedman' ",
+                functionName = ".createDesignPlanSurvival", 
+		parameter ="Schoenfeld", 
+		relatedParameter ="Freedman"
             )
         }
 
@@ -960,7 +971,9 @@ NULL
                     !is.na(designPlan$accountForObservationTimes) &&
                     !designPlan$accountForObservationTimes) {
                 stopIllegalArgument("'accountForObservationTimes' must be TRUE because 'maxNumberOfSubjects' is > 0",
-                    functionName = ".initDesignPlanSurvival", parameter = "accountForObservationTimes", relatedParameter = "maxNumberOfSubjects"
+                    functionName = ".initDesignPlanSurvival", 
+		parameter ="accountForObservationTimes", 
+		relatedParameter ="maxNumberOfSubjects"
                 )
             }
 
@@ -1032,7 +1045,9 @@ NULL
         stopConflictingArguments("determination of optimum allocation ('allocationRatioPlanned' = 0) not possible ",
             "for given 'maxNumberOfSubjects' (", designPlan$maxNumberOfSubjects, ")",
             functionName = ".getSampleSizeFixedSurvival",
-            parameter = "allocationRatioPlanned", relatedParameter = "maxNumberOfSubjects", relatedValue = designPlan$maxNumberOfSubjects
+            parameter = "allocationRatioPlanned", 
+		relatedParameter ="maxNumberOfSubjects", 
+		relatedValue = designPlan$maxNumberOfSubjects
         )
     }
 
@@ -1108,7 +1123,8 @@ NULL
             if (length(maxNumberOfSubjects) > 1) {
                 stopIllegalArgument("length of user defined 'maxNumberOfSubjects' (", .arrayToString(maxNumberOfSubjects),
                     ") must be 1",
-                    functionName = ".getSampleSizeFixedSurvival", parameter = "maxNumberOfSubjects", value = maxNumberOfSubjects
+                    functionName = ".getSampleSizeFixedSurvival", 
+		parameter ="maxNumberOfSubjects", value = maxNumberOfSubjects
                 )
             }
 
@@ -1137,7 +1153,8 @@ NULL
                             paste0("'maxNumberOfSubjects' (%s) is smaller than the number ", "of events (%.3f)"),
                             maxNumberOfSubjects, designPlan$eventsFixed[i]
                         ),
-                        functionName = ".getSampleSizeFixedSurvival", parameter = "maxNumberOfSubjects",
+                        functionName = ".getSampleSizeFixedSurvival", 
+		parameter ="maxNumberOfSubjects",
                         value = maxNumberOfSubjects
                     )
                 }
@@ -1285,7 +1302,8 @@ NULL
                     stopIllegalArgument(sprintf(
                         paste0("the number of subjects (%s) is smaller than the number ", "of events (%s) at stage %s"),
                         designPlan$maxNumberOfSubjects[i], designPlan$cumulativeEventsPerStage[kMax, i], i
-                    ), functionName = ".getSampleSizeSequentialSurvival")
+                    ), 
+		functionName = ".getSampleSizeSequentialSurvival")
                 }
 
                 up <- 2
@@ -1368,7 +1386,9 @@ NULL
 
                 if (is.na(designPlan$followUpTime)) {
                     stopIllegalArgument("'followUpTime' must be defined because 'designPlan$.calculateFollowUpTime' = FALSE",
-                        functionName = ".getSampleSizeSequentialSurvival", parameter = "followUpTime", relatedParameter = "designPlan$.calculateFollowUpTime",
+                        functionName = ".getSampleSizeSequentialSurvival", 
+		parameter ="followUpTime", 
+		relatedParameter ="designPlan$.calculateFollowUpTime",
                         relatedValue = designPlan$.calculateFollowUpTime
                     )
                 }
@@ -1691,21 +1711,25 @@ getEventProbabilities <- function(
     if (length(accrualTime) != length(accrualIntensity)) {
         stopIllegalArgument("length of 'accrualTime' (", (length(accrualTime) + 1), ") must be equal to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
-            functionName = "getEventProbabilities", parameter = "accrualTime",
-            relatedParameter = "accrualIntensity", relatedValue = length(accrualIntensity), value = length(accrualTime)
+            functionName = "getEventProbabilities", 
+		parameter ="accrualTime",
+            relatedParameter = "accrualIntensity", 
+		relatedValue = length(accrualIntensity), value = length(accrualTime)
         )
     }
 
     if (any(accrualIntensity <= 0)) {
         stopIllegalArgument("all values of 'accrualIntensity' must be > 0",
-            functionName = "getEventProbabilities", parameter = "accrualIntensity",
+            functionName = "getEventProbabilities", 
+		parameter ="accrualIntensity",
             value = accrualIntensity
         )
     }
 
     if (any(accrualTime <= 0)) {
         stopIllegalArgument("all values of 'accrualTime' must be > 0",
-            functionName = "getEventProbabilities", parameter = "accrualTime",
+            functionName = "getEventProbabilities", 
+		parameter ="accrualTime",
             value = accrualTime
         )
     }
@@ -1717,12 +1741,14 @@ getEventProbabilities <- function(
     }
 
     if (any(phi < 0)) {
-        stopIllegalArgument("all drop-out rates (phi) must be >= 0", functionName = "getEventProbabilities")
+        stopIllegalArgument("all drop-out rates (phi) must be >= 0", 
+		functionName = "getEventProbabilities")
     }
 
     lambda2 <- .assertIsNumericVector(lambda2, "lambda2")
     if (any(lambda2 <= 0)) {
-        stopIllegalArgument("all rates (lambda2) must be > 0", functionName = "getEventProbabilities")
+        stopIllegalArgument("all rates (lambda2) must be > 0", 
+		functionName = "getEventProbabilities")
     }
 
     eventProbabilities <- EventProbabilities$new(
@@ -1870,28 +1896,33 @@ getNumberOfSubjects <- function(
     if (length(accrualTime) != length(accrualIntensity)) {
         stopIllegalArgument("length of 'accrualTime' (", length(accrualTime), ") must be equal to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
-            functionName = "getNumberOfSubjects", parameter = "accrualTime", value = length(accrualTime),
-            relatedParameter = "accrualIntensity", relatedValue = length(accrualIntensity)
+            functionName = "getNumberOfSubjects", 
+		parameter ="accrualTime", value = length(accrualTime),
+            relatedParameter = "accrualIntensity", 
+		relatedValue = length(accrualIntensity)
         )
     }
 
     if (any(accrualIntensity < 0)) {
         stopIllegalArgument("all values of 'accrualIntensity' must be >= 0",
-            functionName = "getNumberOfSubjects", parameter = "accrualIntensity",
+            functionName = "getNumberOfSubjects", 
+		parameter ="accrualIntensity",
             value = accrualIntensity
         )
     }
 
     if (all(accrualIntensity < 1)) {
         stopIllegalArgument("at least one value of 'accrualIntensity' must be >= 1",
-            functionName = "getNumberOfSubjects", parameter = "accrualIntensity",
+            functionName = "getNumberOfSubjects", 
+		parameter ="accrualIntensity",
             value = accrualIntensity
         )
     }
 
     if (any(accrualTime <= 0)) {
         stopIllegalArgument("all values of 'accrualTime' must be > 0",
-            functionName = "getNumberOfSubjects", parameter = "accrualTime",
+            functionName = "getNumberOfSubjects", 
+		parameter ="accrualTime",
             value = accrualTime
         )
     }
@@ -2066,12 +2097,14 @@ getSampleSizeSurvival <- function(
                 }
                 stopMissingArgument("'followUpTime', 'maxNumberOfSubjects' or end of accrual must be defined",
                     functionName = "getSampleSizeSurvival",
-                    parameter = "followUpTime", relatedParameter = "maxNumberOfSubjects", value = followUpTime
+                    parameter = "followUpTime", 
+		relatedParameter ="maxNumberOfSubjects", value = followUpTime
                 )
             }
 
             stopMissingArgument("'followUpTime' or 'maxNumberOfSubjects' must be defined",
-                functionName = "getSampleSizeSurvival", parameter = "followUpTime",
+                functionName = "getSampleSizeSurvival", 
+		parameter ="followUpTime",
                 relatedParameter = "maxNumberOfSubjects", value = followUpTime
             )
         }
@@ -2118,9 +2151,12 @@ getSampleSizeSurvival <- function(
         if (!is.null(paramName)) {
             paramValue <- pwst[[paramName]]
             if (!is.null(paramValue) && length(paramValue) > 1) {
-                stopIllegalArgument("the calculation of 'maxNumberOfSubjects' for given 'followUpTime' ", "is only available for a single '",
-                    paramName, "'; ", paramName, " = ", .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE),
-                    functionName = "getSampleSizeSurvival", parameter = paramName, value = paramValue, relatedParameter = "followUpTime"
+                stopIllegalArgument("the calculation of 'maxNumberOfSubjects' for given 'followUpTime' ", 
+                    "is only available for a single ", .pQuote(paramName), "; ", 
+                    paramName, " = ", .arrayToString(paramValue, vectorLookAndFeelEnabled = TRUE),
+                    functionName = "getSampleSizeSurvival", 
+		parameter =paramName, value = paramValue, 
+		relatedParameter ="followUpTime"
                 )
             }
         }
@@ -2200,7 +2236,8 @@ getSampleSizeSurvival <- function(
                 if (is.null(sampleSize) || is.na(sampleSize$followUpTime)) {
                     if (!is.na(expectionMessage) && grepl("'allocationRatioPlanned' > 0", expectionMessage)) {
                         stopIllegalArgument(expectionMessage,
-                            parameter = "allocationRatioPlanned", constraint = "must be > 0", functionName = "getSampleSizeSurvival",
+                            parameter = "allocationRatioPlanned", constraint = "must be > 0", 
+		functionName = "getSampleSizeSurvival",
                             value = allocationRatioPlanned
                         )
                     }
@@ -2373,7 +2410,8 @@ getSampleSizeSurvival <- function(
         if (is.na(maxNumberOfSubjectsTarget)) {
             stopRuntimeIssue("failed to calculate 'maxNumberOfSubjects' by given 'followUpTime' ", "(lower = ", maxNumberOfSubjectsLower,
                 ", upper = ", maxNumberOfSubjectsUpper, ")",
-                functionName = "getSampleSizeSurvival", parameter = "maxNumberOfSubjects",
+                functionName = "getSampleSizeSurvival", 
+		parameter ="maxNumberOfSubjects",
                 relatedParameter = "followUpTime", value = maxNumberOfSubjects
             )
         }
@@ -2660,7 +2698,8 @@ getPowerSurvival <- function(
             if (iterate > 50) {
                 stopIllegalArgument("'maxNumberOfSubjects' (", designPlan$maxNumberOfSubjects, ") ", "is too small to reach maximum number of events ",
                     "(presumably due to drop-out rates)",
-                    functionName = "getPowerSurvival", parameter = "maxNumberOfSubjects",
+                    functionName = "getPowerSurvival", 
+		parameter ="maxNumberOfSubjects",
                     value = designPlan$maxNumberOfSubjects
                 )
             }

--- a/R/f_design_plan_utilities.R
+++ b/R/f_design_plan_utilities.R
@@ -287,7 +287,8 @@ NULL
     if (piecewiseSurvivalTime[1] != 0) {
         stopIllegalArgument("the first value of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime),
             ") must be 0",
-            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero", parameter = "piecewiseSurvivalTime",
+            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero", 
+		parameter ="piecewiseSurvivalTime",
             value = piecewiseSurvivalTime
         )
     }
@@ -298,7 +299,8 @@ NULL
 
     if (length(piecewiseSurvivalTime) < 2) {
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", length(piecewiseSurvivalTime), ") must be > 1",
-            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero", parameter = "piecewiseSurvivalTime",
+            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero", 
+		parameter ="piecewiseSurvivalTime",
             value = length(piecewiseSurvivalTime)
         )
     }
@@ -311,7 +313,9 @@ NULL
     if (length(accrualTime) != length(accrualIntensity)) {
         stopIllegalArgument("length of 'accrualTime' (", length(accrualIntensity), ") ", "must be equel to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
-            functionName = ".getNumberOfSubjectsInner", parameter = "accrualTime", relatedParameter = "accrualIntensity",
+            functionName = ".getNumberOfSubjectsInner", 
+		parameter ="accrualTime", 
+		relatedParameter ="accrualIntensity",
             relatedValue = length(accrualIntensity), value = accrualTime
         )
     }

--- a/R/f_design_plan_utilities.R
+++ b/R/f_design_plan_utilities.R
@@ -287,8 +287,8 @@ NULL
     if (piecewiseSurvivalTime[1] != 0) {
         stopIllegalArgument("the first value of 'piecewiseSurvivalTime' (", .arrayToString(piecewiseSurvivalTime),
             ") must be 0",
-            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero", 
-		parameter ="piecewiseSurvivalTime",
+            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero",
+            parameter = "piecewiseSurvivalTime",
             value = piecewiseSurvivalTime
         )
     }
@@ -299,8 +299,8 @@ NULL
 
     if (length(piecewiseSurvivalTime) < 2) {
         stopIllegalArgument("length of 'piecewiseSurvivalTime' (", length(piecewiseSurvivalTime), ") must be > 1",
-            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero", 
-		parameter ="piecewiseSurvivalTime",
+            functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero",
+            parameter = "piecewiseSurvivalTime",
             value = length(piecewiseSurvivalTime)
         )
     }
@@ -313,9 +313,9 @@ NULL
     if (length(accrualTime) != length(accrualIntensity)) {
         stopIllegalArgument("length of 'accrualTime' (", length(accrualIntensity), ") ", "must be equel to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
-            functionName = ".getNumberOfSubjectsInner", 
-		parameter ="accrualTime", 
-		relatedParameter ="accrualIntensity",
+            functionName = ".getNumberOfSubjectsInner",
+            parameter = "accrualTime",
+            relatedParameter = "accrualIntensity",
             relatedValue = length(accrualIntensity), value = accrualTime
         )
     }

--- a/R/f_design_plan_utilities.R
+++ b/R/f_design_plan_utilities.R
@@ -298,7 +298,8 @@ NULL
     }
 
     if (length(piecewiseSurvivalTime) < 2) {
-        stopIllegalArgument("length of 'piecewiseSurvivalTime' (", length(piecewiseSurvivalTime), ") must be > 1",
+        stopIllegalArgument(
+            "length of 'piecewiseSurvivalTime' (", length(piecewiseSurvivalTime), ") must be > 1",
             functionName = ".getPiecewiseExpStartTimesWithoutLeadingZero",
             parameter = "piecewiseSurvivalTime",
             value = length(piecewiseSurvivalTime)
@@ -311,7 +312,8 @@ NULL
 .getNumberOfSubjectsInner <- function(..., timeValue, accrualTime, accrualIntensity, maxNumberOfSubjects) {
     .assertIsSingleNumber(timeValue, "timeValue")
     if (length(accrualTime) != length(accrualIntensity)) {
-        stopIllegalArgument("length of 'accrualTime' (", length(accrualIntensity), ") ", "must be equel to length of 'accrualIntensity' (",
+        stopIllegalArgument("length of 'accrualTime' (", length(accrualIntensity), ") ",
+            "must be equel to length of 'accrualIntensity' (",
             length(accrualIntensity), ")",
             functionName = ".getNumberOfSubjectsInner",
             parameter = "accrualTime",

--- a/R/f_error_handling.R
+++ b/R/f_error_handling.R
@@ -83,7 +83,7 @@ NULL
     return(condition)
 }
 
-.stopRpactError <- function(
+.stopWithError <- function(
         message,
         ...,
         exceptionType,
@@ -122,7 +122,7 @@ stopRuntimeIssue <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -156,7 +156,7 @@ stopIllegalArgument <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -184,7 +184,7 @@ stopIllegalDataInput <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -212,7 +212,7 @@ stopConflictingArguments <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -242,7 +242,7 @@ stopArgumentOutOfBounds <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -276,7 +276,7 @@ stopArgumentLengthOutOfBounds <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -311,7 +311,7 @@ stopIndexOutOfBounds <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -342,7 +342,7 @@ stopMissingArgument <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,
@@ -372,7 +372,7 @@ stopIncompleteArguments <- function(
         call = NULL) {
     call <- .getErrorCall(call = call)
     message <- .getErrorMessage(...)
-    .stopRpactError(
+    .stopWithError(
         message,
         functionName = functionName,
         parameter = parameter,

--- a/R/f_error_handling.R
+++ b/R/f_error_handling.R
@@ -21,7 +21,11 @@ NULL
     return(paste0(unlist(list(...)), collapse = ""))
 }
 
-.getErrorCall <- function(call = NULL) {
+.getErrorCall <- function(call = NULL, asCharacter = TRUE) {
+    if (isTRUE(asCharacter)) {
+        return(sys.calls()[[1]])
+    }
+    
     if (!is.null(call)) {
         return(call)
     }

--- a/R/f_error_handling.R
+++ b/R/f_error_handling.R
@@ -25,7 +25,7 @@ NULL
     if (isTRUE(asCharacter)) {
         return(sys.calls()[[1]])
     }
-    
+
     if (!is.null(call)) {
         return(call)
     }

--- a/R/f_io_utilities.R
+++ b/R/f_io_utilities.R
@@ -120,16 +120,17 @@ writeKeyValueFile <- function(
     .assertIsSingleLogical(safeKeyCheck, "safeKeyCheck")
 
     if (!is.list(keyValueList)) {
-        stopIllegalArgument("'keyValueList' must be a list()", 
-		functionName = "writeKeyValueFile", 
-		parameter ="keyValueList", value = keyValueList)
+        stopIllegalArgument("'keyValueList' must be a list()",
+            functionName = "writeKeyValueFile",
+            parameter = "keyValueList", value = keyValueList
+        )
     }
 
     keyNames <- names(keyValueList)
     if (is.null(keyNames) || any(!nzchar(keyNames))) {
         stopIllegalArgument("'keyValueList' must be a named list()",
-            functionName = "writeKeyValueFile", 
-		parameter ="keyValueList",
+            functionName = "writeKeyValueFile",
+            parameter = "keyValueList",
             value = keyValueList
         )
     }
@@ -144,8 +145,9 @@ writeKeyValueFile <- function(
     if (any(isInvalidValue)) {
         stopIllegalArgument("all values must be length-1 atomic (no lists/vectors). Problem keys: ", paste(names(keyValueList)[isInvalidValue],
             collapse = ", "
-        ), 
-		functionName = "writeKeyValueFile")
+        ),
+        functionName = "writeKeyValueFile"
+        )
     }
 
     if (file.exists(filePath) && !overwrite) {
@@ -183,8 +185,9 @@ writeKeyValueFile <- function(
 
     convertValueToString <- function(value) {
         if (length(value) != 1L) {
-            stopRuntimeIssue("value must be length 1", 
-		functionName = "convertValueToString")
+            stopRuntimeIssue("value must be length 1",
+                functionName = "convertValueToString"
+            )
         }
 
         if (is.na(value)) {
@@ -325,9 +328,10 @@ readKeyValueFile <- function(
     duplicateKeys <- match.arg(duplicateKeys)
 
     if (!file.exists(filePath)) {
-        stopIllegalArgument("file not found: ", sQuote(filePath), 
-		functionName = "readKeyValueFile", 
-		parameter =filePath)
+        stopIllegalArgument("file not found: ", sQuote(filePath),
+            functionName = "readKeyValueFile",
+            parameter = filePath
+        )
     }
 
     con <- file(filePath, open = "r", encoding = "UTF-8")
@@ -430,9 +434,10 @@ readKeyValueFile <- function(
 
         if (key %in% seenKeys) {
             if (duplicateKeys == "error") {
-                stopRuntimeIssue("duplicate key in file: ", sQuote(key), 
-		functionName = "readKeyValueFile", 
-		parameter =key)
+                stopRuntimeIssue("duplicate key in file: ", sQuote(key),
+                    functionName = "readKeyValueFile",
+                    parameter = key
+                )
             }
             if (duplicateKeys == "first") {
                 next

--- a/R/f_io_utilities.R
+++ b/R/f_io_utilities.R
@@ -17,7 +17,7 @@
 
 .writeLinesToFile <- function(lines, fileName) {
     if (is.null(lines) || length(lines) == 0 || !is.character(lines)) {
-        warning("Empty lines. Stop to write '", fileName, "'")
+        warning("Empty lines. Stop to write ", .vQuote(fileName))
         return(invisible(fileName))
     }
 
@@ -120,13 +120,16 @@ writeKeyValueFile <- function(
     .assertIsSingleLogical(safeKeyCheck, "safeKeyCheck")
 
     if (!is.list(keyValueList)) {
-        stopIllegalArgument("'keyValueList' must be a list()", functionName = "writeKeyValueFile", parameter = "keyValueList", value = keyValueList)
+        stopIllegalArgument("'keyValueList' must be a list()", 
+		functionName = "writeKeyValueFile", 
+		parameter ="keyValueList", value = keyValueList)
     }
 
     keyNames <- names(keyValueList)
     if (is.null(keyNames) || any(!nzchar(keyNames))) {
         stopIllegalArgument("'keyValueList' must be a named list()",
-            functionName = "writeKeyValueFile", parameter = "keyValueList",
+            functionName = "writeKeyValueFile", 
+		parameter ="keyValueList",
             value = keyValueList
         )
     }
@@ -141,7 +144,8 @@ writeKeyValueFile <- function(
     if (any(isInvalidValue)) {
         stopIllegalArgument("all values must be length-1 atomic (no lists/vectors). Problem keys: ", paste(names(keyValueList)[isInvalidValue],
             collapse = ", "
-        ), functionName = "writeKeyValueFile")
+        ), 
+		functionName = "writeKeyValueFile")
     }
 
     if (file.exists(filePath) && !overwrite) {
@@ -179,7 +183,8 @@ writeKeyValueFile <- function(
 
     convertValueToString <- function(value) {
         if (length(value) != 1L) {
-            stopRuntimeIssue("value must be length 1", functionName = "convertValueToString")
+            stopRuntimeIssue("value must be length 1", 
+		functionName = "convertValueToString")
         }
 
         if (is.na(value)) {
@@ -230,7 +235,7 @@ writeKeyValueFile <- function(
         key <- keyNames[index]
 
         if (isTRUE(safeKeyCheck) && !grepl("^[A-Za-z0-9_.-]+$", key)) {
-            stopRuntimeIssue("invalid key name '", key, "'. Allowed: A-Za-z0-9_.-",
+            stopRuntimeIssue("invalid key name ", .pQuote(key), ". Allowed: A-Za-z0-9_.-",
                 functionName = "writeKeyValueFile",
                 parameter = "key", value = key
             )
@@ -320,7 +325,9 @@ readKeyValueFile <- function(
     duplicateKeys <- match.arg(duplicateKeys)
 
     if (!file.exists(filePath)) {
-        stopIllegalArgument("file not found: ", sQuote(filePath), functionName = "readKeyValueFile", parameter = filePath)
+        stopIllegalArgument("file not found: ", sQuote(filePath), 
+		functionName = "readKeyValueFile", 
+		parameter =filePath)
     }
 
     con <- file(filePath, open = "r", encoding = "UTF-8")
@@ -423,7 +430,9 @@ readKeyValueFile <- function(
 
         if (key %in% seenKeys) {
             if (duplicateKeys == "error") {
-                stopRuntimeIssue("duplicate key in file: ", sQuote(key), functionName = "readKeyValueFile", parameter = key)
+                stopRuntimeIssue("duplicate key in file: ", sQuote(key), 
+		functionName = "readKeyValueFile", 
+		parameter =key)
             }
             if (duplicateKeys == "first") {
                 next

--- a/R/f_object_r_code.R
+++ b/R/f_object_r_code.R
@@ -249,8 +249,8 @@ NULL
     }
 
     stopRuntimeIssue("function '.getGeneratorFunctionName' is not implemented for class ", .getClassName(obj),
-        functionName = ".getGeneratorFunctionName", 
-		parameter =".getGeneratorFunctionName"
+        functionName = ".getGeneratorFunctionName",
+        parameter = ".getGeneratorFunctionName"
     )
 }
 
@@ -514,8 +514,8 @@ getObjectRCode <- function(
     if (!is.list(newArgumentValues)) {
         stopIllegalArgument("'newArgumentValues' must be a named list ", "(is ", .getClassName(newArgumentValues),
             ")",
-            functionName = "getObjectRCode", 
-		parameter ="newArgumentValues", value = newArgumentValues
+            functionName = "getObjectRCode",
+            parameter = "newArgumentValues", value = newArgumentValues
         )
     }
 
@@ -781,10 +781,10 @@ getObjectRCode <- function(
         illegalArgumentValueNames <- newArgumentValueNames[which(!(newArgumentValueNames %in% names(obj)))]
         if (length(illegalArgumentValueNames) > 0) {
             stopIllegalArgument(.pQuote(illegalArgumentValueNames), " is not a valid ", functionName, "() argument",
-                functionName = "getObjectRCode", 
-		parameter ="illegalArgumentValueNames", value = illegalArgumentValueNames,
-                relatedParameter = "functionName", 
-		relatedValue = functionName
+                functionName = "getObjectRCode",
+                parameter = "illegalArgumentValueNames", value = illegalArgumentValueNames,
+                relatedParameter = "functionName",
+                relatedValue = functionName
             )
         }
 

--- a/R/f_object_r_code.R
+++ b/R/f_object_r_code.R
@@ -512,8 +512,8 @@ getObjectRCode <- function(
     .assertIsParameterSetClass(obj, "ParameterSet")
 
     if (!is.list(newArgumentValues)) {
-        stopIllegalArgument("'newArgumentValues' must be a named list ", "(is ", .getClassName(newArgumentValues),
-            ")",
+        stopIllegalArgument("'newArgumentValues' must be a named list ",
+            "(is ", .getClassName(newArgumentValues), ")",
             functionName = "getObjectRCode",
             parameter = "newArgumentValues", value = newArgumentValues
         )

--- a/R/f_object_r_code.R
+++ b/R/f_object_r_code.R
@@ -249,7 +249,8 @@ NULL
     }
 
     stopRuntimeIssue("function '.getGeneratorFunctionName' is not implemented for class ", .getClassName(obj),
-        functionName = ".getGeneratorFunctionName", parameter = ".getGeneratorFunctionName"
+        functionName = ".getGeneratorFunctionName", 
+		parameter =".getGeneratorFunctionName"
     )
 }
 
@@ -513,7 +514,8 @@ getObjectRCode <- function(
     if (!is.list(newArgumentValues)) {
         stopIllegalArgument("'newArgumentValues' must be a named list ", "(is ", .getClassName(newArgumentValues),
             ")",
-            functionName = "getObjectRCode", parameter = "newArgumentValues", value = newArgumentValues
+            functionName = "getObjectRCode", 
+		parameter ="newArgumentValues", value = newArgumentValues
         )
     }
 
@@ -778,9 +780,11 @@ getObjectRCode <- function(
         newArgumentValueNames <- names(newArgumentValues)
         illegalArgumentValueNames <- newArgumentValueNames[which(!(newArgumentValueNames %in% names(obj)))]
         if (length(illegalArgumentValueNames) > 0) {
-            stopIllegalArgument("'", illegalArgumentValueNames, "' is not a valid ", functionName, "() argument",
-                functionName = "getObjectRCode", parameter = "illegalArgumentValueNames", value = illegalArgumentValueNames,
-                relatedParameter = "functionName", relatedValue = functionName
+            stopIllegalArgument(.pQuote(illegalArgumentValueNames), " is not a valid ", functionName, "() argument",
+                functionName = "getObjectRCode", 
+		parameter ="illegalArgumentValueNames", value = illegalArgumentValueNames,
+                relatedParameter = "functionName", 
+		relatedValue = functionName
             )
         }
 

--- a/R/f_quality_assurance.R
+++ b/R/f_quality_assurance.R
@@ -176,7 +176,8 @@ NULL
 
     if (grepl("testthat(/|\\\\)?$", testFileTargetDirectory)) {
         stopIllegalArgument("'testFileTargetDirectory' (", testFileTargetDirectory, ") must not end with 'testthat'",
-            functionName = ".downloadUnitTests", parameter = "testFileTargetDirectory", value = testFileTargetDirectory,
+            functionName = ".downloadUnitTests", 
+		parameter ="testFileTargetDirectory", value = testFileTargetDirectory,
             relatedParameter = "testthat"
         )
     }
@@ -328,7 +329,8 @@ NULL
             testFiles <- gsub(".*>", "", testFiles)
             testFiles <- gsub(" *$", "", testFiles)
             if (length(testFiles) == 0) {
-                stopIllegalArgument("online source does not contain any unit test files", functionName = ".downloadUnitTestsViaHttp")
+                stopIllegalArgument("online source does not contain any unit test files", 
+		functionName = ".downloadUnitTestsViaHttp")
             }
 
             startTime <- Sys.time()
@@ -362,18 +364,22 @@ NULL
         warning = function(w) {
             if (grepl("404 Not Found", w$message)) {
                 stopRuntimeIssue("failed to download unit test files (http): file ", sQuote(currentFile), " not found",
-                    functionName = ".downloadUnitTestsViaHttp", parameter = currentFile
+                    functionName = ".downloadUnitTestsViaHttp", 
+		parameter =currentFile
                 )
             }
         },
         error = function(e) {
             if (grepl(C_EXCEPTION_TYPE_RUNTIME_ISSUE, e$message)) {
-                stopRuntimeIssue(e$message, functionName = ".downloadUnitTestsViaHttp")
+                stopRuntimeIssue(e$message, 
+		functionName = ".downloadUnitTestsViaHttp")
             }
             .logDebug(e$message)
             stopRuntimeIssue("failed to download unit test files (http): ", "illegal 'token' / 'secret' or rpact version ",
                 version, " unknown",
-                functionName = ".downloadUnitTestsViaHttp", parameter = "token", relatedParameter = "secret"
+                functionName = ".downloadUnitTestsViaHttp", 
+		parameter ="token", 
+		relatedParameter ="secret"
             )
         },
         finally = {
@@ -437,7 +443,8 @@ NULL
             testFiles <- gsub("\\.R<.*", ".R", lines)
             testFiles <- gsub(".*>", "", testFiles)
             if (length(testFiles) == 0) {
-                stopIllegalArgument("online source does not contain any unit test files", functionName = ".downloadUnitTestsViaFtp")
+                stopIllegalArgument("online source does not contain any unit test files", 
+		functionName = ".downloadUnitTestsViaFtp")
             }
 
             startTime <- Sys.time()
@@ -474,7 +481,9 @@ NULL
             .logDebug(e$message)
             stopRuntimeIssue("failed to download unit test files (ftp): ", "illegal 'token' / 'secret' or rpact version ",
                 version, " unknown",
-                functionName = ".downloadUnitTestsViaFtp", parameter = "token", relatedParameter = "secret"
+                functionName = ".downloadUnitTestsViaFtp", 
+		parameter ="token", 
+		relatedParameter ="secret"
             )
         },
         finally = {
@@ -895,15 +904,18 @@ setupPackageTests <- function(token, secret) {
     .assertIsSingleCharacter(secret, "secret")
     installPath <- find.package("rpact")
     if (!dir.exists(installPath)) {
-        stopRuntimeIssue("the rpact package directory was not found", functionName = "setupPackageTests")
+        stopRuntimeIssue("the rpact package directory was not found", 
+		functionName = "setupPackageTests")
     }
 
     if (!dir.exists(file.path(installPath, "tests"))) {
-        stopRuntimeIssue("the rpact package directory does not contain a test directory", functionName = "setupPackageTests")
+        stopRuntimeIssue("the rpact package directory does not contain a test directory", 
+		functionName = "setupPackageTests")
     }
 
     if (!dir.exists(file.path(installPath, "tests", "testthat"))) {
-        stopRuntimeIssue("the rpact package directory does not contain a testthat directory", functionName = "setupPackageTests")
+        stopRuntimeIssue("the rpact package directory does not contain a testthat directory", 
+		functionName = "setupPackageTests")
     }
 
     tmpDir <- tempdir()
@@ -916,7 +928,8 @@ setupPackageTests <- function(token, secret) {
     if (!dir.exists(tmpTestsDir)) {
         stopRuntimeIssue("The test package directory was not created",
             parameter = "tmpTestsDir", value = tmpTestsDir,
-            constraint = "existing test package directory", functionName = "setupPackageTests"
+            constraint = "existing test package directory", 
+		functionName = "setupPackageTests"
         )
     }
 
@@ -1185,19 +1198,20 @@ testPackage <- function(
 
     if (grepl("/|:|\\\\", reportFileBaseName)) {
         stopIllegalArgument("'reportFileBaseName' (", dQuote(reportFileBaseName), ") ", "must not contain path separators or drive specifiers",
-            functionName = "testPackage", parameter = "reportFileBaseName", value = reportFileBaseName
+            functionName = "testPackage", 
+		parameter ="reportFileBaseName", value = reportFileBaseName
         )
     }
 
     if (!dir.exists(outDir)) {
-        stopIllegalArgument("test output directory '", outDir, "' does not exist",
+        stopIllegalArgument("test output directory ", .vQuote(outDir), " does not exist",
             functionName = "testPackage",
             parameter = "outDir", value = outDir
         )
     }
 
     if (outDir != "." && !grepl("^([a-zA-Z]{1,1}:)?(/|\\\\)", outDir, ignore.case = TRUE)) {
-        stopIllegalArgument("test output directory '", outDir, "' must be an absolute path",
+        stopIllegalArgument("test output directory ", .vQuote(outDir), " must be an absolute path",
             functionName = "testPackage",
             parameter = "outDir", value = outDir
         )
@@ -1208,7 +1222,7 @@ testPackage <- function(
     }
 
     if (!is.na(testFileDirectory) && !dir.exists(testFileDirectory)) {
-        stopIllegalArgument("test file directory '", testFileDirectory, "' does not exist",
+        stopIllegalArgument("test file directory ", .vQuote(testFileDirectory), " does not exist",
             functionName = "testPackage",
             parameter = "testFileDirectory", value = testFileDirectory
         )
@@ -1345,13 +1359,13 @@ testPackage <- function(
             "library(rpact)\n\n",
             'test_check("rpact", ',
             "reporter = MarkdownReporter$new(",
-            'outputFile = file.path("', testFileTargetDirectory, '", "', markdownReportFileName, '"), ',
+            'outputFile = file.path(', .dQuote(testFileTargetDirectory), ', ', .dQuote(markdownReportFileName), '), ',
             'outputSize = "', reportType, '", ',
             "openHtmlReport = ", openHtmlReport, ", ",
             "keepSourceFiles = ", keepSourceFiles, ", ",
             "testInstalledBasicPackages = ", testInstalledBasicPackages, ", ",
-            'author = "', author, '", ',
-            'scope = "', scope, '", ',
+            'author = ', .dQuote(author), ', ',
+            'scope = ', .dQuote(scope), ', ',
             'metaDataFile = "', metaDataFile, '"',
             ")",
             ")\n\n"
@@ -1480,7 +1494,7 @@ testPackage <- function(
             cat(resultMessage, "\n")
             .showResultsWereWrittenToDirectoryMessage(resultDir, reportFileNames, resultOuputFile)
         } else {
-            cat("No test results found in directory '", resultDir, "'\n", sep = "")
+            cat("No test results found in directory ", .vQuote(resultDir), "\n", sep = "")
             statusMessage <- "Installation qualification was not successful (no test results found)"
         }
     }
@@ -1613,12 +1627,12 @@ print.InstallationQualificationResult <- function(x, ...) {
 .showResultsWereWrittenToDirectoryMessage <- function(resultDir, reportFileName, resultOuputFile) {
     cat("Test results were written to directory \n")
     if (!is.null(reportFileName)) {
-        cat("'", resultDir, "' (see file", ifelse(length(reportFileName) == 1, "", "s"), " ",
+        cat(.vQuote(resultDir), " (see file", ifelse(length(reportFileName) == 1, "", "s"), " ",
             .arrayToString(sQuote(reportFileName), mode = "and"), ")\n",
             sep = ""
         )
     } else {
-        cat("'", resultDir, "' (see file ", sQuote(resultOuputFile), ")\n", sep = "")
+        cat(.vQuote(resultDir), " (see file ", sQuote(resultOuputFile), ")\n", sep = "")
     }
 }
 

--- a/R/f_quality_assurance.R
+++ b/R/f_quality_assurance.R
@@ -176,8 +176,8 @@ NULL
 
     if (grepl("testthat(/|\\\\)?$", testFileTargetDirectory)) {
         stopIllegalArgument("'testFileTargetDirectory' (", testFileTargetDirectory, ") must not end with 'testthat'",
-            functionName = ".downloadUnitTests", 
-		parameter ="testFileTargetDirectory", value = testFileTargetDirectory,
+            functionName = ".downloadUnitTests",
+            parameter = "testFileTargetDirectory", value = testFileTargetDirectory,
             relatedParameter = "testthat"
         )
     }
@@ -329,8 +329,9 @@ NULL
             testFiles <- gsub(".*>", "", testFiles)
             testFiles <- gsub(" *$", "", testFiles)
             if (length(testFiles) == 0) {
-                stopIllegalArgument("online source does not contain any unit test files", 
-		functionName = ".downloadUnitTestsViaHttp")
+                stopIllegalArgument("online source does not contain any unit test files",
+                    functionName = ".downloadUnitTestsViaHttp"
+                )
             }
 
             startTime <- Sys.time()
@@ -364,22 +365,23 @@ NULL
         warning = function(w) {
             if (grepl("404 Not Found", w$message)) {
                 stopRuntimeIssue("failed to download unit test files (http): file ", sQuote(currentFile), " not found",
-                    functionName = ".downloadUnitTestsViaHttp", 
-		parameter =currentFile
+                    functionName = ".downloadUnitTestsViaHttp",
+                    parameter = currentFile
                 )
             }
         },
         error = function(e) {
             if (grepl(C_EXCEPTION_TYPE_RUNTIME_ISSUE, e$message)) {
-                stopRuntimeIssue(e$message, 
-		functionName = ".downloadUnitTestsViaHttp")
+                stopRuntimeIssue(e$message,
+                    functionName = ".downloadUnitTestsViaHttp"
+                )
             }
             .logDebug(e$message)
             stopRuntimeIssue("failed to download unit test files (http): ", "illegal 'token' / 'secret' or rpact version ",
                 version, " unknown",
-                functionName = ".downloadUnitTestsViaHttp", 
-		parameter ="token", 
-		relatedParameter ="secret"
+                functionName = ".downloadUnitTestsViaHttp",
+                parameter = "token",
+                relatedParameter = "secret"
             )
         },
         finally = {
@@ -443,8 +445,9 @@ NULL
             testFiles <- gsub("\\.R<.*", ".R", lines)
             testFiles <- gsub(".*>", "", testFiles)
             if (length(testFiles) == 0) {
-                stopIllegalArgument("online source does not contain any unit test files", 
-		functionName = ".downloadUnitTestsViaFtp")
+                stopIllegalArgument("online source does not contain any unit test files",
+                    functionName = ".downloadUnitTestsViaFtp"
+                )
             }
 
             startTime <- Sys.time()
@@ -481,9 +484,9 @@ NULL
             .logDebug(e$message)
             stopRuntimeIssue("failed to download unit test files (ftp): ", "illegal 'token' / 'secret' or rpact version ",
                 version, " unknown",
-                functionName = ".downloadUnitTestsViaFtp", 
-		parameter ="token", 
-		relatedParameter ="secret"
+                functionName = ".downloadUnitTestsViaFtp",
+                parameter = "token",
+                relatedParameter = "secret"
             )
         },
         finally = {
@@ -904,18 +907,21 @@ setupPackageTests <- function(token, secret) {
     .assertIsSingleCharacter(secret, "secret")
     installPath <- find.package("rpact")
     if (!dir.exists(installPath)) {
-        stopRuntimeIssue("the rpact package directory was not found", 
-		functionName = "setupPackageTests")
+        stopRuntimeIssue("the rpact package directory was not found",
+            functionName = "setupPackageTests"
+        )
     }
 
     if (!dir.exists(file.path(installPath, "tests"))) {
-        stopRuntimeIssue("the rpact package directory does not contain a test directory", 
-		functionName = "setupPackageTests")
+        stopRuntimeIssue("the rpact package directory does not contain a test directory",
+            functionName = "setupPackageTests"
+        )
     }
 
     if (!dir.exists(file.path(installPath, "tests", "testthat"))) {
-        stopRuntimeIssue("the rpact package directory does not contain a testthat directory", 
-		functionName = "setupPackageTests")
+        stopRuntimeIssue("the rpact package directory does not contain a testthat directory",
+            functionName = "setupPackageTests"
+        )
     }
 
     tmpDir <- tempdir()
@@ -928,8 +934,8 @@ setupPackageTests <- function(token, secret) {
     if (!dir.exists(tmpTestsDir)) {
         stopRuntimeIssue("The test package directory was not created",
             parameter = "tmpTestsDir", value = tmpTestsDir,
-            constraint = "existing test package directory", 
-		functionName = "setupPackageTests"
+            constraint = "existing test package directory",
+            functionName = "setupPackageTests"
         )
     }
 
@@ -1198,8 +1204,8 @@ testPackage <- function(
 
     if (grepl("/|:|\\\\", reportFileBaseName)) {
         stopIllegalArgument("'reportFileBaseName' (", dQuote(reportFileBaseName), ") ", "must not contain path separators or drive specifiers",
-            functionName = "testPackage", 
-		parameter ="reportFileBaseName", value = reportFileBaseName
+            functionName = "testPackage",
+            parameter = "reportFileBaseName", value = reportFileBaseName
         )
     }
 
@@ -1359,13 +1365,13 @@ testPackage <- function(
             "library(rpact)\n\n",
             'test_check("rpact", ',
             "reporter = MarkdownReporter$new(",
-            'outputFile = file.path(', .dQuote(testFileTargetDirectory), ', ', .dQuote(markdownReportFileName), '), ',
+            "outputFile = file.path(", .dQuote(testFileTargetDirectory), ", ", .dQuote(markdownReportFileName), "), ",
             'outputSize = "', reportType, '", ',
             "openHtmlReport = ", openHtmlReport, ", ",
             "keepSourceFiles = ", keepSourceFiles, ", ",
             "testInstalledBasicPackages = ", testInstalledBasicPackages, ", ",
-            'author = ', .dQuote(author), ', ',
-            'scope = ', .dQuote(scope), ', ',
+            "author = ", .dQuote(author), ", ",
+            "scope = ", .dQuote(scope), ", ",
             'metaDataFile = "', metaDataFile, '"',
             ")",
             ")\n\n"

--- a/R/f_simulation_base_counts.R
+++ b/R/f_simulation_base_counts.R
@@ -333,10 +333,12 @@ getSimulationCounts <- function(
                         plannedCalendarTime[kMax], max(accrualTime) + followUpTime
                     ),
                     parameter = "plannedCalendarTime", value = plannedCalendarTime[kMax],
-                    constraint = "last plannedCalendarTime must equal max(accrualTime) + followUpTime", relatedParameter = c(
+                    constraint = "last plannedCalendarTime must equal max(accrualTime) + followUpTime", 
+		relatedParameter =c(
                         "accrualTime",
                         "followUpTime"
-                    ), relatedValue = list(accrualTime = accrualTime, followUpTime = followUpTime),
+                    ), 
+		relatedValue = list(accrualTime = accrualTime, followUpTime = followUpTime),
                     functionName = "getSimulationCounts"
                 )
             }

--- a/R/f_simulation_base_counts.R
+++ b/R/f_simulation_base_counts.R
@@ -333,12 +333,12 @@ getSimulationCounts <- function(
                         plannedCalendarTime[kMax], max(accrualTime) + followUpTime
                     ),
                     parameter = "plannedCalendarTime", value = plannedCalendarTime[kMax],
-                    constraint = "last plannedCalendarTime must equal max(accrualTime) + followUpTime", 
-		relatedParameter =c(
+                    constraint = "last plannedCalendarTime must equal max(accrualTime) + followUpTime",
+                    relatedParameter = c(
                         "accrualTime",
                         "followUpTime"
-                    ), 
-		relatedValue = list(accrualTime = accrualTime, followUpTime = followUpTime),
+                    ),
+                    relatedValue = list(accrualTime = accrualTime, followUpTime = followUpTime),
                     functionName = "getSimulationCounts"
                 )
             }

--- a/R/f_simulation_base_counts.R
+++ b/R/f_simulation_base_counts.R
@@ -329,7 +329,8 @@ getSimulationCounts <- function(
             if (abs(plannedCalendarTime[kMax] - max(accrualTime) - followUpTime) > 1e-04) {
                 stopConflictingArguments(
                     sprintf(
-                        paste0("Last 'plannedCalendarTime' (%s) ", "must be equal to %s (accrualTime + followUpTime)"),
+                        paste0("Last 'plannedCalendarTime' (%s) ", 
+                        "must be equal to %s (accrualTime + followUpTime)"),
                         plannedCalendarTime[kMax], max(accrualTime) + followUpTime
                     ),
                     parameter = "plannedCalendarTime", value = plannedCalendarTime[kMax],

--- a/R/f_simulation_base_means.R
+++ b/R/f_simulation_base_means.R
@@ -272,7 +272,9 @@ getSimulationMeans <- function(
         if (length(allocationRatioPlanned) == 1) {
             allocationRatioPlanned <- rep(allocationRatioPlanned, design$kMax)
         } else if (length(allocationRatioPlanned) != design$kMax) {
-            stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
+            stopIllegalArgument(
+                "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ",
+                "must have length 1 or ",
                 design$kMax, " (kMax)",
                 functionName = "getSimulationMeans",
                 parameter = "allocationRatioPlanned",
@@ -341,7 +343,9 @@ getSimulationMeans <- function(
         }
         if (any(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage < 0) &&
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage))) {
-            stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
+            stopIllegalArgument(
+                "'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), 
+                ") must be not smaller than minNumberOfSubjectsPerStage' (",
                 .arrayToString(minNumberOfSubjectsPerStage), ")",
                 functionName = "getSimulationMeans",
                 parameter = "maxNumberOfSubjectsPerStage",

--- a/R/f_simulation_base_means.R
+++ b/R/f_simulation_base_means.R
@@ -244,7 +244,8 @@ getSimulationMeans <- function(
     simulationResults <- SimulationResultsMeans$new(design, showStatistics = showStatistics)
 
     if (design$sided == 2) {
-        stopIllegalArgument("only one-sided case is implemented for the simulation design", functionName = "getSimulationMeans")
+        stopIllegalArgument("only one-sided case is implemented for the simulation design", 
+		functionName = "getSimulationMeans")
     }
 
     if (groups == 1L) {
@@ -272,7 +273,8 @@ getSimulationMeans <- function(
         } else if (length(allocationRatioPlanned) != design$kMax) {
             stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
                 design$kMax, " (kMax)",
-                functionName = "getSimulationMeans", parameter = "allocationRatioPlanned",
+                functionName = "getSimulationMeans", 
+		parameter ="allocationRatioPlanned",
                 value = allocationRatioPlanned
             )
         }
@@ -331,14 +333,16 @@ getSimulationMeans <- function(
     if (design$kMax > 1) {
         if (!normalApproximation) {
             if (!all(is.na(minNumberOfSubjectsPerStage)) && (any(minNumberOfSubjectsPerStage < groups * 2))) {
-                stopIllegalArgument("minNumberOfSubjectsPerStage not correctly specified", functionName = "getSimulationMeans")
+                stopIllegalArgument("minNumberOfSubjectsPerStage not correctly specified", 
+		functionName = "getSimulationMeans")
             }
         }
         if (any(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage < 0) &&
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage))) {
             stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
                 .arrayToString(minNumberOfSubjectsPerStage), ")",
-                functionName = "getSimulationMeans", parameter = "maxNumberOfSubjectsPerStage",
+                functionName = "getSimulationMeans", 
+		parameter ="maxNumberOfSubjectsPerStage",
                 value = maxNumberOfSubjectsPerStage
             )
         }

--- a/R/f_simulation_base_means.R
+++ b/R/f_simulation_base_means.R
@@ -244,8 +244,9 @@ getSimulationMeans <- function(
     simulationResults <- SimulationResultsMeans$new(design, showStatistics = showStatistics)
 
     if (design$sided == 2) {
-        stopIllegalArgument("only one-sided case is implemented for the simulation design", 
-		functionName = "getSimulationMeans")
+        stopIllegalArgument("only one-sided case is implemented for the simulation design",
+            functionName = "getSimulationMeans"
+        )
     }
 
     if (groups == 1L) {
@@ -273,8 +274,8 @@ getSimulationMeans <- function(
         } else if (length(allocationRatioPlanned) != design$kMax) {
             stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
                 design$kMax, " (kMax)",
-                functionName = "getSimulationMeans", 
-		parameter ="allocationRatioPlanned",
+                functionName = "getSimulationMeans",
+                parameter = "allocationRatioPlanned",
                 value = allocationRatioPlanned
             )
         }
@@ -333,16 +334,17 @@ getSimulationMeans <- function(
     if (design$kMax > 1) {
         if (!normalApproximation) {
             if (!all(is.na(minNumberOfSubjectsPerStage)) && (any(minNumberOfSubjectsPerStage < groups * 2))) {
-                stopIllegalArgument("minNumberOfSubjectsPerStage not correctly specified", 
-		functionName = "getSimulationMeans")
+                stopIllegalArgument("minNumberOfSubjectsPerStage not correctly specified",
+                    functionName = "getSimulationMeans"
+                )
             }
         }
         if (any(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage < 0) &&
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage))) {
             stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
                 .arrayToString(minNumberOfSubjectsPerStage), ")",
-                functionName = "getSimulationMeans", 
-		parameter ="maxNumberOfSubjectsPerStage",
+                functionName = "getSimulationMeans",
+                parameter = "maxNumberOfSubjectsPerStage",
                 value = maxNumberOfSubjectsPerStage
             )
         }

--- a/R/f_simulation_base_rates.R
+++ b/R/f_simulation_base_rates.R
@@ -271,7 +271,8 @@ getSimulationRates <- function(
     .assertIsValidPlannedSubjectsOrEvents(design, plannedSubjects, parameterName = "plannedSubjects")
 
     if (design$sided == 2) {
-        stopIllegalArgument("only one-sided case is implemented for the simulation design", functionName = "getSimulationRates")
+        stopIllegalArgument("only one-sided case is implemented for the simulation design", 
+		functionName = "getSimulationRates")
     }
 
     if (!normalApproximation && (groups == 2) && (riskRatio || (thetaH0 != 0))) {
@@ -307,7 +308,8 @@ getSimulationRates <- function(
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage))) {
             stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
                 .arrayToString(minNumberOfSubjectsPerStage), ")",
-                functionName = "getSimulationRates", parameter = "maxNumberOfSubjectsPerStage",
+                functionName = "getSimulationRates", 
+		parameter ="maxNumberOfSubjectsPerStage",
                 value = maxNumberOfSubjectsPerStage
             )
         }
@@ -398,7 +400,8 @@ getSimulationRates <- function(
         } else if (length(allocationRatioPlanned) != design$kMax) {
             stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
                 design$kMax, " (kMax)",
-                functionName = "getSimulationRates", parameter = "allocationRatioPlanned",
+                functionName = "getSimulationRates", 
+		parameter ="allocationRatioPlanned",
                 value = allocationRatioPlanned
             )
         }

--- a/R/f_simulation_base_rates.R
+++ b/R/f_simulation_base_rates.R
@@ -307,7 +307,9 @@ getSimulationRates <- function(
     if (design$kMax > 1) {
         if (any(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage < 0) &&
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage))) {
-            stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
+            stopIllegalArgument(
+                "'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), 
+                ") must be not smaller than minNumberOfSubjectsPerStage' (",
                 .arrayToString(minNumberOfSubjectsPerStage), ")",
                 functionName = "getSimulationRates",
                 parameter = "maxNumberOfSubjectsPerStage",
@@ -399,7 +401,9 @@ getSimulationRates <- function(
         if (length(allocationRatioPlanned) == 1) {
             allocationRatioPlanned <- rep(allocationRatioPlanned, design$kMax)
         } else if (length(allocationRatioPlanned) != design$kMax) {
-            stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
+            stopIllegalArgument(
+                "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", 
+                "must have length 1 or ",
                 design$kMax, " (kMax)",
                 functionName = "getSimulationRates",
                 parameter = "allocationRatioPlanned",

--- a/R/f_simulation_base_rates.R
+++ b/R/f_simulation_base_rates.R
@@ -271,8 +271,9 @@ getSimulationRates <- function(
     .assertIsValidPlannedSubjectsOrEvents(design, plannedSubjects, parameterName = "plannedSubjects")
 
     if (design$sided == 2) {
-        stopIllegalArgument("only one-sided case is implemented for the simulation design", 
-		functionName = "getSimulationRates")
+        stopIllegalArgument("only one-sided case is implemented for the simulation design",
+            functionName = "getSimulationRates"
+        )
     }
 
     if (!normalApproximation && (groups == 2) && (riskRatio || (thetaH0 != 0))) {
@@ -308,8 +309,8 @@ getSimulationRates <- function(
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage))) {
             stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
                 .arrayToString(minNumberOfSubjectsPerStage), ")",
-                functionName = "getSimulationRates", 
-		parameter ="maxNumberOfSubjectsPerStage",
+                functionName = "getSimulationRates",
+                parameter = "maxNumberOfSubjectsPerStage",
                 value = maxNumberOfSubjectsPerStage
             )
         }
@@ -400,8 +401,8 @@ getSimulationRates <- function(
         } else if (length(allocationRatioPlanned) != design$kMax) {
             stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
                 design$kMax, " (kMax)",
-                functionName = "getSimulationRates", 
-		parameter ="allocationRatioPlanned",
+                functionName = "getSimulationRates",
+                parameter = "allocationRatioPlanned",
                 value = allocationRatioPlanned
             )
         }

--- a/R/f_simulation_base_survival.R
+++ b/R/f_simulation_base_survival.R
@@ -46,17 +46,17 @@ NULL
     if (pwsTimeObject$kappa != 1) {
         if (length(pwsTimeObject$lambda1) != 1) {
             stopIllegalArgument("if 'kappa' != 1 then 'lambda1' (", .arrayToString(pwsTimeObject$lambda1), ") must be a single numeric value",
-                functionName = ".isLambdaBasedSimulationEnabled", 
-		parameter ="kappa", 
-		relatedParameter ="lambda1",
+                functionName = ".isLambdaBasedSimulationEnabled",
+                parameter = "kappa",
+                relatedParameter = "lambda1",
                 relatedValue = pwsTimeObject$lambda1
             )
         }
         if (length(pwsTimeObject$lambda2) != 1) {
             stopIllegalArgument("if 'kappa' != 1 then 'lambda2' (", .arrayToString(pwsTimeObject$lambda2), ") must be a single numeric value",
-                functionName = ".isLambdaBasedSimulationEnabled", 
-		parameter ="kappa", 
-		relatedParameter ="lambda2",
+                functionName = ".isLambdaBasedSimulationEnabled",
+                parameter = "kappa",
+                relatedParameter = "lambda2",
                 relatedValue = pwsTimeObject$lambda2
             )
         }
@@ -372,17 +372,18 @@ getSimulationSurvival <- function(
         )
     }
     if (design$sided == 2) {
-        stopIllegalArgument("Only one-sided case is implemented for the survival simulation design", 
-		functionName = "getSimulationSurvival")
+        stopIllegalArgument("Only one-sided case is implemented for the survival simulation design",
+            functionName = "getSimulationSurvival"
+        )
     }
     if (!all(is.na(lambda2)) && !all(is.na(lambda1)) &&
             length(lambda2) != length(lambda1) && length(lambda2) > 1) {
         stopIllegalArgument("length of 'lambda2' (", length(lambda2), ") must be equal to length of 'lambda1' (",
             length(lambda1), ")",
-            functionName = "getSimulationSurvival", 
-		parameter ="lambda2", value = length(lambda2),
-            relatedParameter = "lambda1", 
-		relatedValue = length(lambda1)
+            functionName = "getSimulationSurvival",
+            parameter = "lambda2", value = length(lambda2),
+            relatedParameter = "lambda1",
+            relatedValue = length(lambda1)
         )
     }
     if (all(is.na(lambda2)) && !all(is.na(lambda1))) {
@@ -395,9 +396,9 @@ getSimulationSurvival <- function(
     if (!all(is.na(lambda2)) && is.list(piecewiseSurvivalTime)) {
         stopIllegalArgument("'piecewiseSurvivalTime' needs to be a numeric vector and not a list ", "because 'lambda2' (", .arrayToString(lambda2),
             ") is defined separately",
-            functionName = "getSimulationSurvival", 
-		parameter ="piecewiseSurvivalTime", 
-		relatedParameter ="lambda2",
+            functionName = "getSimulationSurvival",
+            parameter = "piecewiseSurvivalTime",
+            relatedParameter = "lambda2",
             relatedValue = lambda2, value = piecewiseSurvivalTime
         )
     }
@@ -436,8 +437,8 @@ getSimulationSurvival <- function(
                     !all(is.na(maxNumberOfEventsPerStage - minNumberOfEventsPerStage))) {
                 stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
-                    functionName = "getSimulationSurvival", 
-		parameter ="maxNumberOfEventsPerStage",
+                    functionName = "getSimulationSurvival",
+                    parameter = "maxNumberOfEventsPerStage",
                     value = maxNumberOfEventsPerStage
                 )
             }
@@ -473,13 +474,13 @@ getSimulationSurvival <- function(
         if (identical(accrualIntensity, 1L)) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = "getSimulationSurvival",
-                parameter = "accrualIntensity", 
-		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity",
+                relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
-            functionName = "getSimulationSurvival", 
-		parameter ="maxNumberOfSubjects",
+            functionName = "getSimulationSurvival",
+            parameter = "maxNumberOfSubjects",
             value = maxNumberOfSubjects
         )
     }
@@ -781,8 +782,9 @@ getSimulationSurvival <- function(
 
     overview <- resultData$overview
     if (length(overview) == 0 || nrow(overview) == 0) {
-        stopRuntimeIssue("no simulation results calculated", 
-		functionName = "getSimulationSurvival")
+        stopRuntimeIssue("no simulation results calculated",
+            functionName = "getSimulationSurvival"
+        )
     }
 
     n <- nrow(overview)

--- a/R/f_simulation_base_survival.R
+++ b/R/f_simulation_base_survival.R
@@ -45,7 +45,9 @@ NULL
 
     if (pwsTimeObject$kappa != 1) {
         if (length(pwsTimeObject$lambda1) != 1) {
-            stopIllegalArgument("if 'kappa' != 1 then 'lambda1' (", .arrayToString(pwsTimeObject$lambda1), ") must be a single numeric value",
+            stopIllegalArgument(
+                "if 'kappa' != 1 then 'lambda1' (", .arrayToString(pwsTimeObject$lambda1),
+                ") must be a single numeric value",
                 functionName = ".isLambdaBasedSimulationEnabled",
                 parameter = "kappa",
                 relatedParameter = "lambda1",
@@ -53,7 +55,9 @@ NULL
             )
         }
         if (length(pwsTimeObject$lambda2) != 1) {
-            stopIllegalArgument("if 'kappa' != 1 then 'lambda2' (", .arrayToString(pwsTimeObject$lambda2), ") must be a single numeric value",
+            stopIllegalArgument(
+                "if 'kappa' != 1 then 'lambda2' (", .arrayToString(pwsTimeObject$lambda2),
+                ") must be a single numeric value",
                 functionName = ".isLambdaBasedSimulationEnabled",
                 parameter = "kappa",
                 relatedParameter = "lambda2",
@@ -378,10 +382,12 @@ getSimulationSurvival <- function(
     }
     if (!all(is.na(lambda2)) && !all(is.na(lambda1)) &&
             length(lambda2) != length(lambda1) && length(lambda2) > 1) {
-        stopIllegalArgument("length of 'lambda2' (", length(lambda2), ") must be equal to length of 'lambda1' (",
-            length(lambda1), ")",
+        stopIllegalArgument(
+            "length of 'lambda2' (", length(lambda2), ") must be equal to ",
+            "length of 'lambda1' (", length(lambda1), ")",
             functionName = "getSimulationSurvival",
-            parameter = "lambda2", value = length(lambda2),
+            parameter = "lambda2",
+            value = length(lambda2),
             relatedParameter = "lambda1",
             relatedValue = length(lambda1)
         )
@@ -394,12 +400,14 @@ getSimulationSurvival <- function(
         lambda1 <- NA_real_
     }
     if (!all(is.na(lambda2)) && is.list(piecewiseSurvivalTime)) {
-        stopIllegalArgument("'piecewiseSurvivalTime' needs to be a numeric vector and not a list ", "because 'lambda2' (", .arrayToString(lambda2),
-            ") is defined separately",
+        stopIllegalArgument(
+            "'piecewiseSurvivalTime' needs to be a numeric vector and not a list ",
+            "because 'lambda2' (", .arrayToString(lambda2), ") is defined separately",
             functionName = "getSimulationSurvival",
             parameter = "piecewiseSurvivalTime",
             relatedParameter = "lambda2",
-            relatedValue = lambda2, value = piecewiseSurvivalTime
+            relatedValue = lambda2,
+            value = piecewiseSurvivalTime
         )
     }
     thetaH1 <- .ignoreParameterIfNotUsed(
@@ -435,7 +443,9 @@ getSimulationSurvival <- function(
         if (design$kMax > 1) {
             if (any(maxNumberOfEventsPerStage - minNumberOfEventsPerStage < 0) &&
                     !all(is.na(maxNumberOfEventsPerStage - minNumberOfEventsPerStage))) {
-                stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than minNumberOfEventsPerStage' (",
+                stopIllegalArgument(
+                    "'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage),
+                    ") must be not smaller than minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = "getSimulationSurvival",
                     parameter = "maxNumberOfEventsPerStage",

--- a/R/f_simulation_base_survival.R
+++ b/R/f_simulation_base_survival.R
@@ -46,13 +46,17 @@ NULL
     if (pwsTimeObject$kappa != 1) {
         if (length(pwsTimeObject$lambda1) != 1) {
             stopIllegalArgument("if 'kappa' != 1 then 'lambda1' (", .arrayToString(pwsTimeObject$lambda1), ") must be a single numeric value",
-                functionName = ".isLambdaBasedSimulationEnabled", parameter = "kappa", relatedParameter = "lambda1",
+                functionName = ".isLambdaBasedSimulationEnabled", 
+		parameter ="kappa", 
+		relatedParameter ="lambda1",
                 relatedValue = pwsTimeObject$lambda1
             )
         }
         if (length(pwsTimeObject$lambda2) != 1) {
             stopIllegalArgument("if 'kappa' != 1 then 'lambda2' (", .arrayToString(pwsTimeObject$lambda2), ") must be a single numeric value",
-                functionName = ".isLambdaBasedSimulationEnabled", parameter = "kappa", relatedParameter = "lambda2",
+                functionName = ".isLambdaBasedSimulationEnabled", 
+		parameter ="kappa", 
+		relatedParameter ="lambda2",
                 relatedValue = pwsTimeObject$lambda2
             )
         }
@@ -368,14 +372,17 @@ getSimulationSurvival <- function(
         )
     }
     if (design$sided == 2) {
-        stopIllegalArgument("Only one-sided case is implemented for the survival simulation design", functionName = "getSimulationSurvival")
+        stopIllegalArgument("Only one-sided case is implemented for the survival simulation design", 
+		functionName = "getSimulationSurvival")
     }
     if (!all(is.na(lambda2)) && !all(is.na(lambda1)) &&
             length(lambda2) != length(lambda1) && length(lambda2) > 1) {
         stopIllegalArgument("length of 'lambda2' (", length(lambda2), ") must be equal to length of 'lambda1' (",
             length(lambda1), ")",
-            functionName = "getSimulationSurvival", parameter = "lambda2", value = length(lambda2),
-            relatedParameter = "lambda1", relatedValue = length(lambda1)
+            functionName = "getSimulationSurvival", 
+		parameter ="lambda2", value = length(lambda2),
+            relatedParameter = "lambda1", 
+		relatedValue = length(lambda1)
         )
     }
     if (all(is.na(lambda2)) && !all(is.na(lambda1))) {
@@ -388,7 +395,9 @@ getSimulationSurvival <- function(
     if (!all(is.na(lambda2)) && is.list(piecewiseSurvivalTime)) {
         stopIllegalArgument("'piecewiseSurvivalTime' needs to be a numeric vector and not a list ", "because 'lambda2' (", .arrayToString(lambda2),
             ") is defined separately",
-            functionName = "getSimulationSurvival", parameter = "piecewiseSurvivalTime", relatedParameter = "lambda2",
+            functionName = "getSimulationSurvival", 
+		parameter ="piecewiseSurvivalTime", 
+		relatedParameter ="lambda2",
             relatedValue = lambda2, value = piecewiseSurvivalTime
         )
     }
@@ -427,7 +436,8 @@ getSimulationSurvival <- function(
                     !all(is.na(maxNumberOfEventsPerStage - minNumberOfEventsPerStage))) {
                 stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
-                    functionName = "getSimulationSurvival", parameter = "maxNumberOfEventsPerStage",
+                    functionName = "getSimulationSurvival", 
+		parameter ="maxNumberOfEventsPerStage",
                     value = maxNumberOfEventsPerStage
                 )
             }
@@ -463,11 +473,13 @@ getSimulationSurvival <- function(
         if (identical(accrualIntensity, 1L)) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = "getSimulationSurvival",
-                parameter = "accrualIntensity", relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity", 
+		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
-            functionName = "getSimulationSurvival", parameter = "maxNumberOfSubjects",
+            functionName = "getSimulationSurvival", 
+		parameter ="maxNumberOfSubjects",
             value = maxNumberOfSubjects
         )
     }
@@ -769,7 +781,8 @@ getSimulationSurvival <- function(
 
     overview <- resultData$overview
     if (length(overview) == 0 || nrow(overview) == 0) {
-        stopRuntimeIssue("no simulation results calculated", functionName = "getSimulationSurvival")
+        stopRuntimeIssue("no simulation results calculated", 
+		functionName = "getSimulationSurvival")
     }
 
     n <- nrow(overview)

--- a/R/f_simulation_calc_subjects_function.R
+++ b/R/f_simulation_calc_subjects_function.R
@@ -211,7 +211,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                 "the function definition must match 'myFunctionName <- (myArgs) { myCode }'"
             ),
             functionName = ".regexprCalcSubjectsFunction",
-            parameter = "cmd", value = cmd, relatedParameter = "language", relatedValue = language
+            parameter = "cmd", value = cmd, 
+		relatedParameter ="language", 
+		relatedValue = language
         )
     }
     len <- attr(x1, "match.length")
@@ -246,7 +248,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
         ), " ", ifelse(length(invalidArgs) == 1, "is", "are"), " invalid (the ", length(validArgs),
         " valid arguments can be found in the reference manual)",
         functionName = ".getCalcSubjectsFunctionRCode",
-        parameter = "invalidArgs", value = invalidArgs, relatedParameter = "validArgs", relatedValue = length(validArgs)
+        parameter = "invalidArgs", value = invalidArgs, 
+		relatedParameter ="validArgs", 
+		relatedValue = length(validArgs)
         )
     }
 
@@ -269,7 +273,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
     if (!grepl("#include <Rcpp.h>", cppCodeBody)) {
         stopRuntimeIssue("'cppCodeBody' must contain '#include <Rcpp.h>'",
             functionName = ".getCalcSubjectsFunctionCppCode",
-            parameter = "cppCodeBody", relatedParameter = "#include <Rcpp.h>"
+            parameter = "cppCodeBody", 
+		relatedParameter ="#include <Rcpp.h>"
         )
     }
 
@@ -294,7 +299,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
         ), " ", ifelse(length(invalidArgs) == 1, "is", "are"), " invalid (the ", length(validArgs),
         " valid arguments can be found in the reference manual)",
         functionName = ".getCalcSubjectsFunctionCppCode",
-        parameter = "invalidArgs", value = invalidArgs, relatedParameter = "validArgs", relatedValue = length(validArgs)
+        parameter = "invalidArgs", value = invalidArgs, 
+		relatedParameter ="validArgs", 
+		relatedValue = length(validArgs)
         )
     }
 
@@ -345,7 +352,7 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
 
     if (design$kMax == 1) {
         if (!is.null(calcFunction)) {
-            warning("'", functionFieldName, "' will be ignored for fixed sample design", call. = FALSE)
+            warning(.pQuote(functionFieldName), " will be ignored for fixed sample design", call. = FALSE)
         }
         simulationResults$.setParameterType(functionFieldName, C_PARAM_NOT_APPLICABLE)
         return(list(
@@ -388,8 +395,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
     }
 
     if (!is.character(calcFunction)) {
-        stopIllegalArgument("'", functionFieldName, "' must be a function or a character ", "string specifying a function written in R/C++/Rcpp",
-            functionName = ".getCalcSubjectsFunction", parameter = functionFieldName
+        stopIllegalArgument(.pQuote(functionFieldName), " must be a function or a character ", "string specifying a function written in R/C++/Rcpp",
+            functionName = ".getCalcSubjectsFunction", 
+		parameter =functionFieldName
         )
     }
 
@@ -400,7 +408,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                         !isTRUE(eval(parse(text = "pkgbuild::has_build_tools(debug = FALSE)")))) {
                     stopRuntimeIssue("no C++ compiler found", ifelse(.Platform$OS.type == "windows", " (install RTools to solve the issue)",
                         ""
-                    ), parameter = "calcFunction", value = calcFunction, constraint = "available C++ compiler", functionName = ".getCalcSubjectsFunction")
+                    ), 
+		parameter ="calcFunction", value = calcFunction, constraint = "available C++ compiler", 
+		functionName = ".getCalcSubjectsFunction")
                 }
 
                 survivalEnabled <- inherits(simulationResults, "SimulationResultsSurvival")
@@ -414,19 +424,23 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                 ))
                 functionName <- result$functions
                 if (length(functionName) == 0) {
-                    stopRuntimeIssue("C++ compilation returned an unexpected value", functionName = ".getCalcSubjectsFunction")
+                    stopRuntimeIssue("C++ compilation returned an unexpected value", 
+		functionName = ".getCalcSubjectsFunction")
                 }
                 if (functionName != expectedFunctionName) {
                     stopRuntimeIssue("C++ compilation returned an unexpected ", "function name (", sQuote(functionName),
                         " instead of ", sQuote(expectedFunctionName), ")",
-                        functionName = ".getCalcSubjectsFunction", parameter = functionName,
+                        functionName = ".getCalcSubjectsFunction", 
+		parameter =functionName,
                         relatedParameter = expectedFunctionName
                     )
                 }
 
                 simulationResults[[functionFieldName]] <- calcFunction
                 if (!exists(functionName)) {
-                    stopRuntimeIssue(sQuote(functionName), " is missing", functionName = ".getCalcSubjectsFunction", parameter = functionName)
+                    stopRuntimeIssue(sQuote(functionName), " is missing", 
+		functionName = ".getCalcSubjectsFunction", 
+		parameter =functionName)
                 }
                 if (survivalEnabled) {
                     return(list(
@@ -452,9 +466,10 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                     ),
                     verbose = FALSE, showOutput = TRUE
                 )
-                stopRuntimeIssue("Failed to compile '", functionFieldName, "': ", e$message,
+                stopRuntimeIssue("Failed to compile ", .pQuote(functionFieldName), ": ", e$message,
                     parameter = functionFieldName,
-                    value = calcFunction, constraint = "valid compilable C++ code", functionName = ".getCalcSubjectsFunction"
+                    value = calcFunction, constraint = "valid compilable C++ code", 
+		functionName = ".getCalcSubjectsFunction"
                 )
             }
         )
@@ -471,9 +486,10 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
             ))
         },
         error = function(e) {
-            stopRuntimeIssue("Failed to evaluate and parse '", functionFieldName, "': ", e$message,
+            stopRuntimeIssue("Failed to evaluate and parse ", .pQuote(functionFieldName), ": ", e$message,
                 parameter = functionFieldName,
-                value = calcFunction, constraint = "valid R function code", functionName = ".getCalcSubjectsFunction"
+                value = calcFunction, constraint = "valid R function code", 
+		functionName = ".getCalcSubjectsFunction"
             )
         }
     )

--- a/R/f_simulation_calc_subjects_function.R
+++ b/R/f_simulation_calc_subjects_function.R
@@ -211,9 +211,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                 "the function definition must match 'myFunctionName <- (myArgs) { myCode }'"
             ),
             functionName = ".regexprCalcSubjectsFunction",
-            parameter = "cmd", value = cmd, 
-		relatedParameter ="language", 
-		relatedValue = language
+            parameter = "cmd", value = cmd,
+            relatedParameter = "language",
+            relatedValue = language
         )
     }
     len <- attr(x1, "match.length")
@@ -248,9 +248,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
         ), " ", ifelse(length(invalidArgs) == 1, "is", "are"), " invalid (the ", length(validArgs),
         " valid arguments can be found in the reference manual)",
         functionName = ".getCalcSubjectsFunctionRCode",
-        parameter = "invalidArgs", value = invalidArgs, 
-		relatedParameter ="validArgs", 
-		relatedValue = length(validArgs)
+        parameter = "invalidArgs", value = invalidArgs,
+        relatedParameter = "validArgs",
+        relatedValue = length(validArgs)
         )
     }
 
@@ -273,8 +273,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
     if (!grepl("#include <Rcpp.h>", cppCodeBody)) {
         stopRuntimeIssue("'cppCodeBody' must contain '#include <Rcpp.h>'",
             functionName = ".getCalcSubjectsFunctionCppCode",
-            parameter = "cppCodeBody", 
-		relatedParameter ="#include <Rcpp.h>"
+            parameter = "cppCodeBody",
+            relatedParameter = "#include <Rcpp.h>"
         )
     }
 
@@ -299,9 +299,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
         ), " ", ifelse(length(invalidArgs) == 1, "is", "are"), " invalid (the ", length(validArgs),
         " valid arguments can be found in the reference manual)",
         functionName = ".getCalcSubjectsFunctionCppCode",
-        parameter = "invalidArgs", value = invalidArgs, 
-		relatedParameter ="validArgs", 
-		relatedValue = length(validArgs)
+        parameter = "invalidArgs", value = invalidArgs,
+        relatedParameter = "validArgs",
+        relatedValue = length(validArgs)
         )
     }
 
@@ -396,8 +396,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
 
     if (!is.character(calcFunction)) {
         stopIllegalArgument(.pQuote(functionFieldName), " must be a function or a character ", "string specifying a function written in R/C++/Rcpp",
-            functionName = ".getCalcSubjectsFunction", 
-		parameter =functionFieldName
+            functionName = ".getCalcSubjectsFunction",
+            parameter = functionFieldName
         )
     }
 
@@ -408,9 +408,10 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                         !isTRUE(eval(parse(text = "pkgbuild::has_build_tools(debug = FALSE)")))) {
                     stopRuntimeIssue("no C++ compiler found", ifelse(.Platform$OS.type == "windows", " (install RTools to solve the issue)",
                         ""
-                    ), 
-		parameter ="calcFunction", value = calcFunction, constraint = "available C++ compiler", 
-		functionName = ".getCalcSubjectsFunction")
+                    ),
+                    parameter = "calcFunction", value = calcFunction, constraint = "available C++ compiler",
+                    functionName = ".getCalcSubjectsFunction"
+                    )
                 }
 
                 survivalEnabled <- inherits(simulationResults, "SimulationResultsSurvival")
@@ -424,23 +425,25 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                 ))
                 functionName <- result$functions
                 if (length(functionName) == 0) {
-                    stopRuntimeIssue("C++ compilation returned an unexpected value", 
-		functionName = ".getCalcSubjectsFunction")
+                    stopRuntimeIssue("C++ compilation returned an unexpected value",
+                        functionName = ".getCalcSubjectsFunction"
+                    )
                 }
                 if (functionName != expectedFunctionName) {
                     stopRuntimeIssue("C++ compilation returned an unexpected ", "function name (", sQuote(functionName),
                         " instead of ", sQuote(expectedFunctionName), ")",
-                        functionName = ".getCalcSubjectsFunction", 
-		parameter =functionName,
+                        functionName = ".getCalcSubjectsFunction",
+                        parameter = functionName,
                         relatedParameter = expectedFunctionName
                     )
                 }
 
                 simulationResults[[functionFieldName]] <- calcFunction
                 if (!exists(functionName)) {
-                    stopRuntimeIssue(sQuote(functionName), " is missing", 
-		functionName = ".getCalcSubjectsFunction", 
-		parameter =functionName)
+                    stopRuntimeIssue(sQuote(functionName), " is missing",
+                        functionName = ".getCalcSubjectsFunction",
+                        parameter = functionName
+                    )
                 }
                 if (survivalEnabled) {
                     return(list(
@@ -468,8 +471,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                 )
                 stopRuntimeIssue("Failed to compile ", .pQuote(functionFieldName), ": ", e$message,
                     parameter = functionFieldName,
-                    value = calcFunction, constraint = "valid compilable C++ code", 
-		functionName = ".getCalcSubjectsFunction"
+                    value = calcFunction, constraint = "valid compilable C++ code",
+                    functionName = ".getCalcSubjectsFunction"
                 )
             }
         )
@@ -488,8 +491,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
         error = function(e) {
             stopRuntimeIssue("Failed to evaluate and parse ", .pQuote(functionFieldName), ": ", e$message,
                 parameter = functionFieldName,
-                value = calcFunction, constraint = "valid R function code", 
-		functionName = ".getCalcSubjectsFunction"
+                value = calcFunction, constraint = "valid R function code",
+                functionName = ".getCalcSubjectsFunction"
             )
         }
     )

--- a/R/f_simulation_calc_subjects_function.R
+++ b/R/f_simulation_calc_subjects_function.R
@@ -207,7 +207,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
     x1 <- regexpr(pattern, cmd)
     if (x1 == -1) {
         stopIllegalArgument(
-            ifelse(language == "cpp", "the function definition must match 'double myFunctionName(myArgs) { myCode; }'",
+            ifelse(language == "cpp",
+                "the function definition must match 'double myFunctionName(myArgs) { myCode; }'",
                 "the function definition must match 'myFunctionName <- (myArgs) { myCode }'"
             ),
             functionName = ".regexprCalcSubjectsFunction",
@@ -243,14 +244,16 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
     args <- args[args != "..."]
     if (!all(args %in% validArgs)) {
         invalidArgs <- args[!(args %in% validArgs)]
-        stopIllegalArgument("the argument", ifelse(length(invalidArgs) == 1, "", "s"), " ", .arrayToString(invalidArgs,
-            encapsulate = TRUE
-        ), " ", ifelse(length(invalidArgs) == 1, "is", "are"), " invalid (the ", length(validArgs),
-        " valid arguments can be found in the reference manual)",
-        functionName = ".getCalcSubjectsFunctionRCode",
-        parameter = "invalidArgs", value = invalidArgs,
-        relatedParameter = "validArgs",
-        relatedValue = length(validArgs)
+        stopIllegalArgument(
+            "the argument", ifelse(length(invalidArgs) == 1, "", "s"), " ",
+            .arrayToString(invalidArgs, encapsulate = TRUE), " ",
+            ifelse(length(invalidArgs) == 1, "is", "are"), " invalid (the ", length(validArgs),
+            " valid arguments can be found in the reference manual)",
+            functionName = ".getCalcSubjectsFunctionRCode",
+            parameter = "invalidArgs",
+            value = invalidArgs,
+            relatedParameter = "validArgs",
+            relatedValue = length(validArgs)
         )
     }
 
@@ -271,7 +274,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
 
     cppCodeBody <- paste0(cppCodeBody, collapse = "\n")
     if (!grepl("#include <Rcpp.h>", cppCodeBody)) {
-        stopRuntimeIssue("'cppCodeBody' must contain '#include <Rcpp.h>'",
+        stopRuntimeIssue(
+            "'cppCodeBody' must contain '#include <Rcpp.h>'",
             functionName = ".getCalcSubjectsFunctionCppCode",
             parameter = "cppCodeBody",
             relatedParameter = "#include <Rcpp.h>"
@@ -341,7 +345,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
         cppCodeBodyType <- C_SIMULATION_CALC_SUBJECTS_FUNCTION_BASE_SURVIVAL
     }
     if (is.na(cppCodeBodyType)) {
-        stopRuntimeIssue(".getCalcSubjectsFunction() is not implemented for object ", class(simulationResults)[1],
+        stopRuntimeIssue(
+            ".getCalcSubjectsFunction() is not implemented for object ",
+            class(simulationResults)[1],
             functionName = ".getCalcSubjectsFunction"
         )
     }
@@ -395,7 +401,8 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
     }
 
     if (!is.character(calcFunction)) {
-        stopIllegalArgument(.pQuote(functionFieldName), " must be a function or a character ", "string specifying a function written in R/C++/Rcpp",
+        stopIllegalArgument(.pQuote(functionFieldName), " must be a function or a character ",
+            "string specifying a function written in R/C++/Rcpp",
             functionName = ".getCalcSubjectsFunction",
             parameter = functionFieldName
         )
@@ -406,11 +413,15 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
             {
                 if (.isPackageInstalled("pkgbuild") &&
                         !isTRUE(eval(parse(text = "pkgbuild::has_build_tools(debug = FALSE)")))) {
-                    stopRuntimeIssue("no C++ compiler found", ifelse(.Platform$OS.type == "windows", " (install RTools to solve the issue)",
-                        ""
-                    ),
-                    parameter = "calcFunction", value = calcFunction, constraint = "available C++ compiler",
-                    functionName = ".getCalcSubjectsFunction"
+                    stopRuntimeIssue(
+                        "no C++ compiler found", ifelse(.Platform$OS.type == "windows",
+                            " (install RTools to solve the issue)",
+                            ""
+                        ),
+                        parameter = "calcFunction",
+                        value = calcFunction,
+                        constraint = "available C++ compiler",
+                        functionName = ".getCalcSubjectsFunction"
                     )
                 }
 
@@ -430,7 +441,9 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                     )
                 }
                 if (functionName != expectedFunctionName) {
-                    stopRuntimeIssue("C++ compilation returned an unexpected ", "function name (", sQuote(functionName),
+                    stopRuntimeIssue(
+                        "C++ compilation returned an unexpected ",
+                        "function name (", sQuote(functionName),
                         " instead of ", sQuote(expectedFunctionName), ")",
                         functionName = ".getCalcSubjectsFunction",
                         parameter = functionName,
@@ -469,9 +482,11 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
                     ),
                     verbose = FALSE, showOutput = TRUE
                 )
-                stopRuntimeIssue("Failed to compile ", .pQuote(functionFieldName), ": ", e$message,
+                stopRuntimeIssue(
+                    "Failed to compile ", .pQuote(functionFieldName), ": ", e$message,
                     parameter = functionFieldName,
-                    value = calcFunction, constraint = "valid compilable C++ code",
+                    value = calcFunction,
+                    constraint = "valid compilable C++ code",
                     functionName = ".getCalcSubjectsFunction"
                 )
             }
@@ -489,9 +504,11 @@ C_SIMULATION_CALC_SUBJECTS_FUNCTION_ARGUMENTS[[C_SIMULATION_CALC_SUBJECTS_FUNCTI
             ))
         },
         error = function(e) {
-            stopRuntimeIssue("Failed to evaluate and parse ", .pQuote(functionFieldName), ": ", e$message,
+            stopRuntimeIssue(
+                "Failed to evaluate and parse ", .pQuote(functionFieldName), ": ", e$message,
                 parameter = functionFieldName,
-                value = calcFunction, constraint = "valid R function code",
+                value = calcFunction,
+                constraint = "valid R function code",
                 functionName = ".getCalcSubjectsFunction"
             )
         }

--- a/R/f_simulation_enrichment.R
+++ b/R/f_simulation_enrichment.R
@@ -152,18 +152,18 @@ NULL
         if (length(selectedPopulations) != gMax) {
             stopIllegalArgument(msg, "the output must be a logical vector of length 'gMax' (", gMax, ")",
                 parameter = "selectPopulationsFunction",
-                value = selectedPopulations, constraint = paste0("logical vector of length ", gMax), 
-		relatedParameter ="gMax",
-                relatedValue = gMax, 
-		functionName = ".selectPopulations"
+                value = selectedPopulations, constraint = paste0("logical vector of length ", gMax),
+                relatedParameter = "gMax",
+                relatedValue = gMax,
+                functionName = ".selectPopulations"
             )
         }
         if (!is.logical(selectedPopulations)) {
             stopIllegalArgument(msg, "the output must be a logical vector (is ", .getClassName(selectedPopulations),
                 ")",
                 parameter = "selectPopulationsFunction", value = selectedPopulations, constraint = "logical vector",
-                relatedParameter = "class of selected populations", 
-		relatedValue = .getClassName(selectedPopulations),
+                relatedParameter = "class of selected populations",
+                relatedValue = .getClassName(selectedPopulations),
                 functionName = ".selectPopulations"
             )
         }
@@ -486,10 +486,10 @@ NULL
     if (endpoint == "survival" && is.null(effectList$hazardRatios) && !is.null(effectList$piTreatments)) {
         if (is.null(effectList$piControls)) {
             stopMissingArgument(sQuote("effectList$piControls"), " must be specified when 'effectList$piTreatments' is used",
-                functionName = ".createSimulationResultsEnrichmentObject", 
-		parameter ="effectList$piControls", value = effectList$piControls,
-                relatedParameter = "effectList$piTreatments", 
-		relatedValue = effectList$piTreatments
+                functionName = ".createSimulationResultsEnrichmentObject",
+                parameter = "effectList$piControls", value = effectList$piControls,
+                relatedParameter = "effectList$piTreatments",
+                relatedValue = effectList$piTreatments
             )
         }
 
@@ -547,8 +547,9 @@ NULL
     }
 
     if (!stratifiedAnalysis && endpoint %in% c("means")) {
-        stopIllegalArgument("For testing means, only stratified analysis is supported", 
-		functionName = ".createSimulationResultsEnrichmentObject")
+        stopIllegalArgument("For testing means, only stratified analysis is supported",
+            functionName = ".createSimulationResultsEnrichmentObject"
+        )
     }
 
     kMax <- design$kMax
@@ -623,8 +624,8 @@ NULL
         .assertIsIntegerVector(plannedEvents, "plannedEvents", validateType = FALSE)
         if (length(plannedEvents) != kMax) {
             stopIllegalArgument("'plannedEvents' (", .arrayToString(plannedEvents), ") must have length ", kMax,
-                functionName = ".createSimulationResultsEnrichmentObject", 
-		parameter ="plannedEvents", value = plannedEvents
+                functionName = ".createSimulationResultsEnrichmentObject",
+                parameter = "plannedEvents", value = plannedEvents
             )
         }
         .assertIsInClosedInterval(plannedEvents, "plannedEvents", lower = 1, upper = NULL)
@@ -753,8 +754,8 @@ NULL
                 stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than 'minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = ".createSimulationResultsEnrichmentObject",
-                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage, 
-		relatedParameter ="minNumberOfEventsPerStage",
+                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage,
+                    relatedParameter = "minNumberOfEventsPerStage",
                     relatedValue = minNumberOfEventsPerStage
                 )
             }
@@ -898,8 +899,8 @@ NULL
     } else if (length(allocationRatioPlanned) != design$kMax) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
             design$kMax, " (kMax)",
-            functionName = ".createSimulationResultsEnrichmentObject", 
-		parameter ="allocationRatioPlanned",
+            functionName = ".createSimulationResultsEnrichmentObject",
+            parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }

--- a/R/f_simulation_enrichment.R
+++ b/R/f_simulation_enrichment.R
@@ -152,15 +152,18 @@ NULL
         if (length(selectedPopulations) != gMax) {
             stopIllegalArgument(msg, "the output must be a logical vector of length 'gMax' (", gMax, ")",
                 parameter = "selectPopulationsFunction",
-                value = selectedPopulations, constraint = paste0("logical vector of length ", gMax), relatedParameter = "gMax",
-                relatedValue = gMax, functionName = ".selectPopulations"
+                value = selectedPopulations, constraint = paste0("logical vector of length ", gMax), 
+		relatedParameter ="gMax",
+                relatedValue = gMax, 
+		functionName = ".selectPopulations"
             )
         }
         if (!is.logical(selectedPopulations)) {
             stopIllegalArgument(msg, "the output must be a logical vector (is ", .getClassName(selectedPopulations),
                 ")",
                 parameter = "selectPopulationsFunction", value = selectedPopulations, constraint = "logical vector",
-                relatedParameter = "class of selected populations", relatedValue = .getClassName(selectedPopulations),
+                relatedParameter = "class of selected populations", 
+		relatedValue = .getClassName(selectedPopulations),
                 functionName = ".selectPopulations"
             )
         }
@@ -483,8 +486,10 @@ NULL
     if (endpoint == "survival" && is.null(effectList$hazardRatios) && !is.null(effectList$piTreatments)) {
         if (is.null(effectList$piControls)) {
             stopMissingArgument(sQuote("effectList$piControls"), " must be specified when 'effectList$piTreatments' is used",
-                functionName = ".createSimulationResultsEnrichmentObject", parameter = "effectList$piControls", value = effectList$piControls,
-                relatedParameter = "effectList$piTreatments", relatedValue = effectList$piTreatments
+                functionName = ".createSimulationResultsEnrichmentObject", 
+		parameter ="effectList$piControls", value = effectList$piControls,
+                relatedParameter = "effectList$piTreatments", 
+		relatedValue = effectList$piTreatments
             )
         }
 
@@ -542,7 +547,8 @@ NULL
     }
 
     if (!stratifiedAnalysis && endpoint %in% c("means")) {
-        stopIllegalArgument("For testing means, only stratified analysis is supported", functionName = ".createSimulationResultsEnrichmentObject")
+        stopIllegalArgument("For testing means, only stratified analysis is supported", 
+		functionName = ".createSimulationResultsEnrichmentObject")
     }
 
     kMax <- design$kMax
@@ -617,7 +623,8 @@ NULL
         .assertIsIntegerVector(plannedEvents, "plannedEvents", validateType = FALSE)
         if (length(plannedEvents) != kMax) {
             stopIllegalArgument("'plannedEvents' (", .arrayToString(plannedEvents), ") must have length ", kMax,
-                functionName = ".createSimulationResultsEnrichmentObject", parameter = "plannedEvents", value = plannedEvents
+                functionName = ".createSimulationResultsEnrichmentObject", 
+		parameter ="plannedEvents", value = plannedEvents
             )
         }
         .assertIsInClosedInterval(plannedEvents, "plannedEvents", lower = 1, upper = NULL)
@@ -746,7 +753,8 @@ NULL
                 stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than 'minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = ".createSimulationResultsEnrichmentObject",
-                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage, relatedParameter = "minNumberOfEventsPerStage",
+                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage, 
+		relatedParameter ="minNumberOfEventsPerStage",
                     relatedValue = minNumberOfEventsPerStage
                 )
             }
@@ -890,7 +898,8 @@ NULL
     } else if (length(allocationRatioPlanned) != design$kMax) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
             design$kMax, " (kMax)",
-            functionName = ".createSimulationResultsEnrichmentObject", parameter = "allocationRatioPlanned",
+            functionName = ".createSimulationResultsEnrichmentObject", 
+		parameter ="allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }

--- a/R/f_simulation_enrichment.R
+++ b/R/f_simulation_enrichment.R
@@ -485,7 +485,9 @@ NULL
     effectList <- .getValidatedEffectList(effectList, endpoint = endpoint)
     if (endpoint == "survival" && is.null(effectList$hazardRatios) && !is.null(effectList$piTreatments)) {
         if (is.null(effectList$piControls)) {
-            stopMissingArgument(sQuote("effectList$piControls"), " must be specified when 'effectList$piTreatments' is used",
+            stopMissingArgument(
+                sQuote("effectList$piControls"),
+                " must be specified when 'effectList$piTreatments' is used",
                 functionName = ".createSimulationResultsEnrichmentObject",
                 parameter = "effectList$piControls", value = effectList$piControls,
                 relatedParameter = "effectList$piTreatments",
@@ -511,7 +513,9 @@ NULL
     .assertIsValidIntersectionTestEnrichment(design, intersectionTest)
 
     if (intersectionTest == "SpiessensDebois" && gMax > 2) {
-        stopIllegalArgument("Spiessen & Debois intersection test cannot generally ", "be used for enrichment designs with more than two populations",
+        stopIllegalArgument(
+            "Spiessen & Debois intersection test cannot generally ",
+            "be used for enrichment designs with more than two populations",
             functionName = ".createSimulationResultsEnrichmentObject"
         )
     }
@@ -694,7 +698,8 @@ NULL
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage)) &&
                     any(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage < 0)
                 ) {
-                stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
+                stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage),
+                    ") must be not smaller than minNumberOfSubjectsPerStage' (",
                     .arrayToString(minNumberOfSubjectsPerStage), ")",
                     functionName = ".createSimulationResultsEnrichmentObject",
                     parameter = "maxNumberOfSubjectsPerStage", value = maxNumberOfSubjectsPerStage
@@ -751,7 +756,8 @@ NULL
                 !all(is.na(maxNumberOfEventsPerStage - minNumberOfEventsPerStage)) &&
                     any(maxNumberOfEventsPerStage - minNumberOfEventsPerStage < 0)
                 ) {
-                stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than 'minNumberOfEventsPerStage' (",
+                stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage),
+                    ") must be not smaller than 'minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = ".createSimulationResultsEnrichmentObject",
                     parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage,
@@ -897,7 +903,9 @@ NULL
     if (length(allocationRatioPlanned) == 1) {
         allocationRatioPlanned <- rep(allocationRatioPlanned, design$kMax)
     } else if (length(allocationRatioPlanned) != design$kMax) {
-        stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
+        stopIllegalArgument(
+            "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ",
+            "must have length 1 or ",
             design$kMax, " (kMax)",
             functionName = ".createSimulationResultsEnrichmentObject",
             parameter = "allocationRatioPlanned",
@@ -980,7 +988,8 @@ NULL
         adaptations <- rep(TRUE, kMax - 1)
     }
     if (length(adaptations) != kMax - 1) {
-        stopIllegalArgument("'adaptations' must have length ", (kMax - 1), " (kMax - 1)",
+        stopIllegalArgument(
+            "'adaptations' must have length ", (kMax - 1), " (kMax - 1)",
             functionName = ".createSimulationResultsEnrichmentObject",
             parameter = "adaptations", value = adaptations
         )

--- a/R/f_simulation_enrichment_means.R
+++ b/R/f_simulation_enrichment_means.R
@@ -385,8 +385,8 @@ NULL
                         newSubjects < 0
                     ) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value >= 0",
-                        functionName = ".getSimulatedStageMeansEnrichment", 
-		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageMeansEnrichment",
+                        parameter = "calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
                 if (!is.na(conditionalPower) || calcSubjectsFunctionIsUserDefined) {
@@ -810,8 +810,9 @@ getSimulationEnrichmentMeans <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationEnrichmentMeans")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationEnrichmentMeans"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_means.R
+++ b/R/f_simulation_enrichment_means.R
@@ -384,9 +384,12 @@ NULL
                         is.na(newSubjects) ||
                         newSubjects < 0
                     ) {
-                    stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value >= 0",
+                    stopIllegalArgument(
+                        "'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ",
+                        "the output must be a single numeric value >= 0",
                         functionName = ".getSimulatedStageMeansEnrichment",
-                        parameter = "calcSubjectsFunction", value = calcSubjectsFunction
+                        parameter = "calcSubjectsFunction",
+                        value = calcSubjectsFunction
                     )
                 }
                 if (!is.na(conditionalPower) || calcSubjectsFunctionIsUserDefined) {
@@ -810,7 +813,8 @@ getSimulationEnrichmentMeans <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = "getSimulationEnrichmentMeans"
         )
     }

--- a/R/f_simulation_enrichment_means.R
+++ b/R/f_simulation_enrichment_means.R
@@ -385,7 +385,8 @@ NULL
                         newSubjects < 0
                     ) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value >= 0",
-                        functionName = ".getSimulatedStageMeansEnrichment", parameter = "calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageMeansEnrichment", 
+		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
                 if (!is.na(conditionalPower) || calcSubjectsFunctionIsUserDefined) {
@@ -809,7 +810,8 @@ getSimulationEnrichmentMeans <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationEnrichmentMeans")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationEnrichmentMeans")
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_rates.R
+++ b/R/f_simulation_enrichment_rates.R
@@ -850,8 +850,8 @@ NULL
                     is.null(newSubjects) || length(newSubjects) != 1 || !is.numeric(newSubjects) || is.na(newSubjects)
                     ) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or ", "undefined result (", newSubjects, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageRatesEnrichment", 
-		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageRatesEnrichment",
+                        parameter = "calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
 
@@ -1334,8 +1334,9 @@ getSimulationEnrichmentRates <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationEnrichmentRates")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationEnrichmentRates"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_rates.R
+++ b/R/f_simulation_enrichment_rates.R
@@ -850,7 +850,8 @@ NULL
                     is.null(newSubjects) || length(newSubjects) != 1 || !is.numeric(newSubjects) || is.na(newSubjects)
                     ) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or ", "undefined result (", newSubjects, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageRatesEnrichment", parameter = "calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageRatesEnrichment", 
+		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
 
@@ -1333,7 +1334,8 @@ getSimulationEnrichmentRates <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationEnrichmentRates")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationEnrichmentRates")
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_rates.R
+++ b/R/f_simulation_enrichment_rates.R
@@ -849,9 +849,12 @@ NULL
                 if (
                     is.null(newSubjects) || length(newSubjects) != 1 || !is.numeric(newSubjects) || is.na(newSubjects)
                     ) {
-                    stopIllegalArgument("'calcSubjectsFunction' returned an illegal or ", "undefined result (", newSubjects, "); ", "the output must be a single numeric value",
+                    stopIllegalArgument(
+                        "'calcSubjectsFunction' returned an illegal or ", "undefined result (", newSubjects, "); ",
+                        "the output must be a single numeric value",
                         functionName = ".getSimulatedStageRatesEnrichment",
-                        parameter = "calcSubjectsFunction", value = calcSubjectsFunction
+                        parameter = "calcSubjectsFunction",
+                        value = calcSubjectsFunction
                     )
                 }
 
@@ -1334,7 +1337,8 @@ getSimulationEnrichmentRates <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = "getSimulationEnrichmentRates"
         )
     }

--- a/R/f_simulation_enrichment_survival_crude.R
+++ b/R/f_simulation_enrichment_survival_crude.R
@@ -383,8 +383,8 @@ NULL
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageSurvivalEnrichment", 
-		parameter ="calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageSurvivalEnrichment",
+                        parameter = "calcEventsFunction", value = calcEventsFunction
                     )
                 }
 
@@ -838,8 +838,9 @@ getSimulationEnrichmentSurvivalBasic <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationEnrichmentSurvivalBasic")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationEnrichmentSurvivalBasic"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_survival_crude.R
+++ b/R/f_simulation_enrichment_survival_crude.R
@@ -382,9 +382,12 @@ NULL
                 )
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
-                    stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
+                    stopIllegalArgument(
+                        "'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ",
+                        "the output must be a single numeric value",
                         functionName = ".getSimulatedStageSurvivalEnrichment",
-                        parameter = "calcEventsFunction", value = calcEventsFunction
+                        parameter = "calcEventsFunction",
+                        value = calcEventsFunction
                     )
                 }
 
@@ -838,7 +841,8 @@ getSimulationEnrichmentSurvivalBasic <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = "getSimulationEnrichmentSurvivalBasic"
         )
     }

--- a/R/f_simulation_enrichment_survival_crude.R
+++ b/R/f_simulation_enrichment_survival_crude.R
@@ -383,7 +383,8 @@ NULL
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageSurvivalEnrichment", parameter = "calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageSurvivalEnrichment", 
+		parameter ="calcEventsFunction", value = calcEventsFunction
                     )
                 }
 
@@ -837,7 +838,8 @@ getSimulationEnrichmentSurvivalBasic <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationEnrichmentSurvivalBasic")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationEnrichmentSurvivalBasic")
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_survival_pw.R
+++ b/R/f_simulation_enrichment_survival_pw.R
@@ -192,8 +192,8 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
 
     if (length(allocationRatioPlanned) != 1) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
-            functionName = "getSimulationEnrichmentSurvivalPatientWise", 
-		parameter ="allocationRatioPlanned",
+            functionName = "getSimulationEnrichmentSurvivalPatientWise",
+            parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }
@@ -265,8 +265,8 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
         if (identical(accrualIntensity, 1L)) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = "getSimulationEnrichmentSurvivalPatientWise",
-                parameter = "accrualIntensity", 
-		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity",
+                relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
@@ -419,8 +419,9 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationEnrichmentSurvivalPatientWise")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationEnrichmentSurvivalPatientWise"
+        )
     }
 
     simulationResults$.data <- loopResult$data
@@ -601,8 +602,8 @@ getSimulationEnrichmentSurvival <- function(
     if (identical(simulationType, "testStatisticBased")) {
         if (usesPatientWiseOnlyArgs) {
             stopIllegalArgument("patient-wise simulation arguments cannot be specified if 'simulationType' = \"testStatisticBased\"",
-                functionName = "getSimulationEnrichmentSurvival", 
-		parameter ="simulationType", value = simulationType
+                functionName = "getSimulationEnrichmentSurvival",
+                parameter = "simulationType", value = simulationType
             )
         }
 

--- a/R/f_simulation_enrichment_survival_pw.R
+++ b/R/f_simulation_enrichment_survival_pw.R
@@ -191,7 +191,9 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
     )
 
     if (length(allocationRatioPlanned) != 1) {
-        stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
+        stopIllegalArgument(
+            "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ",
+            "must have length 1",
             functionName = "getSimulationEnrichmentSurvivalPatientWise",
             parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
@@ -608,8 +610,10 @@ getSimulationEnrichmentSurvival <- function(
         }
 
         message(
-            "Note: 'simulationType' = \"testStatisticBased\" simulates normally distributed log-rank test statistics instead of patient-wise survival data. ",
-            "To simulate patient-wise survival data, specify 'simulationType' = \"patientWise\" and the corresponding arguments."
+            "Note: 'simulationType' = \"testStatisticBased\" simulates normally distributed ",
+            "log-rank test statistics instead of patient-wise survival data. ",
+            "To simulate patient-wise survival data, specify 'simulationType' = \"patientWise\" ",
+            "and the corresponding arguments."
         )
 
         return(getSimulationEnrichmentSurvivalBasic(
@@ -680,9 +684,11 @@ getSimulationEnrichmentSurvival <- function(
 
     if (identical(simulationType, "patientWiseBasic")) {
         message(
-            "Note: 'simulationType' = \"patientWiseBasic\" simulates patient-wise survival data using R code instead of C++ code. ",
+            "Note: 'simulationType' = \"patientWiseBasic\" simulates patient-wise ",
+            "survival data using R code instead of C++ code. ",
             "This approach is less efficient and should only be used for testing purposes. ",
-            "To perform a more efficient patient-wise simulation, specify 'simulationType' = \"patientWise\"."
+            "To perform a more efficient patient-wise simulation, ",
+            "specify 'simulationType' = \"patientWise\"."
         )
 
         return(.getSimulationEnrichmentSurvivalPatientWiseBasic(

--- a/R/f_simulation_enrichment_survival_pw.R
+++ b/R/f_simulation_enrichment_survival_pw.R
@@ -192,7 +192,8 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
 
     if (length(allocationRatioPlanned) != 1) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
-            functionName = "getSimulationEnrichmentSurvivalPatientWise", parameter = "allocationRatioPlanned",
+            functionName = "getSimulationEnrichmentSurvivalPatientWise", 
+		parameter ="allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }
@@ -264,7 +265,8 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
         if (identical(accrualIntensity, 1L)) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = "getSimulationEnrichmentSurvivalPatientWise",
-                parameter = "accrualIntensity", relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity", 
+		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
@@ -417,7 +419,8 @@ getSimulationEnrichmentSurvivalPatientWise <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationEnrichmentSurvivalPatientWise")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationEnrichmentSurvivalPatientWise")
     }
 
     simulationResults$.data <- loopResult$data
@@ -598,7 +601,8 @@ getSimulationEnrichmentSurvival <- function(
     if (identical(simulationType, "testStatisticBased")) {
         if (usesPatientWiseOnlyArgs) {
             stopIllegalArgument("patient-wise simulation arguments cannot be specified if 'simulationType' = \"testStatisticBased\"",
-                functionName = "getSimulationEnrichmentSurvival", parameter = "simulationType", value = simulationType
+                functionName = "getSimulationEnrichmentSurvival", 
+		parameter ="simulationType", value = simulationType
             )
         }
 

--- a/R/f_simulation_enrichment_survival_pw_basic.R
+++ b/R/f_simulation_enrichment_survival_pw_basic.R
@@ -402,7 +402,8 @@ updateSubGroupVector <- function(
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageResultsSurvivalEnrichmentPatientWise", parameter = "calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageResultsSurvivalEnrichmentPatientWise", 
+		parameter ="calcEventsFunction", value = calcEventsFunction
                     )
                 }
 
@@ -552,7 +553,8 @@ updateSubGroupVector <- function(
 
     if (length(allocationRatioPlanned) != 1) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
-            functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic", parameter = "allocationRatioPlanned",
+            functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic", 
+		parameter ="allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }
@@ -661,7 +663,8 @@ updateSubGroupVector <- function(
         if (identical(accrualIntensity, 1L)) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic",
-                parameter = "accrualIntensity", relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity", 
+		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
@@ -945,7 +948,8 @@ updateSubGroupVector <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic")
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_survival_pw_basic.R
+++ b/R/f_simulation_enrichment_survival_pw_basic.R
@@ -402,8 +402,8 @@ updateSubGroupVector <- function(
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageResultsSurvivalEnrichmentPatientWise", 
-		parameter ="calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageResultsSurvivalEnrichmentPatientWise",
+                        parameter = "calcEventsFunction", value = calcEventsFunction
                     )
                 }
 
@@ -553,8 +553,8 @@ updateSubGroupVector <- function(
 
     if (length(allocationRatioPlanned) != 1) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
-            functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic", 
-		parameter ="allocationRatioPlanned",
+            functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic",
+            parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }
@@ -663,8 +663,8 @@ updateSubGroupVector <- function(
         if (identical(accrualIntensity, 1L)) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic",
-                parameter = "accrualIntensity", 
-		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity",
+                relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
@@ -948,8 +948,9 @@ updateSubGroupVector <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_enrichment_survival_pw_basic.R
+++ b/R/f_simulation_enrichment_survival_pw_basic.R
@@ -401,9 +401,12 @@ updateSubGroupVector <- function(
                 )
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
-                    stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
+                    stopIllegalArgument(
+                        "'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ",
+                        "the output must be a single numeric value",
                         functionName = ".getSimulatedStageResultsSurvivalEnrichmentPatientWise",
-                        parameter = "calcEventsFunction", value = calcEventsFunction
+                        parameter = "calcEventsFunction",
+                        value = calcEventsFunction
                     )
                 }
 
@@ -552,7 +555,9 @@ updateSubGroupVector <- function(
     )
 
     if (length(allocationRatioPlanned) != 1) {
-        stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
+        stopIllegalArgument(
+            "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ",
+            "must have length 1",
             functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic",
             parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
@@ -948,7 +953,8 @@ updateSubGroupVector <- function(
     }
 
     if (any(simulationResults$rejectedPopulationsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = ".getSimulationEnrichmentSurvivalPatientWiseBasic"
         )
     }

--- a/R/f_simulation_multiarm.R
+++ b/R/f_simulation_multiarm.R
@@ -88,18 +88,18 @@ NULL
         if (length(selectedArms) != gMax) {
             stopIllegalArgument(msg, "the output must be a logical vector of length 'gMax' (", gMax, ")",
                 parameter = "selectArmsFunction",
-                value = selectedArms, constraint = paste0("logical vector of length ", gMax), 
-		relatedParameter ="gMax",
-                relatedValue = gMax, 
-		functionName = ".selectTreatmentArms"
+                value = selectedArms, constraint = paste0("logical vector of length ", gMax),
+                relatedParameter = "gMax",
+                relatedValue = gMax,
+                functionName = ".selectTreatmentArms"
             )
         }
         if (!is.logical(selectedArms)) {
             stopIllegalArgument(msg, "the output must be a logical vector (is ", .getClassName(selectedArms), ")",
-                parameter = "selectArmsFunction", value = selectedArms, constraint = "logical vector", 
-		relatedParameter ="class of selected arms",
-                relatedValue = .getClassName(selectedArms), 
-		functionName = ".selectTreatmentArms"
+                parameter = "selectArmsFunction", value = selectedArms, constraint = "logical vector",
+                relatedParameter = "class of selected arms",
+                relatedValue = .getClassName(selectedArms),
+                functionName = ".selectTreatmentArms"
             )
         }
     }
@@ -284,8 +284,9 @@ NULL
 
 .getCriticalValuesDunnettForSimulation <- function(alpha, indices, allocationRatioPlanned) {
     if (allocationRatioPlanned[1] != allocationRatioPlanned[2]) {
-        stopIllegalArgument("The conditional Dunnett test assumes equal allocation ratios over the stages", 
-		functionName = ".getCriticalValuesDunnettForSimulation")
+        stopIllegalArgument("The conditional Dunnett test assumes equal allocation ratios over the stages",
+            functionName = ".getCriticalValuesDunnettForSimulation"
+        )
     }
 
     gMax <- ncol(indices)
@@ -536,8 +537,8 @@ NULL
         if (!is.null(effectMatrix) && activeArms != ncol(effectMatrix)) {
             stopIllegalArgument("Number of columns of effect matrix (", ncol(effectMatrix), ") is not equal to specified 'activeArms' (",
                 activeArms, ")",
-                functionName = ".createSimulationResultsMultiArmObject", 
-		parameter ="activeArms",
+                functionName = ".createSimulationResultsMultiArmObject",
+                parameter = "activeArms",
                 value = activeArms
             )
         }
@@ -551,7 +552,7 @@ NULL
             parameter = "activeArms", value = activeArms
         )
     }
-    
+
     typeOfShape <- .assertIsValidTypeOfShape(typeOfShape)
     if (!is.null(effectMatrix) && typeOfShape != "userDefined") {
         stopIllegalArgument("Change 'typeOfShape' (", typeOfShape, ") to 'userDefined'",
@@ -757,14 +758,19 @@ NULL
         if (typeOfShape == "userDefined") {
             omegaMaxVector <- effectMatrix[, gMax]
         }
-        if (activeArms == 1 && identical(as.numeric(omegaMaxVector), as.numeric(effectMatrix)) && 
+        if (activeArms == 1 && identical(as.numeric(omegaMaxVector), as.numeric(effectMatrix)) &&
                 !simulationResults$isUserDefinedParameter("effectMatrix")) {
             simulationResults$.setParameterType("effectMatrix", C_PARAM_NOT_APPLICABLE)
         }
-        .setValueAndParameterType(simulationResults, "omegaMaxVector", 
-            omegaMaxVector, C_RANGE_OF_HAZARD_RATIOS_DEFAULT)        if (simulationResults$isUserDefinedParameter("effectMatrix")) {
-            simulationResults$.setParameterType("omegaMaxVector", 
-                ifelse(activeArms == 1, C_PARAM_NOT_APPLICABLE, C_PARAM_DERIVED))
+        .setValueAndParameterType(
+            simulationResults, "omegaMaxVector",
+            omegaMaxVector, C_RANGE_OF_HAZARD_RATIOS_DEFAULT
+        )
+        if (simulationResults$isUserDefinedParameter("effectMatrix")) {
+            simulationResults$.setParameterType(
+                "omegaMaxVector",
+                ifelse(activeArms == 1, C_PARAM_NOT_APPLICABLE, C_PARAM_DERIVED)
+            )
         }
 
         .assertIsSingleNumber(piControl, "piControl", naAllowed = TRUE)
@@ -810,8 +816,8 @@ NULL
         .assertIsIntegerVector(plannedEvents, "plannedEvents", validateType = FALSE)
         if (length(plannedEvents) != kMax) {
             stopIllegalArgument("'plannedEvents' (", .arrayToString(plannedEvents), ") must have length ", kMax,
-                functionName = ".createSimulationResultsMultiArmObject", 
-		parameter ="plannedEvents", value = plannedEvents
+                functionName = ".createSimulationResultsMultiArmObject",
+                parameter = "plannedEvents", value = plannedEvents
             )
         }
         .assertIsInClosedInterval(plannedEvents, "plannedEvents", lower = 1, upper = NULL)
@@ -952,8 +958,8 @@ NULL
                 stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than 'minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = ".createSimulationResultsMultiArmObject",
-                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage, 
-		relatedParameter ="minNumberOfEventsPerStage",
+                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage,
+                    relatedParameter = "minNumberOfEventsPerStage",
                     relatedValue = minNumberOfEventsPerStage
                 )
             }
@@ -1102,8 +1108,8 @@ NULL
     } else if (length(allocationRatioPlanned) != design$kMax) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
             design$kMax, " (kMax)",
-            functionName = ".createSimulationResultsMultiArmObject", 
-		parameter ="allocationRatioPlanned",
+            functionName = ".createSimulationResultsMultiArmObject",
+            parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }

--- a/R/f_simulation_multiarm.R
+++ b/R/f_simulation_multiarm.R
@@ -88,14 +88,18 @@ NULL
         if (length(selectedArms) != gMax) {
             stopIllegalArgument(msg, "the output must be a logical vector of length 'gMax' (", gMax, ")",
                 parameter = "selectArmsFunction",
-                value = selectedArms, constraint = paste0("logical vector of length ", gMax), relatedParameter = "gMax",
-                relatedValue = gMax, functionName = ".selectTreatmentArms"
+                value = selectedArms, constraint = paste0("logical vector of length ", gMax), 
+		relatedParameter ="gMax",
+                relatedValue = gMax, 
+		functionName = ".selectTreatmentArms"
             )
         }
         if (!is.logical(selectedArms)) {
             stopIllegalArgument(msg, "the output must be a logical vector (is ", .getClassName(selectedArms), ")",
-                parameter = "selectArmsFunction", value = selectedArms, constraint = "logical vector", relatedParameter = "class of selected arms",
-                relatedValue = .getClassName(selectedArms), functionName = ".selectTreatmentArms"
+                parameter = "selectArmsFunction", value = selectedArms, constraint = "logical vector", 
+		relatedParameter ="class of selected arms",
+                relatedValue = .getClassName(selectedArms), 
+		functionName = ".selectTreatmentArms"
             )
         }
     }
@@ -280,7 +284,8 @@ NULL
 
 .getCriticalValuesDunnettForSimulation <- function(alpha, indices, allocationRatioPlanned) {
     if (allocationRatioPlanned[1] != allocationRatioPlanned[2]) {
-        stopIllegalArgument("The conditional Dunnett test assumes equal allocation ratios over the stages", functionName = ".getCriticalValuesDunnettForSimulation")
+        stopIllegalArgument("The conditional Dunnett test assumes equal allocation ratios over the stages", 
+		functionName = ".getCriticalValuesDunnettForSimulation")
     }
 
     gMax <- ncol(indices)
@@ -531,7 +536,8 @@ NULL
         if (!is.null(effectMatrix) && activeArms != ncol(effectMatrix)) {
             stopIllegalArgument("Number of columns of effect matrix (", ncol(effectMatrix), ") is not equal to specified 'activeArms' (",
                 activeArms, ")",
-                functionName = ".createSimulationResultsMultiArmObject", parameter = "activeArms",
+                functionName = ".createSimulationResultsMultiArmObject", 
+		parameter ="activeArms",
                 value = activeArms
             )
         }
@@ -804,7 +810,8 @@ NULL
         .assertIsIntegerVector(plannedEvents, "plannedEvents", validateType = FALSE)
         if (length(plannedEvents) != kMax) {
             stopIllegalArgument("'plannedEvents' (", .arrayToString(plannedEvents), ") must have length ", kMax,
-                functionName = ".createSimulationResultsMultiArmObject", parameter = "plannedEvents", value = plannedEvents
+                functionName = ".createSimulationResultsMultiArmObject", 
+		parameter ="plannedEvents", value = plannedEvents
             )
         }
         .assertIsInClosedInterval(plannedEvents, "plannedEvents", lower = 1, upper = NULL)
@@ -945,7 +952,8 @@ NULL
                 stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than 'minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = ".createSimulationResultsMultiArmObject",
-                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage, relatedParameter = "minNumberOfEventsPerStage",
+                    parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage, 
+		relatedParameter ="minNumberOfEventsPerStage",
                     relatedValue = minNumberOfEventsPerStage
                 )
             }
@@ -1094,7 +1102,8 @@ NULL
     } else if (length(allocationRatioPlanned) != design$kMax) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
             design$kMax, " (kMax)",
-            functionName = ".createSimulationResultsMultiArmObject", parameter = "allocationRatioPlanned",
+            functionName = ".createSimulationResultsMultiArmObject", 
+		parameter ="allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }

--- a/R/f_simulation_multiarm.R
+++ b/R/f_simulation_multiarm.R
@@ -535,8 +535,9 @@ NULL
         }
     } else {
         if (!is.null(effectMatrix) && activeArms != ncol(effectMatrix)) {
-            stopIllegalArgument("Number of columns of effect matrix (", ncol(effectMatrix), ") is not equal to specified 'activeArms' (",
-                activeArms, ")",
+            stopIllegalArgument(
+                "Number of columns of effect matrix (", ncol(effectMatrix),
+                ") is not equal to specified 'activeArms' (", activeArms, ")",
                 functionName = ".createSimulationResultsMultiArmObject",
                 parameter = "activeArms",
                 value = activeArms
@@ -898,7 +899,9 @@ NULL
                 !all(is.na(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage)) &&
                     any(maxNumberOfSubjectsPerStage - minNumberOfSubjectsPerStage < 0)
                 ) {
-                stopIllegalArgument("'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage), ") must be not smaller than minNumberOfSubjectsPerStage' (",
+                stopIllegalArgument(
+                    "'maxNumberOfSubjectsPerStage' (", .arrayToString(maxNumberOfSubjectsPerStage),
+                    ") must be not smaller than minNumberOfSubjectsPerStage' (",
                     .arrayToString(minNumberOfSubjectsPerStage), ")",
                     functionName = ".createSimulationResultsMultiArmObject",
                     parameter = "maxNumberOfSubjectsPerStage", value = maxNumberOfSubjectsPerStage
@@ -955,7 +958,9 @@ NULL
                 !all(is.na(maxNumberOfEventsPerStage - minNumberOfEventsPerStage)) &&
                     any(maxNumberOfEventsPerStage - minNumberOfEventsPerStage < 0)
                 ) {
-                stopIllegalArgument("'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage), ") must be not smaller than 'minNumberOfEventsPerStage' (",
+                stopIllegalArgument(
+                    "'maxNumberOfEventsPerStage' (", .arrayToString(maxNumberOfEventsPerStage),
+                    ") must be not smaller than 'minNumberOfEventsPerStage' (",
                     .arrayToString(minNumberOfEventsPerStage), ")",
                     functionName = ".createSimulationResultsMultiArmObject",
                     parameter = "maxNumberOfEventsPerStage", value = maxNumberOfEventsPerStage,
@@ -1106,7 +1111,9 @@ NULL
     if (length(allocationRatioPlanned) == 1) {
         allocationRatioPlanned <- rep(allocationRatioPlanned, design$kMax)
     } else if (length(allocationRatioPlanned) != design$kMax) {
-        stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1 or ",
+        stopIllegalArgument(
+            "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ",
+            "must have length 1 or ",
             design$kMax, " (kMax)",
             functionName = ".createSimulationResultsMultiArmObject",
             parameter = "allocationRatioPlanned",

--- a/R/f_simulation_multiarm_means.R
+++ b/R/f_simulation_multiarm_means.R
@@ -220,7 +220,8 @@ NULL
                 if (is.null(newSubjects) || length(newSubjects) != 1 ||
                         !is.numeric(newSubjects) || is.na(newSubjects) || newSubjects < 0) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value >= 0",
-                        functionName = ".getSimulatedStageMeansMultiArm", parameter = "calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageMeansMultiArm", 
+		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
                 if (!is.na(conditionalPower) || calcSubjectsFunctionIsUserDefined) {
@@ -667,7 +668,8 @@ getSimulationMultiArmMeans <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationMultiArmMeans")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationMultiArmMeans")
     }
 
     data <- data.frame(

--- a/R/f_simulation_multiarm_means.R
+++ b/R/f_simulation_multiarm_means.R
@@ -219,7 +219,9 @@ NULL
 
                 if (is.null(newSubjects) || length(newSubjects) != 1 ||
                         !is.numeric(newSubjects) || is.na(newSubjects) || newSubjects < 0) {
-                    stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value >= 0",
+                    stopIllegalArgument(
+                        "'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ",
+                        "the output must be a single numeric value >= 0",
                         functionName = ".getSimulatedStageMeansMultiArm",
                         parameter = "calcSubjectsFunction", value = calcSubjectsFunction
                     )
@@ -668,7 +670,8 @@ getSimulationMultiArmMeans <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = "getSimulationMultiArmMeans"
         )
     }

--- a/R/f_simulation_multiarm_means.R
+++ b/R/f_simulation_multiarm_means.R
@@ -220,8 +220,8 @@ NULL
                 if (is.null(newSubjects) || length(newSubjects) != 1 ||
                         !is.numeric(newSubjects) || is.na(newSubjects) || newSubjects < 0) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value >= 0",
-                        functionName = ".getSimulatedStageMeansMultiArm", 
-		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageMeansMultiArm",
+                        parameter = "calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
                 if (!is.na(conditionalPower) || calcSubjectsFunctionIsUserDefined) {
@@ -668,8 +668,9 @@ getSimulationMultiArmMeans <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationMultiArmMeans")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationMultiArmMeans"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_multiarm_rates.R
+++ b/R/f_simulation_multiarm_rates.R
@@ -255,8 +255,8 @@ NULL
 
                 if (is.null(newSubjects) || length(newSubjects) != 1 || !is.numeric(newSubjects) || is.na(newSubjects)) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageRatesMultiArm", 
-		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageRatesMultiArm",
+                        parameter = "calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
 
@@ -728,7 +728,7 @@ getSimulationMultiArmRates <- function(
         "numberOfSelectedArms",
         ifelse(gMax == 1, C_PARAM_NOT_APPLICABLE, C_PARAM_GENERATED)
     )
-    
+
     simulationResults$selectedArms <- simulatedSelections / maxNumberOfIterations
     simulationResults$.setParameterType(
         "selectedArms",
@@ -756,8 +756,9 @@ getSimulationMultiArmRates <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationMultiArmRates")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationMultiArmRates"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_multiarm_rates.R
+++ b/R/f_simulation_multiarm_rates.R
@@ -255,7 +255,8 @@ NULL
 
                 if (is.null(newSubjects) || length(newSubjects) != 1 || !is.numeric(newSubjects) || is.na(newSubjects)) {
                     stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageRatesMultiArm", parameter = "calcSubjectsFunction", value = calcSubjectsFunction
+                        functionName = ".getSimulatedStageRatesMultiArm", 
+		parameter ="calcSubjectsFunction", value = calcSubjectsFunction
                     )
                 }
 
@@ -755,7 +756,8 @@ getSimulationMultiArmRates <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationMultiArmRates")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationMultiArmRates")
     }
 
     data <- data.frame(

--- a/R/f_simulation_multiarm_rates.R
+++ b/R/f_simulation_multiarm_rates.R
@@ -254,7 +254,9 @@ NULL
                 )
 
                 if (is.null(newSubjects) || length(newSubjects) != 1 || !is.numeric(newSubjects) || is.na(newSubjects)) {
-                    stopIllegalArgument("'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ", "the output must be a single numeric value",
+                    stopIllegalArgument(
+                        "'calcSubjectsFunction' returned an illegal or undefined result (", newSubjects, "); ",
+                        "the output must be a single numeric value",
                         functionName = ".getSimulatedStageRatesMultiArm",
                         parameter = "calcSubjectsFunction", value = calcSubjectsFunction
                     )
@@ -756,7 +758,8 @@ getSimulationMultiArmRates <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = "getSimulationMultiArmRates"
         )
     }

--- a/R/f_simulation_multiarm_survival_crude.R
+++ b/R/f_simulation_multiarm_survival_crude.R
@@ -208,7 +208,8 @@ NULL
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageSurvivalMultiArm", parameter = "calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageSurvivalMultiArm", 
+		parameter ="calcEventsFunction", value = calcEventsFunction
                     )
                 }
 
@@ -737,7 +738,8 @@ getSimulationMultiArmSurvivalBasic <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationMultiArmSurvivalBasic")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationMultiArmSurvivalBasic")
     }
 
     data <- data.frame(

--- a/R/f_simulation_multiarm_survival_crude.R
+++ b/R/f_simulation_multiarm_survival_crude.R
@@ -208,8 +208,8 @@ NULL
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageSurvivalMultiArm", 
-		parameter ="calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageSurvivalMultiArm",
+                        parameter = "calcEventsFunction", value = calcEventsFunction
                     )
                 }
 
@@ -391,7 +391,7 @@ getSimulationMultiArmSurvivalBasic <- function(
         design,
         objectType = "power", userFunctionCallEnabled = TRUE
     )
-    
+
     simulationResults <- .createSimulationResultsMultiArmObject(
         design                      = design,
         activeArms                  = activeArms,
@@ -685,7 +685,7 @@ getSimulationMultiArmSurvivalBasic <- function(
         "numberOfSelectedArms",
         ifelse(gMax == 1, C_PARAM_NOT_APPLICABLE, C_PARAM_GENERATED)
     )
-    
+
     simulationResults$selectedArms <- simulatedSelections / maxNumberOfIterations
     simulationResults$.setParameterType(
         "selectedArms",
@@ -738,8 +738,9 @@ getSimulationMultiArmSurvivalBasic <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationMultiArmSurvivalBasic")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationMultiArmSurvivalBasic"
+        )
     }
 
     data <- data.frame(

--- a/R/f_simulation_multiarm_survival_crude.R
+++ b/R/f_simulation_multiarm_survival_crude.R
@@ -207,7 +207,9 @@ NULL
                 )
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
-                    stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
+                    stopIllegalArgument(
+                        "'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ",
+                        "the output must be a single numeric value",
                         functionName = ".getSimulatedStageSurvivalMultiArm",
                         parameter = "calcEventsFunction", value = calcEventsFunction
                     )
@@ -738,7 +740,8 @@ getSimulationMultiArmSurvivalBasic <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+        stopRuntimeIssue(
+            "internal error, simulation not possible due to numerical overflow",
             functionName = "getSimulationMultiArmSurvivalBasic"
         )
     }

--- a/R/f_simulation_multiarm_survival_pw.R
+++ b/R/f_simulation_multiarm_survival_pw.R
@@ -183,9 +183,9 @@ getSimulationMultiArmSurvival <- function(
     if (simulationType == "auto") {
         if (usesBasicOnlyArgs && usesPatientWiseOnlyArgs) {
             stopConflictingArguments("arguments from both 'testStatisticBased' and 'patientWise' simulation types were specified",
-                functionName = "getSimulationMultiArmSurvival", 
-		parameter ="testStatisticBased", 
-		relatedParameter ="patientWise"
+                functionName = "getSimulationMultiArmSurvival",
+                parameter = "testStatisticBased",
+                relatedParameter = "patientWise"
             )
         }
         if (usesBasicOnlyArgs) {
@@ -200,8 +200,8 @@ getSimulationMultiArmSurvival <- function(
     if (simulationType == "testStatisticBased") {
         if (usesPatientWiseOnlyArgs) {
             stopIllegalArgument("patient-wise simulation arguments cannot be specified if 'simulationType' = \"testStatisticBased\"",
-                functionName = "getSimulationMultiArmSurvival", 
-		parameter ="simulationType", value = simulationType
+                functionName = "getSimulationMultiArmSurvival",
+                parameter = "simulationType", value = simulationType
             )
         }
 
@@ -247,9 +247,9 @@ getSimulationMultiArmSurvival <- function(
     if (simulationType %in% c("patientWise", "patientWiseBasic")) {
         if (usesBasicOnlyArgs) {
             stopIllegalArgument("'correlationComputation' cannot be specified if 'simulationType' = \"patientWise\" or \"patientWiseBasic\"",
-                functionName = "getSimulationMultiArmSurvival", 
-		parameter ="correlationComputation", 
-		relatedParameter ="simulationType",
+                functionName = "getSimulationMultiArmSurvival",
+                parameter = "correlationComputation",
+                relatedParameter = "simulationType",
                 value = correlationComputation
             )
         }
@@ -492,8 +492,8 @@ getSimulationMultiArmSurvivalPatientWise <- function(
 
     if (length(allocationRatioPlanned) != 1) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
-            functionName = "getSimulationMultiArmSurvivalPatientWise", 
-		parameter ="allocationRatioPlanned",
+            functionName = "getSimulationMultiArmSurvivalPatientWise",
+            parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }
@@ -582,13 +582,13 @@ getSimulationMultiArmSurvivalPatientWise <- function(
         if (accrualIntensity < 1L) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = "getSimulationMultiArmSurvivalPatientWise",
-                parameter = "accrualIntensity", 
-		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity",
+                relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
-            functionName = "getSimulationMultiArmSurvivalPatientWise", 
-		parameter ="maxNumberOfSubjects",
+            functionName = "getSimulationMultiArmSurvivalPatientWise",
+            parameter = "maxNumberOfSubjects",
             value = maxNumberOfSubjects
         )
     }
@@ -731,7 +731,7 @@ getSimulationMultiArmSurvivalPatientWise <- function(
         "numberOfSelectedArms",
         ifelse(gMax == 1, C_PARAM_NOT_APPLICABLE, C_PARAM_GENERATED)
     )
-    
+
     simulationResults$numberOfSubjects <- simulatedNumberOfSubjects
     simulationResults$analysisTime <- simulatedAnalysisTime
     simulationResults$eventsNotAchieved <- simulatedNumberEventsNotAchieved / maxNumberOfIterations
@@ -786,8 +786,9 @@ getSimulationMultiArmSurvivalPatientWise <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
-		functionName = "getSimulationMultiArmSurvivalPatientWise")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow",
+            functionName = "getSimulationMultiArmSurvivalPatientWise"
+        )
     }
 
     simulationResults$.data <- loopResult$data

--- a/R/f_simulation_multiarm_survival_pw.R
+++ b/R/f_simulation_multiarm_survival_pw.R
@@ -183,7 +183,9 @@ getSimulationMultiArmSurvival <- function(
     if (simulationType == "auto") {
         if (usesBasicOnlyArgs && usesPatientWiseOnlyArgs) {
             stopConflictingArguments("arguments from both 'testStatisticBased' and 'patientWise' simulation types were specified",
-                functionName = "getSimulationMultiArmSurvival", parameter = "testStatisticBased", relatedParameter = "patientWise"
+                functionName = "getSimulationMultiArmSurvival", 
+		parameter ="testStatisticBased", 
+		relatedParameter ="patientWise"
             )
         }
         if (usesBasicOnlyArgs) {
@@ -198,7 +200,8 @@ getSimulationMultiArmSurvival <- function(
     if (simulationType == "testStatisticBased") {
         if (usesPatientWiseOnlyArgs) {
             stopIllegalArgument("patient-wise simulation arguments cannot be specified if 'simulationType' = \"testStatisticBased\"",
-                functionName = "getSimulationMultiArmSurvival", parameter = "simulationType", value = simulationType
+                functionName = "getSimulationMultiArmSurvival", 
+		parameter ="simulationType", value = simulationType
             )
         }
 
@@ -244,7 +247,9 @@ getSimulationMultiArmSurvival <- function(
     if (simulationType %in% c("patientWise", "patientWiseBasic")) {
         if (usesBasicOnlyArgs) {
             stopIllegalArgument("'correlationComputation' cannot be specified if 'simulationType' = \"patientWise\" or \"patientWiseBasic\"",
-                functionName = "getSimulationMultiArmSurvival", parameter = "correlationComputation", relatedParameter = "simulationType",
+                functionName = "getSimulationMultiArmSurvival", 
+		parameter ="correlationComputation", 
+		relatedParameter ="simulationType",
                 value = correlationComputation
             )
         }
@@ -487,7 +492,8 @@ getSimulationMultiArmSurvivalPatientWise <- function(
 
     if (length(allocationRatioPlanned) != 1) {
         stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
-            functionName = "getSimulationMultiArmSurvivalPatientWise", parameter = "allocationRatioPlanned",
+            functionName = "getSimulationMultiArmSurvivalPatientWise", 
+		parameter ="allocationRatioPlanned",
             value = allocationRatioPlanned
         )
     }
@@ -576,11 +582,13 @@ getSimulationMultiArmSurvivalPatientWise <- function(
         if (accrualIntensity < 1L) {
             stopIllegalArgument("choose a 'accrualIntensity' > 1 or define 'maxNumberOfSubjects'",
                 functionName = "getSimulationMultiArmSurvivalPatientWise",
-                parameter = "accrualIntensity", relatedParameter = "maxNumberOfSubjects", value = accrualIntensity
+                parameter = "accrualIntensity", 
+		relatedParameter ="maxNumberOfSubjects", value = accrualIntensity
             )
         }
         stopIllegalArgument("'maxNumberOfSubjects' must be defined",
-            functionName = "getSimulationMultiArmSurvivalPatientWise", parameter = "maxNumberOfSubjects",
+            functionName = "getSimulationMultiArmSurvivalPatientWise", 
+		parameter ="maxNumberOfSubjects",
             value = maxNumberOfSubjects
         )
     }
@@ -778,7 +786,8 @@ getSimulationMultiArmSurvivalPatientWise <- function(
     }
 
     if (any(simulationResults$rejectedArmsPerStage < 0)) {
-        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", functionName = "getSimulationMultiArmSurvivalPatientWise")
+        stopRuntimeIssue("internal error, simulation not possible due to numerical overflow", 
+		functionName = "getSimulationMultiArmSurvivalPatientWise")
     }
 
     simulationResults$.data <- loopResult$data

--- a/R/f_simulation_multiarm_survival_pw.R
+++ b/R/f_simulation_multiarm_survival_pw.R
@@ -182,7 +182,9 @@ getSimulationMultiArmSurvival <- function(
 
     if (simulationType == "auto") {
         if (usesBasicOnlyArgs && usesPatientWiseOnlyArgs) {
-            stopConflictingArguments("arguments from both 'testStatisticBased' and 'patientWise' simulation types were specified",
+            stopConflictingArguments(
+                "arguments from both 'testStatisticBased' and 'patientWise' ",
+                "simulation types were specified",
                 functionName = "getSimulationMultiArmSurvival",
                 parameter = "testStatisticBased",
                 relatedParameter = "patientWise"
@@ -199,15 +201,19 @@ getSimulationMultiArmSurvival <- function(
 
     if (simulationType == "testStatisticBased") {
         if (usesPatientWiseOnlyArgs) {
-            stopIllegalArgument("patient-wise simulation arguments cannot be specified if 'simulationType' = \"testStatisticBased\"",
+            stopIllegalArgument(
+                "patient-wise simulation arguments cannot be specified ",
+                "if 'simulationType' = \"testStatisticBased\"",
                 functionName = "getSimulationMultiArmSurvival",
                 parameter = "simulationType", value = simulationType
             )
         }
 
         message(
-            "Note: 'simulationType' = \"testStatisticBased\" simulates normally distributed log-rank test statistics instead of patient-wise survival data. ",
-            "To simulate patient-wise survival data, specify 'simulationType' = \"patientWise\" and the corresponding arguments."
+            "Note: 'simulationType' = \"testStatisticBased\" simulates normally ",
+            "distributed log-rank test statistics instead of patient-wise survival data. ",
+            "To simulate patient-wise survival data, specify ",
+            "'simulationType' = \"patientWise\" and the corresponding arguments."
         )
 
         return(getSimulationMultiArmSurvivalBasic(
@@ -475,9 +481,11 @@ getSimulationMultiArmSurvivalPatientWise <- function(
 
     if (isFALSE(cppEnabled)) {
         message(
-            "Note: 'simulationType' = \"patientWiseBasic\" simulates patient-wise survival data using R code instead of C++ code. ",
+            "Note: 'simulationType' = \"patientWiseBasic\" simulates patient-wise ",
+            "survival data using R code instead of C++ code. ",
             "This approach is less efficient and should only be used for testing purposes. ",
-            "To perform a more efficient patient-wise simulation, specify 'simulationType' = \"patientWise\"."
+            "To perform a more efficient patient-wise simulation, ",
+            "specify 'simulationType' = \"patientWise\"."
         )
     }
 
@@ -491,7 +499,9 @@ getSimulationMultiArmSurvivalPatientWise <- function(
     )
 
     if (length(allocationRatioPlanned) != 1) {
-        stopIllegalArgument("'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ", "must have length 1",
+        stopIllegalArgument(
+            "'allocationRatioPlanned' (", .arrayToString(allocationRatioPlanned), ") ",
+            "must have length 1",
             functionName = "getSimulationMultiArmSurvivalPatientWise",
             parameter = "allocationRatioPlanned",
             value = allocationRatioPlanned
@@ -595,7 +605,10 @@ getSimulationMultiArmSurvivalPatientWise <- function(
     simulationResults$.accrualTime <- accrualSetup
 
     simulationResults$maxNumberOfSubjects <- accrualSetup$maxNumberOfSubjects
-    simulationResults$.setParameterType("maxNumberOfSubjects", accrualSetup$.getParameterType("maxNumberOfSubjects"))
+    simulationResults$.setParameterType(
+        "maxNumberOfSubjects",
+        accrualSetup$.getParameterType("maxNumberOfSubjects")
+    )
 
     allocationFraction <- .getFraction(allocationRatioPlanned)
     .warnInCaseOfExtremeAllocationRatios(allocationFraction[1], allocationFraction[2])

--- a/R/f_simulation_multiarm_survival_pw_basic.R
+++ b/R/f_simulation_multiarm_survival_pw_basic.R
@@ -544,7 +544,9 @@ NULL
                 )
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
-                    stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
+                    stopIllegalArgument(
+                        "'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", 
+                        "the output must be a single numeric value",
                         functionName = ".getSimulatedStageResultsSurvivalMultiArmPatientWise",
                         parameter = "calcEventsFunction", value = calcEventsFunction
                     )

--- a/R/f_simulation_multiarm_survival_pw_basic.R
+++ b/R/f_simulation_multiarm_survival_pw_basic.R
@@ -545,8 +545,8 @@ NULL
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageResultsSurvivalMultiArmPatientWise", 
-		parameter ="calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageResultsSurvivalMultiArmPatientWise",
+                        parameter = "calcEventsFunction", value = calcEventsFunction
                     )
                 }
 

--- a/R/f_simulation_multiarm_survival_pw_basic.R
+++ b/R/f_simulation_multiarm_survival_pw_basic.R
@@ -545,7 +545,8 @@ NULL
 
                 if (is.null(newEvents) || length(newEvents) != 1 || !is.numeric(newEvents) || is.na(newEvents)) {
                     stopIllegalArgument("'calcEventsFunction' returned an illegal or undefined result (", newEvents, "); ", "the output must be a single numeric value",
-                        functionName = ".getSimulatedStageResultsSurvivalMultiArmPatientWise", parameter = "calcEventsFunction", value = calcEventsFunction
+                        functionName = ".getSimulatedStageResultsSurvivalMultiArmPatientWise", 
+		parameter ="calcEventsFunction", value = calcEventsFunction
                     )
                 }
 

--- a/R/f_simulation_performance_score.R
+++ b/R/f_simulation_performance_score.R
@@ -56,7 +56,8 @@ getPerformanceScore <- function(simulationResult) {
     }
 
     if (design$kMax != 2) {
-        stopIllegalArgument("performance score so far implemented only for two-stage designs", functionName = "getPerformanceScore")
+        stopIllegalArgument("performance score so far implemented only for two-stage designs", 
+		functionName = "getPerformanceScore")
     }
 
     # initialize necessary sample size values
@@ -97,7 +98,8 @@ getPerformanceScore <- function(simulationResult) {
         referenceValue <- simulationResult$pi2
         args$pi2 <- referenceValue
     } else {
-        stopIllegalArgument("performance score is not available for class ", class(simulationResult)[1], functionName = "getPerformanceScore")
+        stopIllegalArgument("performance score is not available for class ", class(simulationResult)[1], 
+		functionName = "getPerformanceScore")
     }
     alternativeValues <- simulationResult[[alternativeParamName]]
 

--- a/R/f_simulation_performance_score.R
+++ b/R/f_simulation_performance_score.R
@@ -56,8 +56,9 @@ getPerformanceScore <- function(simulationResult) {
     }
 
     if (design$kMax != 2) {
-        stopIllegalArgument("performance score so far implemented only for two-stage designs", 
-		functionName = "getPerformanceScore")
+        stopIllegalArgument("performance score so far implemented only for two-stage designs",
+            functionName = "getPerformanceScore"
+        )
     }
 
     # initialize necessary sample size values
@@ -98,8 +99,9 @@ getPerformanceScore <- function(simulationResult) {
         referenceValue <- simulationResult$pi2
         args$pi2 <- referenceValue
     } else {
-        stopIllegalArgument("performance score is not available for class ", class(simulationResult)[1], 
-		functionName = "getPerformanceScore")
+        stopIllegalArgument("performance score is not available for class ", class(simulationResult)[1],
+            functionName = "getPerformanceScore"
+        )
     }
     alternativeValues <- simulationResult[[alternativeParamName]]
 

--- a/R/f_simulation_plot.R
+++ b/R/f_simulation_plot.R
@@ -23,8 +23,8 @@ NULL
                 anyNA(simulationResults$alternative) ||
                 length(simulationResults$alternative) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'alternative' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
-		parameter ="alternative"
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting",
+                parameter = "alternative"
             )
         }
     } else if (inherits(simulationResults, "SimulationResultsRates")) {
@@ -32,8 +32,8 @@ NULL
                 anyNA(simulationResults$pi1) ||
                 length(simulationResults$pi1) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'pi1' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
-		parameter ="pi1"
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting",
+                parameter = "pi1"
             )
         }
     } else if (inherits(simulationResults, "SimulationResultsSurvival")) {
@@ -41,14 +41,14 @@ NULL
                 anyNA(simulationResults$hazardRatio) ||
                 length(simulationResults$hazardRatio) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'hazardRatio' with length > 1 is defined or derived",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
-		parameter ="hazardRatio"
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting",
+                parameter = "hazardRatio"
             )
         }
         if (length(simulationResults$hazardRatio) != length(simulationResults$overallReject)) {
             stopIllegalArgument("plot type ", plotType, " is not available for piecewise survival (only type 13 and 14)",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
-		parameter ="plotType",
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting",
+                parameter = "plotType",
                 value = plotType
             )
         }
@@ -234,16 +234,16 @@ NULL
 
     if (type %in% c(1:3) && !multiArmEnabled && !enrichmentEnabled) {
         stopIllegalArgument("'type' (", type, ") is not available for non-multi-arm/non-enrichment simulation results (type must be > 3)",
-            functionName = ".plotSimulationResults", 
-		parameter ="type", value = type
+            functionName = ".plotSimulationResults",
+            parameter = "type", value = type
         )
     }
 
     if ((!survivalEnabled || multiArmEnabled || enrichmentEnabled) && type %in% c(10:14)) {
         if (multiArmEnabled || enrichmentEnabled) {
             stopIllegalArgument("'type' (", type, ") is only available for non-multi-arm/non-enrichment survival simulation results",
-                functionName = ".plotSimulationResults", 
-		parameter ="type", value = type
+                functionName = ".plotSimulationResults",
+                parameter = "type", value = type
             )
         } else {
             stopIllegalArgument("'type' (", type, ") is only available for survival simulation results",
@@ -276,8 +276,8 @@ NULL
             discreteXAxis <- effectDataList$discreteXAxis
             if (length(xValues) <= 1) {
                 stopIllegalArgument("2 ore more situations must be specifed in ", sQuote(paste0("effectList$", effectDataList$effectMatrixName)),
-                    functionName = ".plotSimulationResults", 
-		parameter =paste0("effectList$", effectDataList$effectMatrixName)
+                    functionName = ".plotSimulationResults",
+                    parameter = paste0("effectList$", effectDataList$effectMatrixName)
                 )
             }
         }
@@ -1004,8 +1004,9 @@ plot.SimulationResults <- function(
     if (all(is.na(type))) {
         type <- na.omit(getAvailablePlotTypes(x))
         if (length(type) == 0) {
-            stopIllegalArgument("not plot type available", 
-		functionName = "plot.SimulationResults")
+            stopIllegalArgument("not plot type available",
+                functionName = "plot.SimulationResults"
+            )
         }
 
         type <- type[1]

--- a/R/f_simulation_plot.R
+++ b/R/f_simulation_plot.R
@@ -23,7 +23,8 @@ NULL
                 anyNA(simulationResults$alternative) ||
                 length(simulationResults$alternative) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'alternative' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", parameter = "alternative"
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
+		parameter ="alternative"
             )
         }
     } else if (inherits(simulationResults, "SimulationResultsRates")) {
@@ -31,7 +32,8 @@ NULL
                 anyNA(simulationResults$pi1) ||
                 length(simulationResults$pi1) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'pi1' with length > 1 is defined",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", parameter = "pi1"
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
+		parameter ="pi1"
             )
         }
     } else if (inherits(simulationResults, "SimulationResultsSurvival")) {
@@ -39,12 +41,14 @@ NULL
                 anyNA(simulationResults$hazardRatio) ||
                 length(simulationResults$hazardRatio) <= 1) {
             stopIllegalArgument("plot type ", plotType, " is only available if 'hazardRatio' with length > 1 is defined or derived",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", parameter = "hazardRatio"
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
+		parameter ="hazardRatio"
             )
         }
         if (length(simulationResults$hazardRatio) != length(simulationResults$overallReject)) {
             stopIllegalArgument("plot type ", plotType, " is not available for piecewise survival (only type 13 and 14)",
-                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", parameter = "plotType",
+                functionName = ".assertIsValidVariedParameterVectorForSimulationResultsPlotting", 
+		parameter ="plotType",
                 value = plotType
             )
         }
@@ -230,14 +234,16 @@ NULL
 
     if (type %in% c(1:3) && !multiArmEnabled && !enrichmentEnabled) {
         stopIllegalArgument("'type' (", type, ") is not available for non-multi-arm/non-enrichment simulation results (type must be > 3)",
-            functionName = ".plotSimulationResults", parameter = "type", value = type
+            functionName = ".plotSimulationResults", 
+		parameter ="type", value = type
         )
     }
 
     if ((!survivalEnabled || multiArmEnabled || enrichmentEnabled) && type %in% c(10:14)) {
         if (multiArmEnabled || enrichmentEnabled) {
             stopIllegalArgument("'type' (", type, ") is only available for non-multi-arm/non-enrichment survival simulation results",
-                functionName = ".plotSimulationResults", parameter = "type", value = type
+                functionName = ".plotSimulationResults", 
+		parameter ="type", value = type
             )
         } else {
             stopIllegalArgument("'type' (", type, ") is only available for survival simulation results",
@@ -270,7 +276,8 @@ NULL
             discreteXAxis <- effectDataList$discreteXAxis
             if (length(xValues) <= 1) {
                 stopIllegalArgument("2 ore more situations must be specifed in ", sQuote(paste0("effectList$", effectDataList$effectMatrixName)),
-                    functionName = ".plotSimulationResults", parameter = paste0("effectList$", effectDataList$effectMatrixName)
+                    functionName = ".plotSimulationResults", 
+		parameter =paste0("effectList$", effectDataList$effectMatrixName)
                 )
             }
         }
@@ -997,7 +1004,8 @@ plot.SimulationResults <- function(
     if (all(is.na(type))) {
         type <- na.omit(getAvailablePlotTypes(x))
         if (length(type) == 0) {
-            stopIllegalArgument("not plot type available", functionName = "plot.SimulationResults")
+            stopIllegalArgument("not plot type available", 
+		functionName = "plot.SimulationResults")
         }
 
         type <- type[1]

--- a/R/f_simulation_plot.R
+++ b/R/f_simulation_plot.R
@@ -233,7 +233,9 @@ NULL
     }
 
     if (type %in% c(1:3) && !multiArmEnabled && !enrichmentEnabled) {
-        stopIllegalArgument("'type' (", type, ") is not available for non-multi-arm/non-enrichment simulation results (type must be > 3)",
+        stopIllegalArgument(
+            "'type' (", type, ") is not available for non-multi-arm/non-enrichment ",
+            "simulation results (type must be > 3)",
             functionName = ".plotSimulationResults",
             parameter = "type", value = type
         )
@@ -241,12 +243,15 @@ NULL
 
     if ((!survivalEnabled || multiArmEnabled || enrichmentEnabled) && type %in% c(10:14)) {
         if (multiArmEnabled || enrichmentEnabled) {
-            stopIllegalArgument("'type' (", type, ") is only available for non-multi-arm/non-enrichment survival simulation results",
+            stopIllegalArgument(
+                "'type' (", type, ") is only available for ",
+                "non-multi-arm/non-enrichment survival simulation results",
                 functionName = ".plotSimulationResults",
                 parameter = "type", value = type
             )
         } else {
-            stopIllegalArgument("'type' (", type, ") is only available for survival simulation results",
+            stopIllegalArgument(
+                "'type' (", type, ") is only available for survival simulation results",
                 functionName = ".plotSimulationResults",
                 parameter = "type", value = type
             )
@@ -275,7 +280,9 @@ NULL
             xValues <- effectDataList$xValues
             discreteXAxis <- effectDataList$discreteXAxis
             if (length(xValues) <= 1) {
-                stopIllegalArgument("2 ore more situations must be specifed in ", sQuote(paste0("effectList$", effectDataList$effectMatrixName)),
+                stopIllegalArgument(
+                    "2 ore more situations must be specifed in ",
+                    sQuote(paste0("effectList$", effectDataList$effectMatrixName)),
                     functionName = ".plotSimulationResults",
                     parameter = paste0("effectList$", effectDataList$effectMatrixName)
                 )

--- a/R/f_simulation_utilities.R
+++ b/R/f_simulation_utilities.R
@@ -45,9 +45,10 @@ NULL
 .setSeed <- function(seed = NA_real_) {
     if (!is.null(seed) && !is.na(seed)) {
         if (is.na(as.integer(seed))) {
-            stopIllegalArgument("'seed' must be a valid integer", 
-		functionName = ".setSeed", 
-		parameter ="seed", value = seed)
+            stopIllegalArgument("'seed' must be a valid integer",
+                functionName = ".setSeed",
+                parameter = "seed", value = seed
+            )
         }
 
         set.seed(seed = seed, kind = "Mersenne-Twister", normal.kind = "Inversion")
@@ -103,8 +104,8 @@ NULL
 
     if (!is.data.frame(data)) {
         stopIllegalArgument("'data' (", .getClassName(data), ") must be a data.frame or a simulation result object",
-            functionName = ".getSimulationParametersFromRawData", 
-		parameter ="data", value = data
+            functionName = ".getSimulationParametersFromRawData",
+            parameter = "data", value = data
         )
     }
 
@@ -182,8 +183,8 @@ NULL
     if (is.null(arg) || length(arg) == 0 || all(is.na(arg))) {
         stopIllegalArgument("'effectList' must contain ", sQuote(argName),
             functionName = ".assertArgumentFitsWithSubGroups",
-            parameter = "effectList", 
-		relatedParameter =argName
+            parameter = "effectList",
+            relatedParameter = argName
         )
     }
 
@@ -195,9 +196,9 @@ NULL
             argName <- paste0(argName, " (", .arrayToString(arg), ")")
         }
         stopIllegalArgument(argName, " must have ", length(subGroups), " columns given by the number of sub-groups",
-            functionName = ".assertArgumentFitsWithSubGroups", 
-		parameter =argName, 
-		relatedParameter ="subGroups",
+            functionName = ".assertArgumentFitsWithSubGroups",
+            parameter = argName,
+            relatedParameter = "subGroups",
             relatedValue = length(subGroups)
         )
     }
@@ -222,8 +223,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (is.null(effectList) || length(effectList) == 0 || !is.list(effectList)) {
         stopIllegalArgument(sQuote("effectList"), " must be a non-empty list",
-            functionName = ".getEffectData", 
-		parameter ="effectList",
+            functionName = ".getEffectData",
+            parameter = "effectList",
             value = effectList
         )
     }
@@ -231,8 +232,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     effectListNames <- names(effectList)
     if (is.null(effectListNames) || any(nchar(trimws(effectListNames)) == 0)) {
         stopIllegalArgument(sQuote("effectList"), " must be named. Current names are ", .arrayToString(effectListNames, encapsulate = TRUE),
-            functionName = ".getEffectData", 
-		parameter ="effectList", value = effectList
+            functionName = ".getEffectData",
+            parameter = "effectList", value = effectList
         )
     }
 
@@ -246,8 +247,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (!("subGroups" %in% effectListNames)) {
         stopIllegalArgument(sQuote("effectList"), " must contain ", sQuote("subGroups"),
-            functionName = ".getEffectData", 
-		parameter ="effectList",
+            functionName = ".getEffectData",
+            parameter = "effectList",
             relatedParameter = "subGroups", value = effectList
         )
     }
@@ -255,8 +256,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     subGroups <- effectList[["subGroups"]]
     if (is.null(subGroups) || length(subGroups) == 0 || (!is.character(subGroups) && !is.factor(subGroups))) {
         stopIllegalArgument(sQuote("effectList$subGroups"), " must be a non-empty character vector or factor",
-            functionName = ".getEffectData", 
-		parameter ="effectList$subGroups", value = effectList$subGroups
+            functionName = ".getEffectData",
+            parameter = "effectList$subGroups", value = effectList$subGroups
         )
     }
     if (is.factor(subGroups)) {
@@ -279,8 +280,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
                 2, "", "s"), " ", .arrayToString(subGroups[subGroups != "F"], encapsulate = TRUE, mode = "and"),
             " makes no sense and is not allowed (use remaining population 'R' instead of 'F')",
             functionName = ".getEffectData",
-            parameter = "F", 
-		relatedParameter ="R"
+            parameter = "F",
+            relatedParameter = "R"
             )
         }
         expectedSubGroups <- .createSubsetsByGMax(gMax, stratifiedInput = TRUE, all = FALSE)
@@ -292,8 +293,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     missingSubGroups <- expectedSubGroups[!(expectedSubGroups %in% subGroups)]
     if (length(missingSubGroups) > 0) {
         stopIllegalArgument(sQuote("effectList$subGroups"), " must contain ", .arrayToString(dQuote(missingSubGroups)),
-            functionName = ".getEffectData", 
-		parameter ="effectList$subGroups", value = effectList$subGroups,
+            functionName = ".getEffectData",
+            parameter = "effectList$subGroups", value = effectList$subGroups,
             relatedParameter = missingSubGroups
         )
     }
@@ -303,8 +304,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
         stopIllegalArgument(sQuote("effectList$subGroups"), " must not contain ", .arrayToString(dQuote(unknownSubGroups)),
             " (valid sub-group names: ", .arrayToString(dQuote(expectedSubGroups)), ")",
             functionName = ".getEffectData",
-            parameter = "effectList$subGroups", value = effectList$subGroups, 
-		relatedParameter =unknownSubGroups
+            parameter = "effectList$subGroups", value = effectList$subGroups,
+            relatedParameter = unknownSubGroups
         )
     }
 
@@ -330,8 +331,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (is.na(matrixName)) {
         stopIllegalArgument(sQuote("effectList"), " must contain ", .arrayToString(matrixNames, mode = "or", encapsulate = TRUE),
-            functionName = ".getEffectData", 
-		parameter ="effectList", value = effectList
+            functionName = ".getEffectData",
+            parameter = "effectList", value = effectList
         )
     }
 
@@ -357,8 +358,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (nrow(matrixValues) == 0) {
         stopIllegalArgument(sQuote(paste0("effectList$", matrixName)), " must have one or more rows ", "reflecting the different situations to consider",
-            functionName = ".getEffectData", 
-		parameter =paste0("effectList$", matrixName)
+            functionName = ".getEffectData",
+            parameter = paste0("effectList$", matrixName)
         )
     }
     .assertArgumentFitsWithSubGroups(matrixValues, matrixName, subGroups)
@@ -475,8 +476,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     if (!grepl("SimulationResultsEnrichment", .getClassName(obj))) {
         stopIllegalArgument(sQuote("obj"), " must be a SimulationResultsEnrichment object (is ", .getClassName(obj),
             ")",
-            functionName = ".getSimulationEnrichmentEffectMatrixName", 
-		parameter ="obj", value = obj
+            functionName = ".getSimulationEnrichmentEffectMatrixName",
+            parameter = "obj", value = obj
         )
     }
 
@@ -512,8 +513,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     if (length(xValues) <= 1) {
         if (validatePlotCapability) {
             stopIllegalArgument("2 ore more situations must be specifed in ", sQuote(paste0("effectList$", effectMatrixName)),
-                functionName = ".getSimulationEnrichmentEffectData", 
-		parameter =paste0("effectList$", effectMatrixName)
+                functionName = ".getSimulationEnrichmentEffectData",
+                parameter = paste0("effectList$", effectMatrixName)
             )
         }
         valid <- FALSE
@@ -557,8 +558,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
         stopIllegalArgument(sQuote(parameterName), " must contain ", ifelse(!is.na(expectedMatrixName), sQuote(expectedMatrixName),
             .arrayToString(matrixNames, mode = "or", encapsulate = TRUE)
         ),
-        functionName = ".getEffectList", 
-		parameter =parameterName,
+        functionName = ".getEffectList",
+        parameter = parameterName,
         relatedParameter = expectedMatrixName
         )
     }
@@ -578,8 +579,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
             if (!("stDev" %in% effectDataNames)) {
                 stopIllegalArgument(sQuote(parameterName), " must contain ", sQuote("stDev"),
                     functionName = ".getEffectList",
-                    parameter = parameterName, 
-		relatedParameter ="stDev"
+                    parameter = parameterName,
+                    relatedParameter = "stDev"
                 )
             }
             effectList$stDevs <- c(effectList$stDevs, subData$stDev[1])
@@ -587,8 +588,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
             if (!("piControl" %in% effectDataNames)) {
                 stopIllegalArgument(sQuote(parameterName), " must contain ", sQuote("piControl"),
                     functionName = ".getEffectList",
-                    parameter = parameterName, 
-		relatedParameter ="piControl"
+                    parameter = parameterName,
+                    relatedParameter = "piControl"
                 )
             }
             effectList$piControls <- c(effectList$piControls, subData$piControl[1])
@@ -657,15 +658,15 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     if (is.null(endpoint) || !(endpoint %in% c("means", "rates", "survival"))) {
         stopRuntimeIssue("'endpoint' (", endpoint, ") must be one of 'means', 'rates', or 'survival'",
             functionName = ".getValidatedEffectList",
-            parameter = "endpoint", value = endpoint, 
-		relatedParameter ="means"
+            parameter = "endpoint", value = endpoint,
+            relatedParameter = "means"
         )
     }
 
     if (is.null(effectList) || length(effectList) == 0 || (!is.list(effectList) && !is.data.frame(effectList))) {
         stopIllegalArgument("'effectList' must be a valid list or data.frame",
-            functionName = ".getValidatedEffectList", 
-		parameter ="effectList",
+            functionName = ".getValidatedEffectList",
+            parameter = "effectList",
             value = effectList
         )
     }
@@ -681,8 +682,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 .getVariedParameterSimulationMultiArm <- function(designPlan) {
     if (!grepl("SimulationResultsMultiArm", .getClassName(designPlan))) {
         stopIllegalArgument("'designPlan' (", .getClassName(designPlan), ") must be of class 'SimulationResultsMultiArm'",
-            functionName = ".getVariedParameterSimulationMultiArm", 
-		parameter ="designPlan", value = designPlan,
+            functionName = ".getVariedParameterSimulationMultiArm",
+            parameter = "designPlan", value = designPlan,
             relatedParameter = "SimulationResultsMultiArm"
         )
     }
@@ -696,8 +697,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     }
 
     stopIllegalArgument("'designPlan' (", .getClassName(designPlan), ") must be of class 'SimulationResultsMultiArm'",
-        functionName = ".getVariedParameterSimulationMultiArm", 
-		parameter ="designPlan", value = designPlan,
+        functionName = ".getVariedParameterSimulationMultiArm",
+        parameter = "designPlan", value = designPlan,
         relatedParameter = "SimulationResultsMultiArm"
     )
 }
@@ -771,8 +772,8 @@ getData <- function(x) {
     if (!inherits(x, "SimulationResults")) { #  or 'Dataset'
         stopIllegalArgument("'x' must be a 'SimulationResults' object; for example, use getSimulationMeans() to create one",
             functionName = "getData",
-            parameter = "x", 
-		relatedParameter ="SimulationResults", value = x
+            parameter = "x",
+            relatedParameter = "SimulationResults", value = x
         )
     }
 
@@ -789,8 +790,8 @@ getData.SimulationResults <- function(x) {
     if (!is.na(pi1)) {
         if (is.null(rawData[["pi1"]])) {
             stopRuntimeIssue("'rawData' does not contains a 'pi1' column",
-                functionName = ".getAggregatedDataByIterationNumber", 
-		parameter ="rawData",
+                functionName = ".getAggregatedDataByIterationNumber",
+                parameter = "rawData",
                 relatedParameter = "pi1", value = rawData
             )
         }
@@ -922,8 +923,8 @@ getRawData <- function(x, aggregate = FALSE) {
     if (!inherits(x, "SimulationResultsSurvival")) {
         stopIllegalArgument("'x' must be a 'SimulationResultsSurvival' object; use getSimulationSurvival() to create one",
             functionName = "getRawData",
-            parameter = "x", 
-		relatedParameter ="SimulationResultsSurvival", value = x
+            parameter = "x",
+            relatedParameter = "SimulationResultsSurvival", value = x
         )
     }
 
@@ -931,8 +932,8 @@ getRawData <- function(x, aggregate = FALSE) {
     if (is.null(rawData) || ncol(rawData) == 0 || nrow(rawData) == 0) {
         stopIllegalArgument("simulation results contain no raw data; ", "choose a 'maxNumberOfRawDatasetsPerStage' > 0, e.g., ",
             "getSimulationSurvival(..., maxNumberOfRawDatasetsPerStage = 1)",
-            functionName = "getRawData", 
-		parameter ="maxNumberOfRawDatasetsPerStage"
+            functionName = "getRawData",
+            parameter = "maxNumberOfRawDatasetsPerStage"
         )
     }
 
@@ -1021,13 +1022,13 @@ getRawData <- function(x, aggregate = FALSE) {
         simulationResults$.setParameterType("effectMatrix", C_PARAM_DERIVED)
         if (!is.null(gED50) && !is.na(gED50)) {
             warning("'gED50' (", gED50, ") will be ignored because 'typeOfShape' ",
-                "is defined as ", .vQuote(typeOfShape), 
+                "is defined as ", .vQuote(typeOfShape),
                 call. = FALSE
             )
         }
         if (!is.null(slope) && !is.na(slope) && slope != 1) {
             warning("'slope' (", slope, ") will be ignored because 'typeOfShape' ",
-                "is defined as ", .vQuote(typeOfShape), 
+                "is defined as ", .vQuote(typeOfShape),
                 call. = FALSE
             )
         }

--- a/R/f_simulation_utilities.R
+++ b/R/f_simulation_utilities.R
@@ -92,9 +92,11 @@ NULL
 
 .getSimulationParametersFromRawData <- function(data, ..., variantName, maxNumberOfIterations = NA_integer_) {
     if (is.null(data) || length(data) == 0) {
-        stopIllegalArgument("'data' must be a valid data.frame or a simulation result object",
+        stopIllegalArgument(
+            "'data' must be a valid data.frame or a simulation result object",
             functionName = ".getSimulationParametersFromRawData",
-            parameter = "data", value = data
+            parameter = "data",
+            value = data
         )
     }
 
@@ -103,9 +105,11 @@ NULL
     }
 
     if (!is.data.frame(data)) {
-        stopIllegalArgument("'data' (", .getClassName(data), ") must be a data.frame or a simulation result object",
+        stopIllegalArgument(
+            "'data' (", .getClassName(data), ") must be a data.frame or a simulation result object",
             functionName = ".getSimulationParametersFromRawData",
-            parameter = "data", value = data
+            parameter = "data",
+            value = data
         )
     }
 
@@ -222,7 +226,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     .assertIsSingleInteger(gMax, "gMax", naAllowed = TRUE, validateType = FALSE)
 
     if (is.null(effectList) || length(effectList) == 0 || !is.list(effectList)) {
-        stopIllegalArgument(sQuote("effectList"), " must be a non-empty list",
+        stopIllegalArgument(
+            sQuote("effectList"), " must be a non-empty list",
             functionName = ".getEffectData",
             parameter = "effectList",
             value = effectList
@@ -231,9 +236,12 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     effectListNames <- names(effectList)
     if (is.null(effectListNames) || any(nchar(trimws(effectListNames)) == 0)) {
-        stopIllegalArgument(sQuote("effectList"), " must be named. Current names are ", .arrayToString(effectListNames, encapsulate = TRUE),
+        stopIllegalArgument(
+            sQuote("effectList"), " must be named. Current names are ",
+            .arrayToString(effectListNames, encapsulate = TRUE),
             functionName = ".getEffectData",
-            parameter = "effectList", value = effectList
+            parameter = "effectList",
+            value = effectList
         )
     }
 
@@ -246,18 +254,22 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     effectListNames <- names(effectList)
 
     if (!("subGroups" %in% effectListNames)) {
-        stopIllegalArgument(sQuote("effectList"), " must contain ", sQuote("subGroups"),
+        stopIllegalArgument(
+            sQuote("effectList"), " must contain ", sQuote("subGroups"),
             functionName = ".getEffectData",
             parameter = "effectList",
-            relatedParameter = "subGroups", value = effectList
+            relatedParameter = "subGroups",
+            value = effectList
         )
     }
 
     subGroups <- effectList[["subGroups"]]
     if (is.null(subGroups) || length(subGroups) == 0 || (!is.character(subGroups) && !is.factor(subGroups))) {
-        stopIllegalArgument(sQuote("effectList$subGroups"), " must be a non-empty character vector or factor",
+        stopIllegalArgument(
+            sQuote("effectList$subGroups"), " must be a non-empty character vector or factor",
             functionName = ".getEffectData",
-            parameter = "effectList$subGroups", value = effectList$subGroups
+            parameter = "effectList$subGroups",
+            value = effectList$subGroups
         )
     }
     if (is.factor(subGroups)) {
@@ -276,12 +288,14 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
             }
         }
         if ("F" %in% subGroups) {
-            stopIllegalArgument("definition of full population 'F' ", "together with sub-groups", ifelse(length(subGroups) ==
-                2, "", "s"), " ", .arrayToString(subGroups[subGroups != "F"], encapsulate = TRUE, mode = "and"),
-            " makes no sense and is not allowed (use remaining population 'R' instead of 'F')",
-            functionName = ".getEffectData",
-            parameter = "F",
-            relatedParameter = "R"
+            stopIllegalArgument(
+                "definition of full population 'F' ", "together with sub-groups",
+                ifelse(length(subGroups) == 2, "", "s"), " ",
+                .arrayToString(subGroups[subGroups != "F"], encapsulate = TRUE, mode = "and"),
+                " makes no sense and is not allowed (use remaining population 'R' instead of 'F')",
+                functionName = ".getEffectData",
+                parameter = "F",
+                relatedParameter = "R"
             )
         }
         expectedSubGroups <- .createSubsetsByGMax(gMax, stratifiedInput = TRUE, all = FALSE)
@@ -292,19 +306,25 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     missingSubGroups <- expectedSubGroups[!(expectedSubGroups %in% subGroups)]
     if (length(missingSubGroups) > 0) {
-        stopIllegalArgument(sQuote("effectList$subGroups"), " must contain ", .arrayToString(dQuote(missingSubGroups)),
+        stopIllegalArgument(
+            sQuote("effectList$subGroups"), " must contain ",
+            .arrayToString(dQuote(missingSubGroups)),
             functionName = ".getEffectData",
-            parameter = "effectList$subGroups", value = effectList$subGroups,
+            parameter = "effectList$subGroups",
+            value = effectList$subGroups,
             relatedParameter = missingSubGroups
         )
     }
 
     unknownSubGroups <- subGroups[!(subGroups %in% expectedSubGroups)]
     if (length(unknownSubGroups) > 0) {
-        stopIllegalArgument(sQuote("effectList$subGroups"), " must not contain ", .arrayToString(dQuote(unknownSubGroups)),
+        stopIllegalArgument(
+            sQuote("effectList$subGroups"), " must not contain ",
+            .arrayToString(dQuote(unknownSubGroups)),
             " (valid sub-group names: ", .arrayToString(dQuote(expectedSubGroups)), ")",
             functionName = ".getEffectData",
-            parameter = "effectList$subGroups", value = effectList$subGroups,
+            parameter = "effectList$subGroups",
+            value = effectList$subGroups,
             relatedParameter = unknownSubGroups
         )
     }
@@ -330,7 +350,9 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     }
 
     if (is.na(matrixName)) {
-        stopIllegalArgument(sQuote("effectList"), " must contain ", .arrayToString(matrixNames, mode = "or", encapsulate = TRUE),
+        stopIllegalArgument(
+            sQuote("effectList"), " must contain ",
+            .arrayToString(matrixNames, mode = "or", encapsulate = TRUE),
             functionName = ".getEffectData",
             parameter = "effectList", value = effectList
         )
@@ -346,7 +368,9 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     }
 
     if (!is.matrix(matrixValues) && !is.data.frame(matrixValues)) {
-        stopIllegalArgument(sQuote(paste0("effectList$", matrixName)), " must be a matrix or data.frame",
+        stopIllegalArgument(
+            sQuote(paste0("effectList$", matrixName)),
+            " must be a matrix or data.frame",
             functionName = ".getEffectData",
             parameter = paste0("effectList$", matrixName)
         )
@@ -357,7 +381,9 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     }
 
     if (nrow(matrixValues) == 0) {
-        stopIllegalArgument(sQuote(paste0("effectList$", matrixName)), " must have one or more rows ", "reflecting the different situations to consider",
+        stopIllegalArgument(
+            sQuote(paste0("effectList$", matrixName)), " must have one or more rows ",
+            "reflecting the different situations to consider",
             functionName = ".getEffectData",
             parameter = paste0("effectList$", matrixName)
         )
@@ -474,8 +500,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
 .getSimulationEnrichmentEffectMatrixName <- function(obj) {
     if (!grepl("SimulationResultsEnrichment", .getClassName(obj))) {
-        stopIllegalArgument(sQuote("obj"), " must be a SimulationResultsEnrichment object (is ", .getClassName(obj),
-            ")",
+        stopIllegalArgument(
+            sQuote("obj"), " must be a SimulationResultsEnrichment object (is ", .getClassName(obj), ")",
             functionName = ".getSimulationEnrichmentEffectMatrixName",
             parameter = "obj", value = obj
         )
@@ -512,7 +538,9 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     valid <- TRUE
     if (length(xValues) <= 1) {
         if (validatePlotCapability) {
-            stopIllegalArgument("2 ore more situations must be specifed in ", sQuote(paste0("effectList$", effectMatrixName)),
+            stopIllegalArgument(
+                "2 ore more situations must be specifed in ",
+                sQuote(paste0("effectList$", effectMatrixName)),
                 functionName = ".getSimulationEnrichmentEffectData",
                 parameter = paste0("effectList$", effectMatrixName)
             )
@@ -555,12 +583,14 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
         }
     }
     if (is.na(matrixName)) {
-        stopIllegalArgument(sQuote(parameterName), " must contain ", ifelse(!is.na(expectedMatrixName), sQuote(expectedMatrixName),
-            .arrayToString(matrixNames, mode = "or", encapsulate = TRUE)
-        ),
-        functionName = ".getEffectList",
-        parameter = parameterName,
-        relatedParameter = expectedMatrixName
+        stopIllegalArgument(
+            sQuote(parameterName), " must contain ",
+            ifelse(!is.na(expectedMatrixName), sQuote(expectedMatrixName),
+                .arrayToString(matrixNames, mode = "or", encapsulate = TRUE)
+            ),
+            functionName = ".getEffectList",
+            parameter = parameterName,
+            relatedParameter = expectedMatrixName
         )
     }
 
@@ -577,7 +607,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
         effectList$prevalences <- c(effectList$prevalences, subData$prevalence[1])
         if (matrixName == "effect") {
             if (!("stDev" %in% effectDataNames)) {
-                stopIllegalArgument(sQuote(parameterName), " must contain ", sQuote("stDev"),
+                stopIllegalArgument(
+                    sQuote(parameterName), " must contain ", sQuote("stDev"),
                     functionName = ".getEffectList",
                     parameter = parameterName,
                     relatedParameter = "stDev"
@@ -586,7 +617,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
             effectList$stDevs <- c(effectList$stDevs, subData$stDev[1])
         } else if (matrixName == "piTreatment" || (matrixName == "hazardRatio" && "piControl" %in% effectDataNames)) {
             if (!("piControl" %in% effectDataNames)) {
-                stopIllegalArgument(sQuote(parameterName), " must contain ", sQuote("piControl"),
+                stopIllegalArgument(
+                    sQuote(parameterName), " must contain ", sQuote("piControl"),
                     functionName = ".getEffectList",
                     parameter = parameterName,
                     relatedParameter = "piControl"
@@ -656,7 +688,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
 .getValidatedEffectList <- function(effectList, ..., endpoint, gMax = NA_integer_, nullAllowed = TRUE) {
     if (is.null(endpoint) || !(endpoint %in% c("means", "rates", "survival"))) {
-        stopRuntimeIssue("'endpoint' (", endpoint, ") must be one of 'means', 'rates', or 'survival'",
+        stopRuntimeIssue(
+            "'endpoint' (", endpoint, ") must be one of 'means', 'rates', or 'survival'",
             functionName = ".getValidatedEffectList",
             parameter = "endpoint", value = endpoint,
             relatedParameter = "means"
@@ -921,7 +954,9 @@ getData.SimulationResults <- function(x) {
 #'
 getRawData <- function(x, aggregate = FALSE) {
     if (!inherits(x, "SimulationResultsSurvival")) {
-        stopIllegalArgument("'x' must be a 'SimulationResultsSurvival' object; use getSimulationSurvival() to create one",
+        stopIllegalArgument(
+            "'x' must be a 'SimulationResultsSurvival' object; ",
+            "use getSimulationSurvival() to create one",
             functionName = "getRawData",
             parameter = "x",
             relatedParameter = "SimulationResultsSurvival", value = x
@@ -930,7 +965,9 @@ getRawData <- function(x, aggregate = FALSE) {
 
     rawData <- x$.rawData
     if (is.null(rawData) || ncol(rawData) == 0 || nrow(rawData) == 0) {
-        stopIllegalArgument("simulation results contain no raw data; ", "choose a 'maxNumberOfRawDatasetsPerStage' > 0, e.g., ",
+        stopIllegalArgument(
+            "simulation results contain no raw data; ",
+            "choose a 'maxNumberOfRawDatasetsPerStage' > 0, e.g., ",
             "getSimulationSurvival(..., maxNumberOfRawDatasetsPerStage = 1)",
             functionName = "getRawData",
             parameter = "maxNumberOfRawDatasetsPerStage"

--- a/R/f_simulation_utilities.R
+++ b/R/f_simulation_utilities.R
@@ -45,7 +45,9 @@ NULL
 .setSeed <- function(seed = NA_real_) {
     if (!is.null(seed) && !is.na(seed)) {
         if (is.na(as.integer(seed))) {
-            stopIllegalArgument("'seed' must be a valid integer", functionName = ".setSeed", parameter = "seed", value = seed)
+            stopIllegalArgument("'seed' must be a valid integer", 
+		functionName = ".setSeed", 
+		parameter ="seed", value = seed)
         }
 
         set.seed(seed = seed, kind = "Mersenne-Twister", normal.kind = "Inversion")
@@ -101,7 +103,8 @@ NULL
 
     if (!is.data.frame(data)) {
         stopIllegalArgument("'data' (", .getClassName(data), ") must be a data.frame or a simulation result object",
-            functionName = ".getSimulationParametersFromRawData", parameter = "data", value = data
+            functionName = ".getSimulationParametersFromRawData", 
+		parameter ="data", value = data
         )
     }
 
@@ -179,7 +182,8 @@ NULL
     if (is.null(arg) || length(arg) == 0 || all(is.na(arg))) {
         stopIllegalArgument("'effectList' must contain ", sQuote(argName),
             functionName = ".assertArgumentFitsWithSubGroups",
-            parameter = "effectList", relatedParameter = argName
+            parameter = "effectList", 
+		relatedParameter =argName
         )
     }
 
@@ -191,7 +195,9 @@ NULL
             argName <- paste0(argName, " (", .arrayToString(arg), ")")
         }
         stopIllegalArgument(argName, " must have ", length(subGroups), " columns given by the number of sub-groups",
-            functionName = ".assertArgumentFitsWithSubGroups", parameter = argName, relatedParameter = "subGroups",
+            functionName = ".assertArgumentFitsWithSubGroups", 
+		parameter =argName, 
+		relatedParameter ="subGroups",
             relatedValue = length(subGroups)
         )
     }
@@ -216,7 +222,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (is.null(effectList) || length(effectList) == 0 || !is.list(effectList)) {
         stopIllegalArgument(sQuote("effectList"), " must be a non-empty list",
-            functionName = ".getEffectData", parameter = "effectList",
+            functionName = ".getEffectData", 
+		parameter ="effectList",
             value = effectList
         )
     }
@@ -224,7 +231,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     effectListNames <- names(effectList)
     if (is.null(effectListNames) || any(nchar(trimws(effectListNames)) == 0)) {
         stopIllegalArgument(sQuote("effectList"), " must be named. Current names are ", .arrayToString(effectListNames, encapsulate = TRUE),
-            functionName = ".getEffectData", parameter = "effectList", value = effectList
+            functionName = ".getEffectData", 
+		parameter ="effectList", value = effectList
         )
     }
 
@@ -238,7 +246,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (!("subGroups" %in% effectListNames)) {
         stopIllegalArgument(sQuote("effectList"), " must contain ", sQuote("subGroups"),
-            functionName = ".getEffectData", parameter = "effectList",
+            functionName = ".getEffectData", 
+		parameter ="effectList",
             relatedParameter = "subGroups", value = effectList
         )
     }
@@ -246,7 +255,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     subGroups <- effectList[["subGroups"]]
     if (is.null(subGroups) || length(subGroups) == 0 || (!is.character(subGroups) && !is.factor(subGroups))) {
         stopIllegalArgument(sQuote("effectList$subGroups"), " must be a non-empty character vector or factor",
-            functionName = ".getEffectData", parameter = "effectList$subGroups", value = effectList$subGroups
+            functionName = ".getEffectData", 
+		parameter ="effectList$subGroups", value = effectList$subGroups
         )
     }
     if (is.factor(subGroups)) {
@@ -269,7 +279,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
                 2, "", "s"), " ", .arrayToString(subGroups[subGroups != "F"], encapsulate = TRUE, mode = "and"),
             " makes no sense and is not allowed (use remaining population 'R' instead of 'F')",
             functionName = ".getEffectData",
-            parameter = "F", relatedParameter = "R"
+            parameter = "F", 
+		relatedParameter ="R"
             )
         }
         expectedSubGroups <- .createSubsetsByGMax(gMax, stratifiedInput = TRUE, all = FALSE)
@@ -281,7 +292,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     missingSubGroups <- expectedSubGroups[!(expectedSubGroups %in% subGroups)]
     if (length(missingSubGroups) > 0) {
         stopIllegalArgument(sQuote("effectList$subGroups"), " must contain ", .arrayToString(dQuote(missingSubGroups)),
-            functionName = ".getEffectData", parameter = "effectList$subGroups", value = effectList$subGroups,
+            functionName = ".getEffectData", 
+		parameter ="effectList$subGroups", value = effectList$subGroups,
             relatedParameter = missingSubGroups
         )
     }
@@ -291,7 +303,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
         stopIllegalArgument(sQuote("effectList$subGroups"), " must not contain ", .arrayToString(dQuote(unknownSubGroups)),
             " (valid sub-group names: ", .arrayToString(dQuote(expectedSubGroups)), ")",
             functionName = ".getEffectData",
-            parameter = "effectList$subGroups", value = effectList$subGroups, relatedParameter = unknownSubGroups
+            parameter = "effectList$subGroups", value = effectList$subGroups, 
+		relatedParameter =unknownSubGroups
         )
     }
 
@@ -317,7 +330,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (is.na(matrixName)) {
         stopIllegalArgument(sQuote("effectList"), " must contain ", .arrayToString(matrixNames, mode = "or", encapsulate = TRUE),
-            functionName = ".getEffectData", parameter = "effectList", value = effectList
+            functionName = ".getEffectData", 
+		parameter ="effectList", value = effectList
         )
     }
 
@@ -343,7 +357,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 
     if (nrow(matrixValues) == 0) {
         stopIllegalArgument(sQuote(paste0("effectList$", matrixName)), " must have one or more rows ", "reflecting the different situations to consider",
-            functionName = ".getEffectData", parameter = paste0("effectList$", matrixName)
+            functionName = ".getEffectData", 
+		parameter =paste0("effectList$", matrixName)
         )
     }
     .assertArgumentFitsWithSubGroups(matrixValues, matrixName, subGroups)
@@ -460,7 +475,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     if (!grepl("SimulationResultsEnrichment", .getClassName(obj))) {
         stopIllegalArgument(sQuote("obj"), " must be a SimulationResultsEnrichment object (is ", .getClassName(obj),
             ")",
-            functionName = ".getSimulationEnrichmentEffectMatrixName", parameter = "obj", value = obj
+            functionName = ".getSimulationEnrichmentEffectMatrixName", 
+		parameter ="obj", value = obj
         )
     }
 
@@ -496,7 +512,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     if (length(xValues) <= 1) {
         if (validatePlotCapability) {
             stopIllegalArgument("2 ore more situations must be specifed in ", sQuote(paste0("effectList$", effectMatrixName)),
-                functionName = ".getSimulationEnrichmentEffectData", parameter = paste0("effectList$", effectMatrixName)
+                functionName = ".getSimulationEnrichmentEffectData", 
+		parameter =paste0("effectList$", effectMatrixName)
             )
         }
         valid <- FALSE
@@ -540,7 +557,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
         stopIllegalArgument(sQuote(parameterName), " must contain ", ifelse(!is.na(expectedMatrixName), sQuote(expectedMatrixName),
             .arrayToString(matrixNames, mode = "or", encapsulate = TRUE)
         ),
-        functionName = ".getEffectList", parameter = parameterName,
+        functionName = ".getEffectList", 
+		parameter =parameterName,
         relatedParameter = expectedMatrixName
         )
     }
@@ -560,7 +578,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
             if (!("stDev" %in% effectDataNames)) {
                 stopIllegalArgument(sQuote(parameterName), " must contain ", sQuote("stDev"),
                     functionName = ".getEffectList",
-                    parameter = parameterName, relatedParameter = "stDev"
+                    parameter = parameterName, 
+		relatedParameter ="stDev"
                 )
             }
             effectList$stDevs <- c(effectList$stDevs, subData$stDev[1])
@@ -568,7 +587,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
             if (!("piControl" %in% effectDataNames)) {
                 stopIllegalArgument(sQuote(parameterName), " must contain ", sQuote("piControl"),
                     functionName = ".getEffectList",
-                    parameter = parameterName, relatedParameter = "piControl"
+                    parameter = parameterName, 
+		relatedParameter ="piControl"
                 )
             }
             effectList$piControls <- c(effectList$piControls, subData$piControl[1])
@@ -637,13 +657,15 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     if (is.null(endpoint) || !(endpoint %in% c("means", "rates", "survival"))) {
         stopRuntimeIssue("'endpoint' (", endpoint, ") must be one of 'means', 'rates', or 'survival'",
             functionName = ".getValidatedEffectList",
-            parameter = "endpoint", value = endpoint, relatedParameter = "means"
+            parameter = "endpoint", value = endpoint, 
+		relatedParameter ="means"
         )
     }
 
     if (is.null(effectList) || length(effectList) == 0 || (!is.list(effectList) && !is.data.frame(effectList))) {
         stopIllegalArgument("'effectList' must be a valid list or data.frame",
-            functionName = ".getValidatedEffectList", parameter = "effectList",
+            functionName = ".getValidatedEffectList", 
+		parameter ="effectList",
             value = effectList
         )
     }
@@ -659,7 +681,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 .getVariedParameterSimulationMultiArm <- function(designPlan) {
     if (!grepl("SimulationResultsMultiArm", .getClassName(designPlan))) {
         stopIllegalArgument("'designPlan' (", .getClassName(designPlan), ") must be of class 'SimulationResultsMultiArm'",
-            functionName = ".getVariedParameterSimulationMultiArm", parameter = "designPlan", value = designPlan,
+            functionName = ".getVariedParameterSimulationMultiArm", 
+		parameter ="designPlan", value = designPlan,
             relatedParameter = "SimulationResultsMultiArm"
         )
     }
@@ -673,7 +696,8 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
     }
 
     stopIllegalArgument("'designPlan' (", .getClassName(designPlan), ") must be of class 'SimulationResultsMultiArm'",
-        functionName = ".getVariedParameterSimulationMultiArm", parameter = "designPlan", value = designPlan,
+        functionName = ".getVariedParameterSimulationMultiArm", 
+		parameter ="designPlan", value = designPlan,
         relatedParameter = "SimulationResultsMultiArm"
     )
 }
@@ -747,7 +771,8 @@ getData <- function(x) {
     if (!inherits(x, "SimulationResults")) { #  or 'Dataset'
         stopIllegalArgument("'x' must be a 'SimulationResults' object; for example, use getSimulationMeans() to create one",
             functionName = "getData",
-            parameter = "x", relatedParameter = "SimulationResults", value = x
+            parameter = "x", 
+		relatedParameter ="SimulationResults", value = x
         )
     }
 
@@ -764,7 +789,8 @@ getData.SimulationResults <- function(x) {
     if (!is.na(pi1)) {
         if (is.null(rawData[["pi1"]])) {
             stopRuntimeIssue("'rawData' does not contains a 'pi1' column",
-                functionName = ".getAggregatedDataByIterationNumber", parameter = "rawData",
+                functionName = ".getAggregatedDataByIterationNumber", 
+		parameter ="rawData",
                 relatedParameter = "pi1", value = rawData
             )
         }
@@ -896,7 +922,8 @@ getRawData <- function(x, aggregate = FALSE) {
     if (!inherits(x, "SimulationResultsSurvival")) {
         stopIllegalArgument("'x' must be a 'SimulationResultsSurvival' object; use getSimulationSurvival() to create one",
             functionName = "getRawData",
-            parameter = "x", relatedParameter = "SimulationResultsSurvival", value = x
+            parameter = "x", 
+		relatedParameter ="SimulationResultsSurvival", value = x
         )
     }
 
@@ -904,7 +931,8 @@ getRawData <- function(x, aggregate = FALSE) {
     if (is.null(rawData) || ncol(rawData) == 0 || nrow(rawData) == 0) {
         stopIllegalArgument("simulation results contain no raw data; ", "choose a 'maxNumberOfRawDatasetsPerStage' > 0, e.g., ",
             "getSimulationSurvival(..., maxNumberOfRawDatasetsPerStage = 1)",
-            functionName = "getRawData", parameter = "maxNumberOfRawDatasetsPerStage"
+            functionName = "getRawData", 
+		parameter ="maxNumberOfRawDatasetsPerStage"
         )
     }
 
@@ -993,13 +1021,13 @@ getRawData <- function(x, aggregate = FALSE) {
         simulationResults$.setParameterType("effectMatrix", C_PARAM_DERIVED)
         if (!is.null(gED50) && !is.na(gED50)) {
             warning("'gED50' (", gED50, ") will be ignored because 'typeOfShape' ",
-                "is defined as '", typeOfShape, "'",
+                "is defined as ", .vQuote(typeOfShape), 
                 call. = FALSE
             )
         }
         if (!is.null(slope) && !is.na(slope) && slope != 1) {
             warning("'slope' (", slope, ") will be ignored because 'typeOfShape' ",
-                "is defined as '", typeOfShape, "'",
+                "is defined as ", .vQuote(typeOfShape), 
                 call. = FALSE
             )
         }

--- a/man/TrialDesignPlanRates.Rd
+++ b/man/TrialDesignPlanRates.Rd
@@ -7,7 +7,8 @@
 Trial design plan for rates.
 }
 \details{
-This object cannot be created directly; use \code{\link[=getSampleSizeRates]{getSampleSizeRates()}}
+This object cannot be created directly;
+use \code{\link[=getSampleSizeRates]{getSampleSizeRates()}}
 with suitable arguments to create a design plan for a dataset of rates.
 }
 \section{Fields}{

--- a/man/TrialDesignPlanSurvival.Rd
+++ b/man/TrialDesignPlanSurvival.Rd
@@ -7,7 +7,8 @@
 Trial design plan for survival data.
 }
 \details{
-This object cannot be created directly; use \code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}}
+This object cannot be created directly;
+use \code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}}
 with suitable arguments to create a design plan for a dataset of survival data.
 }
 \section{Fields}{

--- a/man/dataEnrichmentMeans.Rd
+++ b/man/dataEnrichmentMeans.Rd
@@ -12,6 +12,7 @@ dataEnrichmentMeans
 }
 \description{
 A dataset containing the sample sizes, means, and standard deviations of two groups.
-Use \code{getDataset(dataEnrichmentMeans)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataEnrichmentMeans)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataEnrichmentMeansStratified.Rd
+++ b/man/dataEnrichmentMeansStratified.Rd
@@ -12,6 +12,7 @@ dataEnrichmentMeansStratified
 }
 \description{
 A dataset containing the sample sizes, means, and standard deviations of two groups.
-Use \code{getDataset(dataEnrichmentMeansStratified)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataEnrichmentMeansStratified)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataEnrichmentRates.Rd
+++ b/man/dataEnrichmentRates.Rd
@@ -12,6 +12,7 @@ dataEnrichmentRates
 }
 \description{
 A dataset containing the sample sizes and events of two groups.
-Use \code{getDataset(dataEnrichmentRates)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataEnrichmentRates)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataEnrichmentRatesStratified.Rd
+++ b/man/dataEnrichmentRatesStratified.Rd
@@ -12,6 +12,7 @@ dataEnrichmentRatesStratified
 }
 \description{
 A dataset containing the sample sizes and events of two groups.
-Use \code{getDataset(dataEnrichmentRatesStratified)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataEnrichmentRatesStratified)} to create a dataset object that
+can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataEnrichmentSurvival.Rd
+++ b/man/dataEnrichmentSurvival.Rd
@@ -12,6 +12,7 @@ dataEnrichmentSurvival
 }
 \description{
 A dataset containing the log-rank statistics, events, and allocation ratios of two groups.
-Use \code{getDataset(dataEnrichmentSurvival)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataEnrichmentSurvival)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataEnrichmentSurvivalStratified.Rd
+++ b/man/dataEnrichmentSurvivalStratified.Rd
@@ -12,6 +12,7 @@ dataEnrichmentSurvivalStratified
 }
 \description{
 A dataset containing the log-rank statistics, events, and allocation ratios of two groups.
-Use \code{getDataset(dataEnrichmentSurvivalStratified)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataEnrichmentSurvivalStratified)} to create a dataset object that
+can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataMeans.Rd
+++ b/man/dataMeans.Rd
@@ -12,6 +12,7 @@ dataMeans
 }
 \description{
 A dataset containing the sample sizes, means, and standard deviations of one group.
-Use \code{getDataset(dataMeans)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataMeans)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataMultiArmMeans.Rd
+++ b/man/dataMultiArmMeans.Rd
@@ -12,6 +12,7 @@ dataMultiArmMeans
 }
 \description{
 A dataset containing the sample sizes, means, and standard deviations of four groups.
-Use \code{getDataset(dataMultiArmMeans)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataMultiArmMeans)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataMultiArmRates.Rd
+++ b/man/dataMultiArmRates.Rd
@@ -12,6 +12,7 @@ dataMultiArmRates
 }
 \description{
 A dataset containing the sample sizes and events of three groups.
-Use \code{getDataset(dataMultiArmRates)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataMultiArmRates)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataMultiArmSurvival.Rd
+++ b/man/dataMultiArmSurvival.Rd
@@ -12,6 +12,7 @@ dataMultiArmSurvival
 }
 \description{
 A dataset containing the log-rank statistics, events, and allocation ratios of three groups.
-Use \code{getDataset(dataMultiArmSurvival)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataMultiArmSurvival)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataRates.Rd
+++ b/man/dataRates.Rd
@@ -12,6 +12,7 @@ dataRates
 }
 \description{
 A dataset containing the sample sizes and events of one group.
-Use \code{getDataset(dataRates)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataRates)} to create a dataset object that can
+be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/dataSurvival.Rd
+++ b/man/dataSurvival.Rd
@@ -12,6 +12,7 @@ dataSurvival
 }
 \description{
 A dataset containing the log-rank statistics, events, and allocation ratios of one group.
-Use \code{getDataset(dataSurvival)} to create a dataset object that can be processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
+Use \code{getDataset(dataSurvival)} to create a dataset object that can b
+e processed by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.
 }
 \keyword{internal}

--- a/man/fetch.ParameterSet.Rd
+++ b/man/fetch.ParameterSet.Rd
@@ -24,12 +24,14 @@ fetch(x, ..., output)
 \item a positive integer, giving the position counting from the left
 \item a negative integer, giving the position counting from the right.
 The default returns the last parameter.
-This argument is taken by expression and supports quasi-quotation (you can unquote column names and column locations).
+This argument is taken by expression and supports quasi-quotation
+(you can unquote column names and column locations).
 }}
 
 \item{output}{A character defining the output type as follows:
 \itemize{
-\item "named" (default) returns the named value if the value is a single value, the value inside a named list otherwise
+\item "named" (default) returns the named value if the value is
+a single value, the value inside a named list otherwise
 \item "value" returns only the value itself
 \item "list" returns the value inside a named list
 }}

--- a/man/getDesignCharacteristics.Rd
+++ b/man/getDesignCharacteristics.Rd
@@ -20,7 +20,8 @@ The following generics (R generic functions) are available for this result objec
 \item \code{\link[=print.FieldSet]{print()}} to print the object,
 \item \code{\link[=summary.ParameterSet]{summary()}} to display a summary of the object,
 \item \code{\link[=plot.ParameterSet]{plot()}} to plot the object,
-\item \code{\link[=as.data.frame.TrialDesignCharacteristics]{as.data.frame()}} to coerce the object to a \code{\link[base]{data.frame}},
+\item \code{\link[=as.data.frame.TrialDesignCharacteristics]{as.data.frame()}}
+to coerce the object to a \code{\link[base]{data.frame}},
 \item \code{\link[=as.matrix.FieldSet]{as.matrix()}} to coerce the object to a \code{\link[base]{matrix}}.
 }
 }

--- a/man/getFisherInformation.Rd
+++ b/man/getFisherInformation.Rd
@@ -2,32 +2,35 @@
 % Please edit documentation in R/f_design_futility_bounds.R
 \name{getFisherInformation}
 \alias{getFisherInformation}
-\title{Get Fisher Information From a Design Plan}
+\title{Get Fisher Information From a Design Plan or Simulation Results}
 \usage{
 getFisherInformation(designPlan)
 }
 \arguments{
-\item{designPlan}{A trial design plan object as returned by functions such as
+\item{designPlan}{A trial design plan or simulation results object as returned by functions such as
 \code{\link[=getSampleSizeMeans]{getSampleSizeMeans()}},
 \code{\link[=getPowerMeans]{getPowerMeans()}},
 \code{\link[=getSampleSizeRates]{getSampleSizeRates()}},
 \code{\link[=getPowerRates]{getPowerRates()}},
-\code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}}, or
-\code{\link[=getPowerSurvival]{getPowerSurvival()}}.}
+\code{\link[=getSampleSizeSurvival]{getSampleSizeSurvival()}},
+\code{\link[=getPowerSurvival]{getPowerSurvival()}},
+\code{\link[=getSimulationMeans]{getSimulationMeans()}},
+\code{\link[=getSimulationRates]{getSimulationRates()}}, or
+\code{\link[=getSimulationSurvival]{getSimulationSurvival()}}.}
 }
 \value{
 A numeric value or numeric vector containing the first-stage Fisher
-information. A vector is returned if the design plan contains several
+information. A vector is returned if the object contains several
 planning alternatives or sample size values. \code{NA_real_} is returned if
 the endpoint type is not supported by this helper.
 }
 \description{
 Calculates the Fisher information at the first planned analysis stage for
-a design plan for means, rates, or survival endpoints.
+a design plan or simulation results object for means, rates, or survival endpoints.
 }
 \details{
 The returned information is the information used at the first stage of the
-design plan. For group sequential designs, information at later stages can be
+design plan or simulation setup. For group sequential designs, information at later stages can be
 obtained by multiplying this value by the ratio of the corresponding
 information rate to the first information rate.
 
@@ -47,6 +50,12 @@ designPlan <- getPowerMeans(design,
     alternative = c(0.3, 0.4), maxNumberOfSubjects = 100
 )
 getFisherInformation(designPlan)
+
+simulationResults <- getSimulationMeans(design,
+    plannedSubjects = c(20, 40, 60), alternative = 0.4,
+    maxNumberOfIterations = 10
+)
+getFisherInformation(simulationResults)
 }
 
 }

--- a/man/names.AnalysisResults.Rd
+++ b/man/names.AnalysisResults.Rd
@@ -7,7 +7,8 @@
 \method{names}{AnalysisResults}(x)
 }
 \arguments{
-\item{x}{An \code{\link{AnalysisResults}} object created by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.}
+\item{x}{An \code{\link{AnalysisResults}} object created
+by \code{\link[=getAnalysisResults]{getAnalysisResults()}}.}
 }
 \value{
 Returns a \code{\link[base]{character}} vector containing the names of the \code{\link{AnalysisResults}} object.

--- a/man/summary.ParameterSet.Rd
+++ b/man/summary.ParameterSet.Rd
@@ -26,7 +26,8 @@ that a warning will be displayed if unknown arguments are passed.}
 
 \item{printObject}{Show also the print output after the summary, default is \code{FALSE}.}
 
-\item{sep}{The separator line between the summary and the optional print output, default is \code{"\n\n-----\n\n"}.}
+\item{sep}{The separator line between the summary and the
+optional print output, default is \code{"\n\n-----\n\n"}.}
 }
 \value{
 Returns a \code{\link{SummaryFactory}} object.


### PR DESCRIPTION
This pull request makes several improvements to parameter naming and error handling in the codebase, primarily to clarify output labels and enhance error reporting. The main changes involve updating parameter captions for clarity in both general and plotting contexts, as well as improving the `.getErrorCall` function to optionally return the call as a character.

**Parameter naming and caption improvements:**

* Updated the display name for the `rejectAtLeastOne` parameter to "Overall reject at least one" in both `C_PARAMETER_NAMES` and `C_TABLE_COLUMN_NAMES` for improved clarity in outputs. [[1]](diffhunk://#diff-f597aa5b80af94b37bb0153549c49c59b5cd7827bbe36b7b3f40378db78e81e7L671-R671) [[2]](diffhunk://#diff-f597aa5b80af94b37bb0153549c49c59b5cd7827bbe36b7b3f40378db78e81e7L987-R987)
* Adjusted plot settings so that for single-arm survival simulations, `rejectAtLeastOne` is captioned as "Overall reject" and `rejectedArmsPerStage` as "Reject per stage", making plot labels more context-appropriate.

**Error handling improvements:**

* Enhanced the `.getErrorCall` function to include an `asCharacter` argument, allowing the function to return the error call as a character string for easier debugging.