### PR TITLE
Polish `getRawData()` and `getData()` for multiarm simulations

### DIFF
--- a/R/f_simulation_multiarm_means.R
+++ b/R/f_simulation_multiarm_means.R
@@ -474,6 +474,7 @@ getSimulationMultiArmMeans <- function(
     dataSubjectsActiveArm <- rep(NA_real_, len)
     dataNumberOfSubjects <- rep(NA_real_, len)
     dataNumberOfCumulatedSubjects <- rep(NA_real_, len)
+    dataSelectedForNextStage <- rep(NA, len)
     dataRejectPerStage <- rep(NA, len)
     dataSuccessStop <- rep(NA, len)
     dataFutilityStop <- rep(NA, len)
@@ -570,6 +571,9 @@ getSimulationMultiArmMeans <- function(
                     dataSubjectsActiveArm[index] <- round(stageResults$subjectsPerStage[g, k], 1)
                     dataNumberOfSubjects[index] <- round(sum(stageResults$subjectsPerStage[, k], na.rm = TRUE), 1)
                     dataNumberOfCumulatedSubjects[index] <- round(sum(stageResults$subjectsPerStage[, 1:k], na.rm = TRUE), 1)
+                    if (k < kMax) {
+                        dataSelectedForNextStage[index] <- closedTest$selectedArms[g, k + 1]
+                    }
                     dataRejectPerStage[index] <- closedTest$rejected[g, k]
                     dataTestStatistics[index] <- stageResults$testStatistics[g, k]
                     dataSuccessStop[index] <- closedTest$successStop[k]
@@ -682,6 +686,7 @@ getSimulationMultiArmMeans <- function(
         pValue = dataPValuesSeparate,
         conditionalCriticalValue = round(dataConditionalCriticalValue, 6),
         conditionalPowerAchieved = round(dataConditionalPowerAchieved, 6),
+        selectedForNextStage = dataSelectedForNextStage,
         rejectPerStage = dataRejectPerStage,
         successStop = dataSuccessStop,
         futilityPerStage = dataFutilityStop

--- a/R/f_simulation_multiarm_rates.R
+++ b/R/f_simulation_multiarm_rates.R
@@ -559,6 +559,7 @@ getSimulationMultiArmRates <- function(
     dataSubjectsActiveArm <- rep(NA_real_, len)
     dataNumberOfSubjects <- rep(NA_real_, len)
     dataNumberOfCumulatedSubjects <- rep(NA_real_, len)
+    dataSelectedForNextStage <- rep(NA, len)
     dataRejectPerStage <- rep(NA, len)
     dataFutilityStop <- rep(NA_real_, len)
     dataSuccessStop <- rep(NA, len)
@@ -654,6 +655,9 @@ getSimulationMultiArmRates <- function(
                     dataSubjectsActiveArm[index] <- round(stageResults$subjectsPerStage[g, k], 1)
                     dataNumberOfSubjects[index] <- round(sum(stageResults$subjectsPerStage[, k], na.rm = TRUE), 1)
                     dataNumberOfCumulatedSubjects[index] <- round(sum(stageResults$subjectsPerStage[, 1:k], na.rm = TRUE), 1)
+                    if (k < kMax) {
+                        dataSelectedForNextStage[index] <- closedTest$selectedArms[g, k + 1]
+                    }
                     dataRejectPerStage[index] <- closedTest$rejected[g, k]
                     dataTestStatistics[index] <- stageResults$testStatistics[g, k]
                     dataSuccessStop[index] <- closedTest$successStop[k]
@@ -769,6 +773,7 @@ getSimulationMultiArmRates <- function(
         pValue = dataPValuesSeparate,
         conditionalCriticalValue = round(dataConditionalCriticalValue, 6),
         conditionalPowerAchieved = round(dataConditionalPowerAchieved, 6),
+        selectedForNextStage = dataSelectedForNextStage,
         rejectPerStage = dataRejectPerStage,
         successStop = dataSuccessStop,
         futilityPerStage = dataFutilityStop

--- a/R/f_simulation_multiarm_survival_crude.R
+++ b/R/f_simulation_multiarm_survival_crude.R
@@ -494,6 +494,7 @@ getSimulationMultiArmSurvivalBasic <- function(
     dataAlternative <- rep(NA_real_, len)
     dataEffect <- rep(NA_real_, len)
     dataNumberOfEvents <- rep(NA_real_, len)
+    dataSelectedForNextStage <- rep(NA, len)
     dataRejectPerStage <- rep(NA, len)
     dataFutilityStop <- rep(NA_real_, len)
     dataSuccessStop <- rep(NA, len)
@@ -621,6 +622,9 @@ getSimulationMultiArmSurvivalBasic <- function(
                     dataAlternative[index] <- omegaMaxVector[i]
                     dataEffect[index] <- effectMatrix[i, g]
                     dataNumberOfEvents[index] <- round(stageResults$cumulativeEventsPerStage[g, k], 1)
+                    if (k < kMax) {
+                        dataSelectedForNextStage[index] <- closedTest$selectedArms[g, k + 1]
+                    }
                     dataRejectPerStage[index] <- closedTest$rejected[g, k]
                     dataTestStatistics[index] <- stageResults$testStatistics[g, k]
                     dataSuccessStop[index] <- closedTest$successStop[k]
@@ -753,6 +757,7 @@ getSimulationMultiArmSurvivalBasic <- function(
         pValue = dataPValuesSeparate,
         conditionalCriticalValue = round(dataConditionalCriticalValue, 6),
         conditionalPowerAchieved = round(dataConditionalPowerAchieved, 6),
+        selectedForNextStage = dataSelectedForNextStage,
         rejectPerStage = dataRejectPerStage,
         successStop = dataSuccessStop,
         futilityPerStage = dataFutilityStop

--- a/R/f_simulation_multiarm_survival_pw_basic.R
+++ b/R/f_simulation_multiarm_survival_pw_basic.R
@@ -660,6 +660,7 @@ NULL
     dataAnalysisTime <- rep(NA_real_, len)
     dataNumberOfSubjects <- rep(NA_real_, len)
     dataNumberOfEvents <- rep(NA_real_, len)
+    dataSelectedForNextStage <- rep(NA, len)
     dataRejectPerStage <- rep(NA, len)
     dataFutilityStop <- rep(NA_real_, len)
     dataSuccessStop <- rep(NA, len)
@@ -793,6 +794,9 @@ NULL
                         dataAnalysisTime[index] <- stageResults$analysisTime[k]
                         dataNumberOfSubjects[index] <- stageResults$numberOfSubjects[k]
                         dataNumberOfEvents[index] <- round(stageResults$cumulativeEventsPerStage[g, k], 1)
+                        if (k < kMax) {
+                            dataSelectedForNextStage[index] <- closedTest$selectedArms[g, k + 1]
+                        }
                         dataRejectPerStage[index] <- closedTest$rejected[g, k]
                         dataTestStatistics[index] <- stageResults$testStatistics[g, k]
                         dataSuccessStop[index] <- closedTest$successStop[k]
@@ -889,6 +893,7 @@ NULL
         pValue = dataPValuesSeparate,
         conditionalCriticalValue = round(dataConditionalCriticalValue, 6),
         conditionalPowerAchieved = round(dataConditionalPowerAchieved, 6),
+        selectedForNextStage = dataSelectedForNextStage,
         rejectPerStage = dataRejectPerStage,
         successStop = dataSuccessStop,
         futilityPerStage = dataFutilityStop

--- a/R/f_simulation_utilities.R
+++ b/R/f_simulation_utilities.R
@@ -787,6 +787,13 @@ C_EFFECT_LIST_NAMES_EXPECTED_SURVIVAL <- c("subGroups", "prevalences", "piContro
 #' }
 #' A subset of variables is provided for \code{\link[=getSimulationMeans]{getSimulationMeans()}}, \code{\link[=getSimulationRates]{getSimulationRates()}}, \code{\link[=getSimulationMultiArmMeans]{getSimulationMultiArmMeans()}},\cr
 #'  \code{\link[=getSimulationMultiArmRates]{getSimulationMultiArmRates()}}, or \code{\link[=getSimulationMultiArmSurvival]{getSimulationMultiArmSurvival()}}.
+#' Multi-arm simulation data additionally contain \code{selectedForNextStage}. At
+#' non-final stages, this logical value indicates whether the adaptation selected
+#' the arm to continue, conditional on the trial not stopping; it is \code{NA} at
+#' the final stage. In contrast,
+#' \code{rejectPerStage} indicates rejection of the arm's null hypothesis, while
+#' \code{futilityPerStage} is a trial-level futility-stopping decision repeated for
+#' the arm rows of the stage.
 #'
 #' @template return_dataframe
 #'
@@ -1056,7 +1063,6 @@ getData.SimulationResults <- function(x) {
 #'   \item \code{treatmentGroup}: The treatment group number (1 or 2).
 #'   \item \code{survivalTime}: The survival time of the subject.
 #'   \item \code{dropoutTime}: The dropout time of the subject (may be \code{NA}).
-#'   \item \code{lastObservationTime}: The specific observation time.
 #'   \item \code{timeUnderObservation}: The time under observation is defined as follows:
 #' ```
 #' if (event == TRUE) {
@@ -1064,9 +1070,11 @@ getData.SimulationResults <- function(x) {
 #' } else if (dropoutEvent == TRUE) {
 #'     timeUnderObservation <- dropoutTime
 #' } else {
-#'     timeUnderObservation <- lastObservationTime - accrualTime
+#'     timeUnderObservation <- analysisTime - accrualTime
 #' }
 #' ```
+#' where \code{analysisTime} is available from the corresponding row of
+#' \code{\link[=getData]{getData()}}.
 #'   \item \code{event}: \code{TRUE} if an event occurred; \code{FALSE} otherwise.
 #'   \item \code{dropoutEvent}: \code{TRUE} if an dropout event occurred; \code{FALSE} otherwise.
 #' }
@@ -1131,7 +1139,7 @@ getRawData <- function(x, aggregate = FALSE) {
     }
 
     if (!aggregate) {
-        return(rawData)
+        return(rawData[, names(rawData) != "lastObservationTime", drop = FALSE])
     }
 
     if (inherits(x, "SimulationResultsMultiArmSurvival")) {

--- a/man/getData.Rd
+++ b/man/getData.Rd
@@ -57,6 +57,13 @@ log-rank statistic.
 }
 A subset of variables is provided for \code{\link[=getSimulationMeans]{getSimulationMeans()}}, \code{\link[=getSimulationRates]{getSimulationRates()}}, \code{\link[=getSimulationMultiArmMeans]{getSimulationMultiArmMeans()}},\cr
 \code{\link[=getSimulationMultiArmRates]{getSimulationMultiArmRates()}}, or \code{\link[=getSimulationMultiArmSurvival]{getSimulationMultiArmSurvival()}}.
+Multi-arm simulation data additionally contain \code{selectedForNextStage}. At
+non-final stages, this logical value indicates whether the adaptation selected
+the arm to continue, conditional on the trial not stopping; it is \code{NA} at
+the final stage. In contrast,
+\code{rejectPerStage} indicates rejection of the arm's null hypothesis, while
+\code{futilityPerStage} is a trial-level futility-stopping decision repeated for
+the arm rows of the stage.
 }
 \examples{
 \dontrun{

--- a/man/getRawData.Rd
+++ b/man/getRawData.Rd
@@ -37,7 +37,6 @@ The data frame contains the following columns:
 \item \code{treatmentGroup}: The treatment group number (1 or 2).
 \item \code{survivalTime}: The survival time of the subject.
 \item \code{dropoutTime}: The dropout time of the subject (may be \code{NA}).
-\item \code{lastObservationTime}: The specific observation time.
 \item \code{timeUnderObservation}: The time under observation is defined as follows:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{if (event == TRUE) \{
@@ -45,10 +44,12 @@ The data frame contains the following columns:
 \} else if (dropoutEvent == TRUE) \{
     timeUnderObservation <- dropoutTime
 \} else \{
-    timeUnderObservation <- lastObservationTime - accrualTime
+    timeUnderObservation <- analysisTime - accrualTime
 \}
 }\if{html}{\out{</div>}}
 
+where \code{analysisTime} is available from the corresponding row of
+\code{\link[=getData]{getData()}}.
 \item \code{event}: \code{TRUE} if an event occurred; \code{FALSE} otherwise.
 \item \code{dropoutEvent}: \code{TRUE} if an dropout event occurred; \code{FALSE} otherwise.
 }

--- a/src/f_simulation_multiarm_survival.cpp
+++ b/src/f_simulation_multiarm_survival.cpp
@@ -954,6 +954,7 @@ List performSimulationMultiArmSurvivalLoop(
 	NumericVector dataAnalysisTime(len, NA_REAL);
 	NumericVector dataNumberOfSubjects(len, NA_REAL);
 	NumericVector dataNumberOfEvents(len, NA_REAL);
+	LogicalVector dataSelectedForNextStage(len, NA_LOGICAL);
 	LogicalVector dataRejectPerStage(len, NA_LOGICAL);
 	LogicalVector dataFutilityStop(len, NA_LOGICAL);
 	LogicalVector dataSuccessStop(len, NA_LOGICAL);
@@ -1137,6 +1138,9 @@ List performSimulationMultiArmSurvivalLoop(
 						dataAnalysisTime[index] = analysisTime[k];
 						dataNumberOfSubjects[index] = numberOfSubjects[k];
 						dataNumberOfEvents[index] = round(cumulativeEventsPerStage(g, k), 1);
+						if (k < kMax - 1) {
+							dataSelectedForNextStage[index] = selectedArmsTest(g, k + 1);
+						}
 						dataRejectPerStage[index] = rejected(g, k);
 						dataTestStatistics[index] = testStatistics(g, k);
 						dataSuccessStop[index] = successStop[k];
@@ -1279,6 +1283,7 @@ List performSimulationMultiArmSurvivalLoop(
 		_["pValue"] = dataPValuesSeparate[validRows],
 		_["conditionalCriticalValue"] = dataConditionalCriticalValue[validRows],
 		_["conditionalPowerAchieved"] = dataConditionalPowerAchieved[validRows],
+		_["selectedForNextStage"] = dataSelectedForNextStage[validRows],
 		_["rejectPerStage"] = dataRejectPerStage[validRows],
 		_["successStop"] = dataSuccessStop[validRows],
 		_["futilityPerStage"] = dataFutilityStop[validRows]


### PR DESCRIPTION
getRawData() no longer exposes lastObservationTime. The value remains… internal so aggregate = TRUE can still provide analysisTime: [f_simulation_utilities.R](/Users/daniel/git/rpact/R/f_simulation_utilities.R).

Multi-arm getData() now includes selectedForNextStage:- FALSE, TRUE, TRUE for stage-1 arms in the example.
- NA at the final stage.
- Applied consistently to means, rates, test-statistic-based survival, and both patient-wise survival engines.

Documentation now distinguishes:- selectedForNextStage: arm-level adaptation decision.
- rejectPerStage: arm-level hypothesis rejection.
- futilityPerStage: trial-level futility stopping repeated across arm rows.