### PR TITLE
Added thetaH0 to getSimulationMultiArmMeans() and getSimulationMultiArmRates()

### DIFF
--- a/R/class_simulation_results.R
+++ b/R/class_simulation_results.R
@@ -824,6 +824,7 @@ SimulationResultsMultiArmMeans <- R6::R6Class(
         slope = NULL,
         successCriterion = NULL,
         successPerStage = NULL,
+        thetaH0 = NULL,
         threshold = NULL,
         typeOfSelection = NULL,
         typeOfShape = NULL,
@@ -1022,6 +1023,7 @@ SimulationResultsRates <- R6::R6Class(
 #' @template field_threshold
 #' @template field_typeOfSelection
 #' @template field_typeOfShape
+#' @template field_thetaH0
 #'
 #' @details
 #' Use \code{\link[=getSimulationMultiArmRates]{getSimulationMultiArmRates()}}
@@ -1067,6 +1069,7 @@ SimulationResultsMultiArmRates <- R6::R6Class(
         slope = NULL,
         successCriterion = NULL,
         successPerStage = NULL,
+        thetaH0 = NULL,
         threshold = NULL,
         typeOfSelection = NULL,
         typeOfShape = NULL,

--- a/R/f_simulation_multiarm.R
+++ b/R/f_simulation_multiarm.R
@@ -469,7 +469,7 @@ NULL
         minNumberOfEventsPerStage = NA_real_, # survival only
         maxNumberOfEventsPerStage = NA_real_, # survival only
         conditionalPower,
-        thetaH0 = NA_real_, # survival only
+        thetaH0 = NA_real_, # means + rates + survival only
         thetaH1 = NA_real_, # means + survival only
         stDevH1 = NA_real_, # means only
         piTreatmentsH1 = NA_real_, # rates only
@@ -608,10 +608,7 @@ NULL
     if (endpoint %in% c("means", "survival")) {
         .assertIsSingleNumber(thetaH1, "thetaH1", naAllowed = TRUE) # means + survival only
     }
-    if (endpoint == "survival") {
-        .assertIsSingleNumber(thetaH0, "thetaH0")
-        .assertIsInOpenInterval(thetaH0, "thetaH0", lower = 0, upper = NULL, naAllowed = TRUE)
-    }
+    .assertIsValidThetaH0(thetaH0, endpoint = endpoint, groups = 2)
 
     if (endpoint == "means") {
         stDev <- .assertIsValidStandardDeviation(stDev) # means only
@@ -1167,8 +1164,14 @@ NULL
     if (endpoint %in% c("means", "survival")) {
         .setValueAndParameterType(simulationResults, "thetaH1", thetaH1, NA_real_, notApplicableIfNA = TRUE)
     }
-    if (endpoint == "survival") {
-        .setValueAndParameterType(simulationResults, "thetaH0", thetaH0, C_THETA_H0_SURVIVAL_DEFAULT)
+    if (endpoint %in% c("means", "rates", "survival")) {
+        thetaH0Default <- switch(
+            endpoint,
+            "means" = C_THETA_H0_MEANS_DEFAULT,
+            "rates" = C_THETA_H0_RATES_DEFAULT,
+            "survival" = C_THETA_H0_SURVIVAL_DEFAULT
+        )
+        .setValueAndParameterType(simulationResults, "thetaH0", thetaH0, thetaH0Default)
     }
     if (endpoint == "means") {
         .setValueAndParameterType(simulationResults, "stDevH1", stDevH1, NA_real_, notApplicableIfNA = TRUE)

--- a/R/f_simulation_multiarm_means.R
+++ b/R/f_simulation_multiarm_means.R
@@ -25,6 +25,7 @@ NULL
         plannedSubjects,
         allocationRatioPlanned,
         selectedArms,
+        thetaH0,
         thetaH1,
         overallEffects,
         stDevH1,
@@ -36,11 +37,11 @@ NULL
     if (!is.na(conditionalPower)) {
         if (any(selectedArms[1:gMax, stage + 1], na.rm = TRUE)) {
             if (is.na(thetaH1)) {
-                thetaStandardized <- max(min(overallEffects[
+                thetaStandardized <- max(min((overallEffects[
                     selectedArms[1:gMax, stage + 1], stage
-                ] / stDevH1, na.rm = TRUE), 1e-07)
+                ] - thetaH0) / stDevH1, na.rm = TRUE), 1e-07)
             } else {
-                thetaStandardized <- max(thetaH1 / stDevH1, 1e-07)
+                thetaStandardized <- max((thetaH1 - thetaH0) / stDevH1, 1e-07)
             }
 
             if (conditionalCriticalValue[stage] > 8) {
@@ -79,6 +80,7 @@ NULL
         minNumberOfSubjectsPerStage,
         maxNumberOfSubjectsPerStage,
         conditionalPower,
+        thetaH0,
         thetaH1,
         stDevH1,
         calcSubjectsFunction,
@@ -128,7 +130,7 @@ NULL
                         1, muVector[treatmentArm],
                         stDev / sqrt(subjectsPerStage[treatmentArm, k])
                     )
-                    testStatistics[treatmentArm, k] <- (simMeans[treatmentArm, k] - simMeans[gMax + 1, k]) /
+                    testStatistics[treatmentArm, k] <- (simMeans[treatmentArm, k] - simMeans[gMax + 1, k] - thetaH0) /
                         (stDev * sqrt(1 / subjectsPerStage[treatmentArm, k] + 1 / subjectsPerStage[gMax + 1, k]))
                 }
 
@@ -137,7 +139,7 @@ NULL
                     sum(subjectsPerStage[treatmentArm, 1:k]) -
                     subjectsPerStage[gMax + 1, 1:k] %*% simMeans[gMax + 1, 1:k] / sum(subjectsPerStage[gMax + 1, 1:k])
 
-                overallTestStatistics[treatmentArm, k] <- overallEffects[treatmentArm, k] /
+                overallTestStatistics[treatmentArm, k] <- (overallEffects[treatmentArm, k] - thetaH0) /
                     (stDev * sqrt(1 / sum(subjectsPerStage[treatmentArm, 1:k]) + 1 / sum(subjectsPerStage[gMax + 1, 1:k])))
 
                 separatePValues[treatmentArm, k] <- 1 - stats::pnorm(testStatistics[treatmentArm, k])
@@ -180,6 +182,7 @@ NULL
                     plannedSubjects = plannedSubjects,
                     allocationRatioPlanned = allocationRatioPlanned,
                     selectedArms = selectedArms,
+                    thetaH0 = thetaH0,
                     thetaH1 = thetaH1,
                     stDevH1 = stDevH1,
                     overallEffects = overallEffects
@@ -210,6 +213,7 @@ NULL
                     plannedSubjects = plannedSubjects,
                     allocationRatioPlanned = allocationRatioPlanned,
                     selectedArms = selectedArms,
+                    thetaH0 = thetaH0,
                     thetaH1 = thetaH1,
                     stDevH1 = stDevH1,
                     overallEffects = overallEffects,
@@ -235,9 +239,9 @@ NULL
             }
 
             if (is.na(thetaH1)) {
-                thetaStandardized <- max(min(overallEffects[selectedArms[1:gMax, k], k] / stDevH1, na.rm = TRUE), 1e-12)
+                thetaStandardized <- max(min((overallEffects[selectedArms[1:gMax, k], k] - thetaH0) / stDevH1, na.rm = TRUE), 1e-12)
             } else {
-                thetaStandardized <- thetaH1 / stDevH1
+                thetaStandardized <- (thetaH1 - thetaH0) / stDevH1
             }
 
             conditionalPowerPerStage[k] <- 1 - stats::pnorm(conditionalCriticalValue[k] -
@@ -299,6 +303,7 @@ NULL
 #' @inheritParams param_seed
 #' @inheritParams param_three_dots
 #' @inheritParams param_showStatistics
+#' @inheritParams param_thetaH0
 #'
 #' @details
 #' At given design the function simulates the power, stopping probabilities, selection probabilities,
@@ -357,6 +362,7 @@ getSimulationMultiArmMeans <- function(
         minNumberOfSubjectsPerStage = NA_real_,
         maxNumberOfSubjectsPerStage = NA_real_,
         conditionalPower = NA_real_,
+        thetaH0 = C_THETA_H0_MEANS_DEFAULT,
         thetaH1 = NA_real_,
         stDevH1 = NA_real_,
         maxNumberOfIterations = NA_integer_, # C_MAX_SIMULATION_ITERATIONS_DEFAULT
@@ -409,6 +415,7 @@ getSimulationMultiArmMeans <- function(
         minNumberOfSubjectsPerStage = minNumberOfSubjectsPerStage, # means + rates only
         maxNumberOfSubjectsPerStage = maxNumberOfSubjectsPerStage, # means + rates only
         conditionalPower            = conditionalPower,
+        thetaH0                     = thetaH0,
         thetaH1                     = thetaH1, # means + survival only
         stDevH1                     = stDevH1, # means only
         maxNumberOfIterations       = maxNumberOfIterations,
@@ -431,6 +438,7 @@ getSimulationMultiArmMeans <- function(
     effectMatrix <- t(simulationResults$effectMatrix)
     muMaxVector <- simulationResults$muMaxVector # means only
     thetaH1 <- simulationResults$thetaH1 # means + survival only
+    thetaH0 <- simulationResults$thetaH0
     stDevH1 <- simulationResults$stDevH1 # means only
     conditionalPower <- simulationResults$conditionalPower
     minNumberOfSubjectsPerStage <- simulationResults$minNumberOfSubjectsPerStage
@@ -506,6 +514,7 @@ getSimulationMultiArmMeans <- function(
                 minNumberOfSubjectsPerStage = minNumberOfSubjectsPerStage,
                 maxNumberOfSubjectsPerStage = maxNumberOfSubjectsPerStage,
                 conditionalPower = conditionalPower,
+                thetaH0 = thetaH0,
                 thetaH1 = thetaH1,
                 stDevH1 = stDevH1,
                 calcSubjectsFunction = calcSubjectsFunction,

--- a/R/f_simulation_multiarm_rates.R
+++ b/R/f_simulation_multiarm_rates.R
@@ -26,6 +26,7 @@ NULL
         plannedSubjects,
         allocationRatioPlanned,
         selectedArms,
+        thetaH0,
         piTreatmentsH1,
         piControlH1,
         overallRates,
@@ -51,16 +52,20 @@ NULL
             } else {
                 piAssumedH1 <- piTreatmentsH1
             }
-            pim <- (allocationRatioPlanned[stage] * piAssumedH1 + piAssumedControlH1) / (1 + allocationRatioPlanned[stage])
+            fm <- .getFarringtonManningValues(
+                rate1 = piAssumedH1, rate2 = piAssumedControlH1, theta = thetaH0,
+                allocation = allocationRatioPlanned[stage], method = "diff"
+            )
 
             if (conditionalCriticalValue[stage] > 8) {
                 newSubjects <- maxNumberOfSubjectsPerStage[stage + 1]
             } else {
                 newSubjects <- (max(0, conditionalCriticalValue[stage] *
-                    sqrt(pim * (1 - pim) * (1 + allocationRatioPlanned[stage])) +
+                    sqrt(fm$ml1 * (1 - fm$ml1) +
+                        fm$ml2 * (1 - fm$ml2) * allocationRatioPlanned[stage]) +
                     .getQNorm(conditionalPower) * sqrt(piAssumedH1 * (1 - piAssumedH1) +
                         piAssumedControlH1 * (1 - piAssumedControlH1) * allocationRatioPlanned[stage])))^2 /
-                    (max(1e-07, (2 * directionUpper - 1) * (piAssumedH1 - piAssumedControlH1)))^2
+                    (max(1e-07, (2 * directionUpper - 1) * (piAssumedH1 - piAssumedControlH1 - thetaH0)))^2
                 newSubjects <- min(
                     max(minNumberOfSubjectsPerStage[stage + 1], newSubjects),
                     maxNumberOfSubjectsPerStage[stage + 1]
@@ -91,6 +96,7 @@ NULL
         minNumberOfSubjectsPerStage,
         maxNumberOfSubjectsPerStage,
         conditionalPower,
+        thetaH0,
         piTreatmentsH1,
         piControlH1,
         calcSubjectsFunction,
@@ -137,16 +143,19 @@ NULL
                 simRates[treatmentArm, k] <- stats::rbinom(1, subjectsPerStage[treatmentArm, k], piVector[treatmentArm]) /
                     subjectsPerStage[treatmentArm, k]
 
-                rm <- (subjectsPerStage[treatmentArm, k] * simRates[treatmentArm, k] +
-                    subjectsPerStage[gMax + 1, k] * simRates[gMax + 1, k]) /
-                    (subjectsPerStage[treatmentArm, k] + subjectsPerStage[gMax + 1, k])
-
-                if (simRates[treatmentArm, k] - simRates[gMax + 1, k] == 0) {
+                rateDifference <- simRates[treatmentArm, k] - simRates[gMax + 1, k] - thetaH0
+                if (rateDifference == 0) {
                     testStatistics[treatmentArm, k] <- 0
                 } else {
+                    fm <- .getFarringtonManningValues(
+                        rate1 = simRates[treatmentArm, k], rate2 = simRates[gMax + 1, k],
+                        theta = thetaH0,
+                        allocation = subjectsPerStage[treatmentArm, k] / subjectsPerStage[gMax + 1, k],
+                        method = "diff"
+                    )
                     testStatistics[treatmentArm, k] <- (2 * directionUpper - 1) *
-                        (simRates[treatmentArm, k] - simRates[gMax + 1, k]) /
-                        sqrt(rm * (1 - rm) * (1 / subjectsPerStage[treatmentArm, k] + 1 / subjectsPerStage[gMax + 1, k]))
+                        rateDifference / sqrt(fm$ml1 * (1 - fm$ml1) / subjectsPerStage[treatmentArm, k] +
+                            fm$ml2 * (1 - fm$ml2) / subjectsPerStage[gMax + 1, k])
                 }
 
                 separatePValues[treatmentArm, k] <- 1 - stats::pnorm(testStatistics[treatmentArm, k])
@@ -160,15 +169,27 @@ NULL
                 overallEffectSizes[treatmentArm, k] <- (2 * directionUpper - 1) *
                     (overallRates[treatmentArm, k] - overallRatesControl[k])
 
-                rmOverall <- (allocationRatioPlanned[k] * overallRates[treatmentArm, k] +
-                    overallRatesControl[k]) / (allocationRatioPlanned[k] + 1)
-
-                if (overallEffectSizes[treatmentArm, k] == 0) {
+                overallRateDifference <- overallRates[treatmentArm, k] - overallRatesControl[k] - thetaH0
+                if (overallRateDifference == 0) {
                     overallTestStatistics[treatmentArm, k] <- 0
-                } else {
+                } else if (thetaH0 == 0) {
+                    rmOverall <- (allocationRatioPlanned[k] * overallRates[treatmentArm, k] +
+                        overallRatesControl[k]) / (allocationRatioPlanned[k] + 1)
                     overallTestStatistics[treatmentArm, k] <- overallEffectSizes[treatmentArm, k] /
-                        sqrt(rmOverall * (1 - rmOverall) * sqrt(1 / sum(subjectsPerStage[treatmentArm, 1:k]) +
-                            1 / sum(subjectsPerStage[gMax + 1, 1:k])))
+                        sqrt(rmOverall * (1 - rmOverall) * sqrt(
+                            1 / sum(subjectsPerStage[treatmentArm, 1:k]) +
+                                1 / sum(subjectsPerStage[gMax + 1, 1:k])
+                        ))
+                } else {
+                    activeSubjects <- sum(subjectsPerStage[treatmentArm, 1:k])
+                    controlSubjects <- sum(subjectsPerStage[gMax + 1, 1:k])
+                    fmOverall <- .getFarringtonManningValues(
+                        rate1 = overallRates[treatmentArm, k], rate2 = overallRatesControl[k],
+                        theta = thetaH0, allocation = activeSubjects / controlSubjects, method = "diff"
+                    )
+                    overallTestStatistics[treatmentArm, k] <- (2 * directionUpper - 1) * overallRateDifference /
+                        sqrt(fmOverall$ml1 * (1 - fmOverall$ml1) / activeSubjects +
+                            fmOverall$ml2 * (1 - fmOverall$ml2) / controlSubjects)
                 }
             }
         }
@@ -213,6 +234,7 @@ NULL
                     plannedSubjects = plannedSubjects,
                     allocationRatioPlanned = allocationRatioPlanned,
                     selectedArms = selectedArms,
+                    thetaH0 = thetaH0,
                     piTreatmentsH1 = piTreatmentsH1,
                     piControlH1 = piControlH1,
                     overallRates = overallRates,
@@ -245,6 +267,7 @@ NULL
                     plannedSubjects = plannedSubjects,
                     allocationRatioPlanned = allocationRatioPlanned,
                     selectedArms = selectedArms,
+                    thetaH0 = thetaH0,
                     piTreatmentsH1 = piTreatmentsH1,
                     piControlH1 = piControlH1,
                     overallRates = overallRates,
@@ -303,7 +326,7 @@ NULL
                     )
             }
 
-            thetaStandardized <- (2 * directionUpper - 1) * thetaStandardized
+            thetaStandardized <- (2 * directionUpper - 1) * (thetaStandardized - thetaH0)
 
             conditionalPowerPerStage[k] <- 1 - stats::pnorm(conditionalCriticalValue[k] -
                 thetaStandardized * sqrt((1 + allocationRatioPlanned[k]) / allocationRatioPlanned[k]) *
@@ -406,6 +429,7 @@ NULL
 #' @template how_to_get_help_for_generics
 #'
 #' @template examples_get_simulation_multiarm_rates
+#' @inheritParams param_thetaH0
 #'
 #' @export
 #'
@@ -434,6 +458,7 @@ getSimulationMultiArmRates <- function(
         minNumberOfSubjectsPerStage = NA_real_,
         maxNumberOfSubjectsPerStage = NA_real_,
         conditionalPower = NA_real_,
+        thetaH0 = C_THETA_H0_MEANS_DEFAULT,
         piTreatmentsH1 = NA_real_,
         piControlH1 = NA_real_,
         maxNumberOfIterations = NA_integer_, # C_MAX_SIMULATION_ITERATIONS_DEFAULT
@@ -492,6 +517,7 @@ getSimulationMultiArmRates <- function(
         minNumberOfSubjectsPerStage = minNumberOfSubjectsPerStage, # means + rates only
         maxNumberOfSubjectsPerStage = maxNumberOfSubjectsPerStage, # means + rates only
         conditionalPower            = conditionalPower,
+        thetaH0                     = thetaH0,
         piTreatmentsH1              = piTreatmentsH1, # rates only
         piControlH1                 = piControlH1, # rates only
         maxNumberOfIterations       = maxNumberOfIterations,
@@ -514,6 +540,7 @@ getSimulationMultiArmRates <- function(
     effectMatrix <- t(simulationResults$effectMatrix)
     piMaxVector <- simulationResults$piMaxVector # rates only
     piControl <- simulationResults$piControl # rates only
+    thetaH0 <- simulationResults$thetaH0
     piTreatmentsH1 <- simulationResults$piTreatmentsH1 # rates only
     piControlH1 <- simulationResults$piControlH1 # rates only
     conditionalPower <- simulationResults$conditionalPower
@@ -590,6 +617,7 @@ getSimulationMultiArmRates <- function(
                 minNumberOfSubjectsPerStage = minNumberOfSubjectsPerStage,
                 maxNumberOfSubjectsPerStage = maxNumberOfSubjectsPerStage,
                 conditionalPower = conditionalPower,
+                thetaH0 = thetaH0,
                 piTreatmentsH1 = piTreatmentsH1,
                 piControlH1 = piControlH1,
                 calcSubjectsFunction = calcSubjectsFunction,

--- a/man/SimulationResultsMultiArmRates.Rd
+++ b/man/SimulationResultsMultiArmRates.Rd
@@ -88,6 +88,8 @@ to create an object of this type.
 \item{\code{typeOfSelection}}{The way the treatment arms or populations are selected at interim. Is a single character value.}
 
 \item{\code{typeOfShape}}{The shape of the dose-response relationship over the treatment groups. Is a single character value.}
+
+\item{\code{thetaH0}}{The difference or assumed effect under H0. Is a single numeric value.}
 }}
 
 \keyword{internal}

--- a/man/getSimulationMultiArmMeans.Rd
+++ b/man/getSimulationMultiArmMeans.Rd
@@ -28,6 +28,7 @@ getSimulationMultiArmMeans(
   minNumberOfSubjectsPerStage = NA_real_,
   maxNumberOfSubjectsPerStage = NA_real_,
   conditionalPower = NA_real_,
+  thetaH0 = C_THETA_H0_MEANS_DEFAULT,
   thetaH1 = NA_real_,
   stDevH1 = NA_real_,
   maxNumberOfIterations = NA_integer_,
@@ -150,6 +151,23 @@ It is defined as the power for the subsequent stage given the current data. By d
 the conditional power will be calculated under the observed effect size. Optionally, you can also specify \code{thetaH1} and
 \code{stDevH1} (for simulating means), \code{pi1H1} and \code{pi2H1} (for simulating rates), or \code{thetaH1} (for simulating
 hazard ratios) as parameters under which it is calculated and the sample size recalculation is performed.}
+
+\item{thetaH0}{The null hypothesis value,
+default is \code{0} for general estimates, the normal case, and the binary case,
+it is \code{1} for the survival case (testing the hazard ratio).\cr\cr
+For non-inferiority designs, \code{thetaH0} is the non-inferiority bound.
+That is, in case of (one-sided) testing of
+\itemize{
+\item \emph{general estimates}: a value on the scale of the supplied estimates can be specified.
+\item \emph{means}: a value \code{!= 0}
+(or a value \code{!= 1} for testing the mean ratio) can be specified.
+\item \emph{rates}: a value \code{!= 0}
+(or a value \code{!= 1} for testing the risk ratio \code{pi1 / pi2}) can be specified.
+\item \emph{survival data}: a bound for testing H0: \code{hazard ratio = thetaH0 != 1} can be specified.
+\item \emph{count data}: a bound for testing H0: \code{lambda1 / lambda2 = thetaH0 != 1} can be specified.
+}
+For testing a rate in one sample, a value \code{thetaH0} in (0, 1) has to be specified for
+defining the null hypothesis H0: \code{pi = thetaH0}.}
 
 \item{thetaH1}{If specified, the value of the alternative under which
 the conditional power or sample size recalculation calculation is performed. Must be a numeric of length 1.}

--- a/man/getSimulationMultiArmRates.Rd
+++ b/man/getSimulationMultiArmRates.Rd
@@ -29,6 +29,7 @@ getSimulationMultiArmRates(
   minNumberOfSubjectsPerStage = NA_real_,
   maxNumberOfSubjectsPerStage = NA_real_,
   conditionalPower = NA_real_,
+  thetaH0 = C_THETA_H0_MEANS_DEFAULT,
   piTreatmentsH1 = NA_real_,
   piControlH1 = NA_real_,
   maxNumberOfIterations = NA_integer_,
@@ -152,6 +153,23 @@ It is defined as the power for the subsequent stage given the current data. By d
 the conditional power will be calculated under the observed effect size. Optionally, you can also specify \code{thetaH1} and
 \code{stDevH1} (for simulating means), \code{pi1H1} and \code{pi2H1} (for simulating rates), or \code{thetaH1} (for simulating
 hazard ratios) as parameters under which it is calculated and the sample size recalculation is performed.}
+
+\item{thetaH0}{The null hypothesis value,
+default is \code{0} for general estimates, the normal case, and the binary case,
+it is \code{1} for the survival case (testing the hazard ratio).\cr\cr
+For non-inferiority designs, \code{thetaH0} is the non-inferiority bound.
+That is, in case of (one-sided) testing of
+\itemize{
+\item \emph{general estimates}: a value on the scale of the supplied estimates can be specified.
+\item \emph{means}: a value \code{!= 0}
+(or a value \code{!= 1} for testing the mean ratio) can be specified.
+\item \emph{rates}: a value \code{!= 0}
+(or a value \code{!= 1} for testing the risk ratio \code{pi1 / pi2}) can be specified.
+\item \emph{survival data}: a bound for testing H0: \code{hazard ratio = thetaH0 != 1} can be specified.
+\item \emph{count data}: a bound for testing H0: \code{lambda1 / lambda2 = thetaH0 != 1} can be specified.
+}
+For testing a rate in one sample, a value \code{thetaH0} in (0, 1) has to be specified for
+defining the null hypothesis H0: \code{pi = thetaH0}.}
 
 \item{piTreatmentsH1}{If specified, the assumed probability in the active treatment arm(s)
 under which the sample size recalculation is performed.}


### PR DESCRIPTION
- Continuous outcomes now subtract thetaH0 in stage-wise and cumulative test statistics. 
- Binary outcomes now use pairwise Farrington–Manning constrained estimates for nonzero thetaH0. 
- Updated conditional-power and sample-size recalculation formulas. 
- Added validation, result-object fields, generated documentation.